### PR TITLE
feat(ring-13): AR pipeline — all 7 specs gen+seal

### DIFF
--- a/bootstrap/src/compiler.rs
+++ b/bootstrap/src/compiler.rs
@@ -127,7 +127,7 @@ pub enum TokenKind {
     LBracket, RBracket, Dot, Bang,
 
     // Multi-char
-    Arrow, FatArrow, Power, DotDot,
+    Arrow, FatArrow, Power, DotDot, PlusPlus,
     ShiftLeft, ShiftRight, PlusEquals, PlusPercent,
 
     // Special
@@ -449,6 +449,17 @@ impl Lexer {
                 return Token {
                     kind: TokenKind::ShiftRight,
                     lexeme: String::from(">>"),
+                    line: start_line,
+                    col: start_col,
+                };
+            }
+
+            if two == [b'+', b'+'] {
+                self.advance();
+                self.advance();
+                return Token {
+                    kind: TokenKind::PlusPlus,
+                    lexeme: String::from("++"),
                     line: start_line,
                     col: start_col,
                 };
@@ -1990,32 +2001,43 @@ impl Parser {
         lit.name = name;
 
         while self.current.kind != TokenKind::RBrace && self.current.kind != TokenKind::Eof {
-            // Expect .field = expr
+            // Expect .field = expr  OR  field = expr (dot-prefix optional)
+            let field_name;
             if self.current.kind == TokenKind::Dot {
                 self.advance(); // consume .
-                let field_name = if self.current.kind == TokenKind::Ident {
+                field_name = if self.current.kind == TokenKind::Ident {
                     let n = self.current.lexeme.clone();
                     self.advance();
                     n
                 } else {
                     String::new()
                 };
-
-                if self.current.kind == TokenKind::Equals {
-                    self.advance(); // consume =
-                }
-
-                let val = self.parse_expr()?;
-                let mut field = Node::new(NodeKind::ExprFieldAccess);
-                field.name = field_name;
-                field.children.push(val);
-                lit.children.push(field);
-
-                if self.current.kind == TokenKind::Comma {
-                    self.advance();
+            } else if self.current.kind == TokenKind::Ident {
+                // Allow field = expr without dot prefix
+                let n = self.current.lexeme.clone();
+                // Peek: only treat as field init if followed by '='
+                if self.peek.kind == TokenKind::Equals {
+                    field_name = n;
+                    self.advance(); // consume field name
+                } else {
+                    break;
                 }
             } else {
                 break;
+            }
+
+            if self.current.kind == TokenKind::Equals {
+                self.advance(); // consume =
+            }
+
+            let val = self.parse_expr()?;
+            let mut field = Node::new(NodeKind::ExprFieldAccess);
+            field.name = field_name;
+            field.children.push(val);
+            lit.children.push(field);
+
+            if self.current.kind == TokenKind::Comma {
+                self.advance();
             }
         }
         self.expect(TokenKind::RBrace)?;
@@ -2044,36 +2066,93 @@ impl Parser {
 
         // Check for { ... } initializer — collect verbatim with proper spacing
         if self.current.kind == TokenKind::LBrace {
-            text.push_str("{ ");
-            self.advance(); // consume {
-            let mut depth = 1;
-            while depth > 0 && self.current.kind != TokenKind::Eof {
+            self.collect_array_brace_init(&mut text)?;
+        }
+
+        // Handle ++ array concatenation: [_]T{a} ++ [_]T{b} ** N
+        // Collect the entire expression verbatim for Zig pass-through
+        while self.current.kind == TokenKind::PlusPlus {
+            text.push_str(" ++ ");
+            self.advance(); // consume ++
+
+            // Expect another array literal: [_]Type{ ... }
+            if self.current.kind == TokenKind::LBracket {
+                text.push('[');
+                self.advance(); // consume [
+                while self.current.kind != TokenKind::RBracket && self.current.kind != TokenKind::Eof {
+                    text.push_str(&self.current.lexeme);
+                    self.advance();
+                }
+                text.push(']');
+                self.expect(TokenKind::RBracket)?;
+
+                if self.current.kind == TokenKind::Ident {
+                    text.push_str(&self.current.lexeme);
+                    self.advance();
+                }
+
                 if self.current.kind == TokenKind::LBrace {
-                    depth += 1;
-                } else if self.current.kind == TokenKind::RBrace {
-                    depth -= 1;
-                    if depth == 0 {
-                        break;
+                    self.collect_array_brace_init(&mut text)?;
+                }
+            }
+
+            // Handle ** repeat operator after concatenation: ++ [_]T{v} ** (N)
+            if self.current.kind == TokenKind::Power {
+                text.push_str(" ** ");
+                self.advance(); // consume **
+                // Collect the repeat count (could be a parenthesized expression)
+                if self.current.kind == TokenKind::LParen {
+                    text.push('(');
+                    self.advance();
+                    let mut paren_depth = 1;
+                    while paren_depth > 0 && self.current.kind != TokenKind::Eof {
+                        if self.current.kind == TokenKind::LParen { paren_depth += 1; }
+                        if self.current.kind == TokenKind::RParen {
+                            paren_depth -= 1;
+                            if paren_depth == 0 { break; }
+                        }
+                        text.push_str(&self.current.lexeme);
+                        if self.current.kind == TokenKind::Minus || self.current.kind == TokenKind::Plus {
+                            text.push(' ');
+                        }
+                        self.advance();
                     }
-                }
-                // Dot immediately before an identifier (enum value like .neg)
-                // should not have a space between them
-                if self.current.kind == TokenKind::Dot {
-                    text.push('.');
+                    text.push(')');
+                    self.expect(TokenKind::RParen)?;
+                } else {
+                    // Simple number or identifier
+                    text.push_str(&self.current.lexeme);
                     self.advance();
-                    continue;
                 }
-                // After comma, add space
-                if self.current.kind == TokenKind::Comma {
-                    text.push_str(", ");
+            }
+        }
+
+        // Handle ** repeat operator on standalone array literal: [_]T{v} ** N
+        if self.current.kind == TokenKind::Power {
+            text.push_str(" ** ");
+            self.advance(); // consume **
+            if self.current.kind == TokenKind::LParen {
+                text.push('(');
+                self.advance();
+                let mut paren_depth = 1;
+                while paren_depth > 0 && self.current.kind != TokenKind::Eof {
+                    if self.current.kind == TokenKind::LParen { paren_depth += 1; }
+                    if self.current.kind == TokenKind::RParen {
+                        paren_depth -= 1;
+                        if paren_depth == 0 { break; }
+                    }
+                    text.push_str(&self.current.lexeme);
+                    if self.current.kind == TokenKind::Minus || self.current.kind == TokenKind::Plus {
+                        text.push(' ');
+                    }
                     self.advance();
-                    continue;
                 }
+                text.push(')');
+                self.expect(TokenKind::RParen)?;
+            } else {
                 text.push_str(&self.current.lexeme);
                 self.advance();
             }
-            text.push_str(" }");
-            self.expect(TokenKind::RBrace)?;
         }
 
         Ok(Node {
@@ -2081,6 +2160,38 @@ impl Parser {
             value: text,
             ..Default::default()
         })
+    }
+
+    /// Collect { ... } brace-delimited array initializer content verbatim
+    fn collect_array_brace_init(&mut self, text: &mut String) -> Result<(), String> {
+        text.push_str("{ ");
+        self.advance(); // consume {
+        let mut depth = 1;
+        while depth > 0 && self.current.kind != TokenKind::Eof {
+            if self.current.kind == TokenKind::LBrace {
+                depth += 1;
+            } else if self.current.kind == TokenKind::RBrace {
+                depth -= 1;
+                if depth == 0 {
+                    break;
+                }
+            }
+            if self.current.kind == TokenKind::Dot {
+                text.push('.');
+                self.advance();
+                continue;
+            }
+            if self.current.kind == TokenKind::Comma {
+                text.push_str(", ");
+                self.advance();
+                continue;
+            }
+            text.push_str(&self.current.lexeme);
+            self.advance();
+        }
+        text.push_str(" }");
+        self.expect(TokenKind::RBrace)?;
+        Ok(())
     }
 
     /// Parse if expression: if (cond) expr else expr

--- a/stage0/FROZEN_HASH
+++ b/stage0/FROZEN_HASH
@@ -1,1 +1,1 @@
-b6d82cd9f3ef8abbc65127ccaa2bbc3a03d1393097f9e8235741f0a52774650e  bootstrap/src/compiler.rs
+ec2e84d72900de78ad77a0b3ec27e21637a86c61d251d63ab5a186b38ac36562  bootstrap/src/compiler.rs


### PR DESCRIPTION
## Summary
- Added `++` (PlusPlus) array concatenation operator to the lexer and array literal parser, enabling Zig-style `[_]T{a} ++ [_]T{b}` syntax
- Relaxed struct literal syntax to accept `field = expr` without the `.` dot prefix (in addition to the existing `.field = expr`)
- Array literal parser now handles `**` repeat operator in context (e.g., `[_]T{v} ** N`)
- Extracted `collect_array_brace_init` helper method to reduce code duplication
- Updated `stage0/FROZEN_HASH`

## Results
All 7 AR spec files pass `gen` and `seal`:
| Spec | gen | seal |
|------|-----|------|
| asp_solver.t27 | OK | OK |
| composition.t27 | OK | OK |
| datalog_engine.t27 | OK | OK |
| explainability.t27 | OK | OK |
| proof_trace.t27 | OK | OK |
| restraint.t27 | OK | OK |
| ternary_logic.t27 | OK | OK |

No regressions in other spec directories (base, fpga, isa, math, nn, queen, vsa all unchanged).

## Test plan
- [x] `t27c gen` passes for all 7 AR specs
- [x] `t27c seal` produces valid hashes for all 7 AR specs  
- [x] Regression test: all previously-passing specs still pass
- [x] Compiler builds with `cargo build --release` (no errors)

Closes #35

---
🤖 *Generated by Computer*