### PR TITLE
feat(ring-16): Self-parse — compiler reads its own specs

### DIFF
--- a/.trinity/seals/ast.json
+++ b/.trinity/seals/ast.json
@@ -1,0 +1,10 @@
+{
+  "gen_hash_c": "sha256:eaf75db19e8953470a773b81d54f8569c9a8cb7e8a4d2322f27e82b93f0863eb",
+  "gen_hash_verilog": "sha256:a742cf87624f180da1042feea2cddc33b0d331dc38da556f0120c020f1417db9",
+  "gen_hash_zig": "sha256:78cebab6e362112e89341a00f993b7702816f8ccd819455ad83d3798d696b244",
+  "module": "ast",
+  "ring": 12,
+  "sealed_at": "2026-04-04T12:59:11Z",
+  "spec_hash": "sha256:28bfcdf211a0360991fe8d89dc376440d2144b936e030f81e0b5794a1c0eeb00",
+  "spec_path": "compiler/ast.t27"
+}

--- a/.trinity/seals/commands.json
+++ b/.trinity/seals/commands.json
@@ -4,7 +4,7 @@
   "gen_hash_zig": "sha256:6eb3ea9d422dea6693f889ab8dddfa8457b86139c448f8839f683b6d57f7b6b5",
   "module": "commands",
   "ring": 12,
-  "sealed_at": "2026-04-04T12:46:48Z",
+  "sealed_at": "2026-04-04T12:59:11Z",
   "spec_hash": "sha256:e3db9746da96ce709e8b815560b9cf11a854325f95a55f77b5fd5db6b3475885",
   "spec_path": "compiler/runtime/commands.t27"
 }

--- a/.trinity/seals/gen_commands.json
+++ b/.trinity/seals/gen_commands.json
@@ -4,7 +4,7 @@
   "gen_hash_zig": "sha256:c390f7731198f189aa3d7fc1e92c6b9b85469533b8a0c9bb0cf5bf862f754148",
   "module": "gen_commands",
   "ring": 12,
-  "sealed_at": "2026-04-04T12:46:48Z",
+  "sealed_at": "2026-04-04T12:59:11Z",
   "spec_hash": "sha256:f424b8fd08858a0bac83c2ba6a885446600819c0b79a838163c5b51b375413c3",
   "spec_path": "compiler/cli/gen.t27"
 }

--- a/.trinity/seals/git_commands.json
+++ b/.trinity/seals/git_commands.json
@@ -4,7 +4,7 @@
   "gen_hash_zig": "sha256:28bef8dccbfe7181f4e1efb849b5d9ee366f10e5a282c134e4eb08957a041c3d",
   "module": "git_commands",
   "ring": 12,
-  "sealed_at": "2026-04-04T12:46:48Z",
+  "sealed_at": "2026-04-04T12:59:11Z",
   "spec_hash": "sha256:a2ed7ccff916e322f238d01ec8a8ba31e0c24cbcd2bcabf7c36c190f8ad74c2e",
   "spec_path": "compiler/cli/git.t27"
 }

--- a/.trinity/seals/parser.json
+++ b/.trinity/seals/parser.json
@@ -4,7 +4,7 @@
   "gen_hash_zig": "sha256:e75a7674fa82c47a570a523fbd517569dd0eaf198131af6e8f482edd10c979c2",
   "module": "parser",
   "ring": 12,
-  "sealed_at": "2026-04-04T12:46:48Z",
+  "sealed_at": "2026-04-04T12:59:11Z",
   "spec_hash": "sha256:1598012842f8d2c195ecd1f706fcc5ac0a7b521db35282ecbee4bce748b725ee",
   "spec_path": "compiler/parser/parser.t27"
 }

--- a/.trinity/seals/skill_registry.json
+++ b/.trinity/seals/skill_registry.json
@@ -4,7 +4,7 @@
   "gen_hash_zig": "sha256:086aa439505c9ef0371372065268414a21606af509100fa538a76465dccee334",
   "module": "skill_registry",
   "ring": 12,
-  "sealed_at": "2026-04-04T12:46:48Z",
+  "sealed_at": "2026-04-04T12:59:11Z",
   "spec_hash": "sha256:d492aa25a1e06b4ced6c44067db4ae48e4cfa14f2939dea8c45cfc838f38c6b6",
   "spec_path": "compiler/skill/registry.t27"
 }

--- a/.trinity/seals/spec_commands.json
+++ b/.trinity/seals/spec_commands.json
@@ -4,7 +4,7 @@
   "gen_hash_zig": "sha256:0031a0fe8b826c6365745f134d47e0b5f6d843fff1fbc818099c44ba765a8e54",
   "module": "spec_commands",
   "ring": 12,
-  "sealed_at": "2026-04-04T12:46:48Z",
+  "sealed_at": "2026-04-04T12:59:11Z",
   "spec_hash": "sha256:66f48663fb58c54066c3c13d0fa2afcfbfd38536ded273d84cd63bab51325b5a",
   "spec_path": "compiler/cli/spec.t27"
 }

--- a/.trinity/seals/testgen.json
+++ b/.trinity/seals/testgen.json
@@ -4,7 +4,7 @@
   "gen_hash_zig": "sha256:f72edfadaae7b439a4f8b8fbe97fdc97971149635e2b82afd4c6b3a48aba6d14",
   "module": "testgen",
   "ring": 12,
-  "sealed_at": "2026-04-04T12:46:48Z",
+  "sealed_at": "2026-04-04T12:59:11Z",
   "spec_hash": "sha256:f132d76e373fa4780e558e3265e743d5b5847cd92f2f90735cde6c648a7af1fe",
   "spec_path": "compiler/codegen/testgen.t27"
 }

--- a/.trinity/seals/tricgen-c.json
+++ b/.trinity/seals/tricgen-c.json
@@ -1,0 +1,10 @@
+{
+  "gen_hash_c": "sha256:0c8aa454f0b1901b875cd54e72341dd62112970b24517b876f05b8984c086121",
+  "gen_hash_verilog": "sha256:3a983788318509eefe8cbbfdc02f79f284e10c7b20d7ffb852f5da7cfe02cd8b",
+  "gen_hash_zig": "sha256:2299b3511b7f82c457a1cab8184b0dd9c781fbe567f91b6556c6e7843431ad28",
+  "module": "tricgen-c",
+  "ring": 12,
+  "sealed_at": "2026-04-04T12:59:11Z",
+  "spec_hash": "sha256:405fdea7d1fb2b058f76601757ce3b28a5c6667fdb68203b311c80d7f4db7407",
+  "spec_path": "compiler/codegen/c/codegen.t27"
+}

--- a/.trinity/seals/trilexer.json
+++ b/.trinity/seals/trilexer.json
@@ -4,7 +4,7 @@
   "gen_hash_zig": "sha256:d3800cc5ed250afd87ea18aa11776ba1d147f9d89207ee2ecaa172b57c39b182",
   "module": "trilexer",
   "ring": 12,
-  "sealed_at": "2026-04-04T12:46:48Z",
+  "sealed_at": "2026-04-04T12:59:11Z",
   "spec_hash": "sha256:cf665b400e73091057d195296506e68e8c16acff3adc70a1756b58cd88e30afc",
   "spec_path": "compiler/parser/lexer.t27"
 }

--- a/.trinity/seals/triruntime.json
+++ b/.trinity/seals/triruntime.json
@@ -4,7 +4,7 @@
   "gen_hash_zig": "sha256:b0b8aeaebe360a967c654c54bd28440dda6a128f65a83d1281c75b82c3345c6b",
   "module": "triruntime",
   "ring": 12,
-  "sealed_at": "2026-04-04T12:46:48Z",
+  "sealed_at": "2026-04-04T12:59:11Z",
   "spec_hash": "sha256:83969c01bc42ca48ab841ba4e77ce26d08e9b23a0922dcc33dffee3b69cdab74",
   "spec_path": "compiler/runtime/runtime.t27"
 }

--- a/.trinity/seals/validation_rules.json
+++ b/.trinity/seals/validation_rules.json
@@ -4,7 +4,7 @@
   "gen_hash_zig": "sha256:34f0206db4cee459ef78153e9258447f87f251141eea7ee0d831cc6e1404b534",
   "module": "validation_rules",
   "ring": 12,
-  "sealed_at": "2026-04-04T12:46:48Z",
+  "sealed_at": "2026-04-04T12:59:11Z",
   "spec_hash": "sha256:33678b37e2c94763d2da70fee97c6a0070cb6fac64b6d2dfa12619af3b164e7c",
   "spec_path": "compiler/runtime/validation.t27"
 }

--- a/.trinity/seals/verilog_codegen.json
+++ b/.trinity/seals/verilog_codegen.json
@@ -1,0 +1,10 @@
+{
+  "gen_hash_c": "sha256:52df6d7029c3c5417a475cebb471fbd94c78c4e21e3622c82d8406d4d30af34d",
+  "gen_hash_verilog": "sha256:6ce05ae4911f1c506f159776ae3062576e708f28da3a882efef3771b8a68782a",
+  "gen_hash_zig": "sha256:3122a69f23dee6299ab57bb6ed2b1b7fb04fc0d301ba0fc9688261e4be3b64af",
+  "module": "verilog_codegen",
+  "ring": 12,
+  "sealed_at": "2026-04-04T12:59:11Z",
+  "spec_hash": "sha256:7702b4a3b4ad5d2c38ef039b916dfffbb21e76533c2b02ed09feb25b5576357a",
+  "spec_path": "compiler/codegen/verilog/codegen.t27"
+}

--- a/.trinity/seals/zig_codegen.json
+++ b/.trinity/seals/zig_codegen.json
@@ -1,0 +1,10 @@
+{
+  "gen_hash_c": "sha256:ad3e869258a03537b1824ddd76d8dc5c421ee4ae440851bf2da665a958489e97",
+  "gen_hash_verilog": "sha256:29aa455981764165ed693ce940c3a1bf0b582b7433a599576ae8e127ad3b37ae",
+  "gen_hash_zig": "sha256:38a6c2bf4b0110cef7d19452734815178f43e2043668cd9367c4a97d0d6ee329",
+  "module": "zig_codegen",
+  "ring": 12,
+  "sealed_at": "2026-04-04T12:59:11Z",
+  "spec_hash": "sha256:face91b2c4dda278c97006286cdbd18e00e2a2d01e9288eeb0d6520aa47f7fce",
+  "spec_path": "compiler/codegen/zig/codegen.t27"
+}

--- a/.trinity/seals/zig_runtime.json
+++ b/.trinity/seals/zig_runtime.json
@@ -1,0 +1,10 @@
+{
+  "gen_hash_c": "sha256:71e23bc8295b19df9b60da1788fa042bcc822565cbb6371eae67865779d89778",
+  "gen_hash_verilog": "sha256:acb8c3a518ea255a79b27a3a43c4b421081c6b731f5ac4fdde1f83dd0e9fe719",
+  "gen_hash_zig": "sha256:fe57cf18526db56fbb5bb977426da2bdf7a7f831342f4e5e30b90d3b5da6f179",
+  "module": "zig_runtime",
+  "ring": 12,
+  "sealed_at": "2026-04-04T12:59:11Z",
+  "spec_hash": "sha256:295218999824f8be1facebfa4cdf9e7dbe55c31f692d1b025a668bd974569a6d",
+  "spec_path": "compiler/codegen/zig/runtime.t27"
+}


### PR DESCRIPTION
## Summary
- All 15 compiler spec files in `compiler/` parse, gen, and seal successfully
- The compiler can read its own specification (self-parse milestone)
- 5 new seal files added: `ast`, `tricgen-c`, `verilog_codegen`, `zig_codegen`, `zig_runtime`
- 10 existing compiler seals refreshed (content hashes unchanged, timestamps updated)
- `stage0/FROZEN_HASH` verified — compiler source unchanged

## Compiler Specs (15/15 ✅)
| Directory | Files | Status |
|-----------|-------|--------|
| `compiler/` | `ast.t27` | ✅ gen + seal |
| `compiler/cli/` | `gen.t27`, `git.t27`, `spec.t27` | ✅ gen + seal |
| `compiler/codegen/` | `testgen.t27` | ✅ gen + seal |
| `compiler/codegen/c/` | `codegen.t27` | ✅ gen + seal |
| `compiler/codegen/zig/` | `codegen.t27`, `runtime.t27` | ✅ gen + seal |
| `compiler/codegen/verilog/` | `codegen.t27` | ✅ gen + seal |
| `compiler/parser/` | `lexer.t27`, `parser.t27` | ✅ gen + seal |
| `compiler/runtime/` | `commands.t27`, `runtime.t27`, `validation.t27` | ✅ gen + seal |
| `compiler/skill/` | `registry.t27` | ✅ gen + seal |

## Test plan
- [x] `t27c gen` passes for all 15 compiler spec files
- [x] `t27c seal --save` succeeds for all 15 files
- [x] `t27c seal --verify` confirms all seals match
- [x] FROZEN_HASH verified unchanged

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)