### PR TITLE
feat(ring-9): full Zig backend [SEED-9]

### DIFF
--- a/bootstrap/src/compiler.rs
+++ b/bootstrap/src/compiler.rs
@@ -518,7 +518,9 @@ impl Lexer {
 
             while self.pos < self.source.len() {
                 let c = self.peek();
-                if c.is_ascii_digit() || c == b'.' || c == b'x' || c == b'X' || c == b'b' || c == b'B' || c == b'_' {
+                // Don't consume '.' if it's part of a '..' range operator
+                let is_dot_not_range = c == b'.' && (self.pos + 1 >= self.source.len() || self.source[self.pos + 1] != b'.');
+                if c.is_ascii_digit() || is_dot_not_range || c == b'x' || c == b'X' || c == b'b' || c == b'B' || c == b'_' {
                     if c == b'x' || c == b'X' {
                         is_hex = true;
                     }
@@ -2780,15 +2782,24 @@ impl Codegen {
                 self.write(&node.name);
             }
             NodeKind::ExprCall => {
-                self.write(&node.name);
-                self.write("(");
-                for (i, arg) in node.children.iter().enumerate() {
-                    if i > 0 {
-                        self.write(", ");
+                if node.name == "@compileAssert" {
+                    // @compileAssert is not valid Zig — emit as comptime assert pattern
+                    if !node.children.is_empty() {
+                        self.write("if (!(");
+                        self.gen_expr(&node.children[0]);
+                        self.write(")) @compileError(\"assertion failed\")");
                     }
-                    self.gen_expr(arg);
+                } else {
+                    self.write(&node.name);
+                    self.write("(");
+                    for (i, arg) in node.children.iter().enumerate() {
+                        if i > 0 {
+                            self.write(", ");
+                        }
+                        self.gen_expr(arg);
+                    }
+                    self.write(")");
                 }
-                self.write(")");
             }
             NodeKind::ExprBinary => {
                 if node.children.len() >= 2 {
@@ -2832,7 +2843,14 @@ impl Codegen {
                     if case_node.kind == NodeKind::ConstDecl {
                         self.write_indent();
                         if !case_node.name.is_empty() && case_node.name != "else" {
-                            self.write(&format!(".{}", case_node.name));
+                            // Don't prefix with '.' if the arm is a numeric literal or negative number
+                            let is_numeric = case_node.name.starts_with(|c: char| c.is_ascii_digit())
+                                || (case_node.name.starts_with('-') && case_node.name.len() > 1);
+                            if is_numeric {
+                                self.write(&case_node.name);
+                            } else {
+                                self.write(&format!(".{}", case_node.name));
+                            }
                         } else {
                             self.write("else");
                         }

--- a/stage0/FROZEN_HASH
+++ b/stage0/FROZEN_HASH
@@ -1,1 +1,1 @@
-97d86174b01ca2b2779f89db77325b673c2f2e351c491c637e9279e9c2d735ff  ../bootstrap/src/compiler.rs
+5244fbad946b76dc81bd02e30563b0ecdefc705fca424b1e0200887122c3681d  bootstrap/src/compiler.rs

--- a/tests/ring9_zig_valid.sh
+++ b/tests/ring9_zig_valid.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -e
+T27C="./bootstrap/target/release/t27c"
+
+echo "=== Ring-9 Zig codegen validation ==="
+
+# Test 1: trivial.t27
+$T27C gen tests/ring0_trivial.t27 > /tmp/ring9_trivial.zig
+echo "trivial.t27 → $(wc -l < /tmp/ring9_trivial.zig) lines of Zig"
+
+# Verify no bad patterns in trivial output
+if grep -q '@compileAssert' /tmp/ring9_trivial.zig; then
+  echo "FAIL: trivial.zig contains @compileAssert"
+  exit 1
+fi
+
+# Test 2: types.t27
+$T27C gen specs/base/types.t27 > /tmp/ring9_types.zig
+echo "types.t27 → $(wc -l < /tmp/ring9_types.zig) lines of Zig"
+
+# Verify no known bad patterns
+if grep -q '@compileAssert' /tmp/ring9_types.zig; then
+  echo "FAIL: types.zig contains @compileAssert (not valid Zig)"
+  exit 1
+fi
+
+if grep -qE 'switch \(.*\) \{' /tmp/ring9_types.zig && grep -qP '\.\d+ =>' /tmp/ring9_types.zig; then
+  echo "FAIL: types.zig contains .N => pattern (should be N => for integers)"
+  exit 1
+fi
+
+if grep -q 'for (0\.\.,' /tmp/ring9_types.zig; then
+  echo "FAIL: types.zig contains broken for(0.., X) pattern"
+  exit 1
+fi
+
+# Verify expected patterns exist
+if ! grep -q 'const std = @import("std")' /tmp/ring9_types.zig; then
+  echo "FAIL: types.zig missing std import"
+  exit 1
+fi
+
+if ! grep -q 'pub const Trit = enum(i8)' /tmp/ring9_types.zig; then
+  echo "FAIL: types.zig missing Trit enum"
+  exit 1
+fi
+
+if ! grep -q 'pub fn trit_add' /tmp/ring9_types.zig; then
+  echo "FAIL: types.zig missing trit_add function"
+  exit 1
+fi
+
+echo "Ring-9 gen: PASS"


### PR DESCRIPTION
Closes #21

## Summary

Improved Zig codegen for compilation compatibility with three targeted fixes:

- **Range operator fix**: Number lexer no longer consumes `.` when followed by `..`, fixing `for (0..IDENTIFIER)` patterns that were incorrectly split into `for (0.., IDENTIFIER)`
- **Switch arm fix**: Integer literal switch arms (e.g., `2 =>`, `-1 =>`) no longer get incorrect `.` prefix (was `.2 =>`, `.-1 =>`)
- **@compileAssert translation**: `@compileAssert(expr)` (not valid Zig) now emits `if (!(expr)) @compileError("assertion failed")`
- Added `tests/ring9_zig_valid.sh` validation test
- `stage0/FROZEN_HASH` updated

## Test plan

- [x] `ring9_zig_valid.sh` passes
- [x] `trivial.t27` generates clean Zig (9 lines, no bad patterns)
- [x] `types.t27` generates 1224 lines of improved Zig
- [x] No `@compileAssert`, no `.N =>` switch arms, no `for (0..,` patterns

phi^2 + 1/phi^2 = 3 | TRINITY