### PR TITLE
feat(ring-14): Queen + NN specs gen and seal [SEED-14]

### DIFF
--- a/.trinity/seals/HSLM.json
+++ b/.trinity/seals/HSLM.json
@@ -1,0 +1,10 @@
+{
+  "gen_hash_c": "sha256:39dd2788f55bc4ab7aa89acac17342fa1a519298e48f6a00bfe551026a9ff40d",
+  "gen_hash_verilog": "sha256:59c3388e9db687f2217970689668fbaf6d5ff984ac85c95f633bac4291b61903",
+  "gen_hash_zig": "sha256:290f90b583554a75ba16c7eec0e6e388631de6675423160be88d6b57cd92a71c",
+  "module": "HSLM",
+  "ring": 12,
+  "sealed_at": "2026-04-04T12:26:34Z",
+  "spec_hash": "sha256:b330b7482ef3d92f88d57a40bb97e1a0cd62a62687da483c83558c72d59153d1",
+  "spec_path": "specs/nn/hslm.t27"
+}

--- a/.trinity/seals/QueenLotus.json
+++ b/.trinity/seals/QueenLotus.json
@@ -1,0 +1,10 @@
+{
+  "gen_hash_c": "sha256:944237b7237c3f0126b1b2cb646467d46f488901aac7595650b3cfc48f14e050",
+  "gen_hash_verilog": "sha256:cd112aef565c74334fbe8acba6787643c6c5f24261f06b0ba0bb472e840643eb",
+  "gen_hash_zig": "sha256:7b3d09fb1e9e46805edd70ca1e55103efc453c3e60518c70d8b2f9ab7626441e",
+  "module": "QueenLotus",
+  "ring": 12,
+  "sealed_at": "2026-04-04T12:26:33Z",
+  "spec_hash": "sha256:aba0e5052c50fecef28f0a08d3d9f10a5269a0c51e77461ff6e1a2330ff2eab9",
+  "spec_path": "specs/queen/lotus.t27"
+}

--- a/.trinity/seals/SacredAttention.json
+++ b/.trinity/seals/SacredAttention.json
@@ -1,0 +1,10 @@
+{
+  "gen_hash_c": "sha256:2fffff078c553a6c2dc0c4ec7c9e2273418fe595922bf56d4f4dd33bf7db0bbc",
+  "gen_hash_verilog": "sha256:8d91c2d5baa7cbb88327db7851dec70664f7df6a424d7aa204d83232e2e1a141",
+  "gen_hash_zig": "sha256:dd002b43de0e42078f5ab46a01b22b9775bfdbc5e79bc0279c9415a1edc225a0",
+  "module": "SacredAttention",
+  "ring": 12,
+  "sealed_at": "2026-04-04T12:26:34Z",
+  "spec_hash": "sha256:040670fefe75e4de94153cc64f5a7c8f3babb4d5878e506e44e5cfc26a2e2524",
+  "spec_path": "specs/nn/attention.t27"
+}

--- a/bootstrap/src/main.rs
+++ b/bootstrap/src/main.rs
@@ -271,7 +271,7 @@ fn extract_module_name(source: &str) -> Option<String> {
         let trimmed = line.trim();
         if trimmed.starts_with("module ") {
             let rest = trimmed.strip_prefix("module ").unwrap().trim();
-            let name = rest.trim_end_matches(';').trim();
+            let name = rest.trim_end_matches(';').trim_end_matches('{').trim();
             if !name.is_empty() {
                 return Some(name.to_string());
             }


### PR DESCRIPTION
## Summary
- All three specs (`specs/queen/lotus.t27`, `specs/nn/attention.t27`, `specs/nn/hslm.t27`) gen and seal successfully
- Fix `extract_module_name` to handle brace-style `module Name {` declarations (was only stripping `;`, now also strips `{`)
- Add seal files for QueenLotus, SacredAttention, and HSLM modules

## Test plan
- [x] `t27c gen specs/queen/lotus.t27` — OK
- [x] `t27c gen specs/nn/attention.t27` — OK
- [x] `t27c gen specs/nn/hslm.t27` — OK
- [x] `t27c seal --save` for all three — OK
- [x] `t27c seal --verify` for all three — all hashes MATCH
- [x] `cargo test --release` — 0 failures

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)