### PR TITLE
fix(deploy): correct Dockerfile paths for Railway build context

### DIFF
--- a/bootstrap/Dockerfile
+++ b/bootstrap/Dockerfile
@@ -1,11 +1,14 @@
 # Multi-stage Dockerfile for t27c compiler
-FROM rust:1.75-slim as builder
+# NOTE: Docker build context is the REPO ROOT (Railway sets dockerfilePath = "bootstrap/Dockerfile")
+FROM rust:1.82-slim as builder
 
 WORKDIR /app
 
-# Copy source code (using standard src/ structure)
-COPY Cargo.toml .
-COPY src ./src
+# Copy manifest and lock for reproducible builds
+COPY bootstrap/Cargo.toml bootstrap/Cargo.lock ./
+
+# Copy source code from bootstrap directory
+COPY bootstrap/src ./src
 
 # Build with server feature enabled
 RUN cargo build --release --features server
@@ -18,6 +21,10 @@ RUN apt-get update && apt-get install -y ca-certificates \
 
 # Copy compiled binary
 COPY --from=builder /app/target/release/t27c /t27c
+
+# Copy specs and conformance data for the API to serve
+COPY specs/ /specs/
+COPY conformance/ /conformance/
 
 # Expose port for HTTP server
 EXPOSE 8080


### PR DESCRIPTION
## Summary
- Fixed `COPY` paths in `bootstrap/Dockerfile` to account for Railway's build context being the repo root (not `bootstrap/`)
- Added `Cargo.lock` to the build for reproducible deployments
- Added `COPY specs/` and `COPY conformance/` so the server can serve spec and test data
- Bumped Rust base image from 1.75 to 1.82

## What was wrong
Railway sets `dockerfilePath = "bootstrap/Dockerfile"` which means the Docker build context is the **repo root**. The old Dockerfile used `COPY Cargo.toml .` and `COPY src ./src` which looked for files at the repo root — but they live under `bootstrap/`.

## Test plan
- [ ] Railway deployment succeeds (Docker build completes)
- [ ] `/health` endpoint responds after deploy
- [ ] Specs and conformance data are accessible via the API

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)