### PR TITLE
feat(cli): fix compile-all path resolution + add stats command

### DIFF
--- a/bootstrap/Cargo.lock
+++ b/bootstrap/Cargo.lock
@@ -628,6 +628,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,6 +792,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tokio",
+ "walkdir",
 ]
 
 [[package]]
@@ -886,6 +896,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,6 +954,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]

--- a/bootstrap/src/main.rs
+++ b/bootstrap/src/main.rs
@@ -96,7 +96,13 @@ enum Commands {
         /// Output directory
         #[arg(short, long, default_value = "build")]
         output: String,
+        /// Path to directory containing specs/ and compiler/ (auto-detected if omitted)
+        #[arg(long)]
+        specs_dir: Option<String>,
     },
+
+    /// Show repository statistics
+    Stats,
 
     /// Start HTTP server on Railway
     Serve {
@@ -482,18 +488,59 @@ fn run_compile(input_path: &str, backend: &str, output: Option<&str>) -> anyhow:
     Ok(())
 }
 
-fn run_compile_all(backend: &str, output_dir: &str) -> anyhow::Result<()> {
+/// Auto-detect the repository root by looking for a directory containing specs/.
+/// Searches CWD first, then up to 3 parent directories.
+fn find_repo_root() -> Option<std::path::PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    let mut dir = cwd.as_path();
+    for _ in 0..4 {
+        if dir.join("specs").is_dir() {
+            return Some(dir.to_path_buf());
+        }
+        dir = dir.parent()?;
+    }
+    None
+}
+
+fn run_compile_all(backend: &str, output_dir: &str, specs_dir: Option<&str>) -> anyhow::Result<()> {
+    let root = match specs_dir {
+        Some(d) => std::path::PathBuf::from(d),
+        None => find_repo_root()
+            .ok_or_else(|| anyhow::anyhow!(
+                "Could not find specs/ directory. Run from the repo root or use --specs-dir"
+            ))?,
+    };
+
     let ext = backend_extension(backend);
     let out_base = Path::new(output_dir);
     let mut count = 0u32;
 
+    // Count total .t27 files first for the progress message
     let dirs = ["specs", "compiler"];
+    let mut total = 0u32;
     for dir in &dirs {
-        let base = Path::new(dir);
+        let base = root.join(dir);
         if !base.exists() {
             continue;
         }
-        for entry in walkdir::WalkDir::new(base)
+        for entry in walkdir::WalkDir::new(&base)
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
+            if entry.path().extension().and_then(|e| e.to_str()) == Some("t27") {
+                total += 1;
+            }
+        }
+    }
+
+    println!("Compiling {} files from {} to {}/", total, root.display(), output_dir);
+
+    for dir in &dirs {
+        let base = root.join(dir);
+        if !base.exists() {
+            continue;
+        }
+        for entry in walkdir::WalkDir::new(&base)
             .into_iter()
             .filter_map(|e| e.ok())
         {
@@ -510,7 +557,7 @@ fn run_compile_all(backend: &str, output_dir: &str) -> anyhow::Result<()> {
                 }
             };
             // Preserve directory structure: specs/base/types.t27 -> build/specs/base/types.zig
-            let rel = p.strip_prefix(".").unwrap_or(p);
+            let rel = p.strip_prefix(&root).unwrap_or(p);
             let dest = out_base.join(rel).with_extension(&ext[1..]);
             if let Some(parent) = dest.parent() {
                 fs::create_dir_all(parent)?;
@@ -522,6 +569,205 @@ fn run_compile_all(backend: &str, output_dir: &str) -> anyhow::Result<()> {
     }
 
     println!("\ncompiled {} files to {}/", count, output_dir);
+    Ok(())
+}
+
+// ============================================================================
+// Stats Command
+// ============================================================================
+
+fn count_pattern_in_dir(root: &Path, dirs: &[&str], pattern: &str) -> u32 {
+    let mut count = 0u32;
+    for dir in dirs {
+        let base = root.join(dir);
+        if !base.exists() {
+            continue;
+        }
+        for entry in walkdir::WalkDir::new(&base)
+            .into_iter()
+            .filter_map(|e| e.ok())
+        {
+            let p = entry.path();
+            if p.extension().and_then(|e| e.to_str()) != Some("t27") {
+                continue;
+            }
+            if let Ok(contents) = fs::read_to_string(p) {
+                for line in contents.lines() {
+                    let trimmed = line.trim();
+                    if trimmed.starts_with(pattern) {
+                        count += 1;
+                    }
+                }
+            }
+        }
+    }
+    count
+}
+
+fn count_t27_files(root: &Path, dir: &str) -> u32 {
+    let base = root.join(dir);
+    if !base.exists() {
+        return 0;
+    }
+    let mut count = 0u32;
+    for entry in walkdir::WalkDir::new(&base)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        if entry.path().extension().and_then(|e| e.to_str()) == Some("t27") {
+            count += 1;
+        }
+    }
+    count
+}
+
+fn count_lines(path: &Path) -> u32 {
+    if let Ok(contents) = fs::read_to_string(path) {
+        contents.lines().count() as u32
+    } else {
+        0
+    }
+}
+
+fn count_files_in_dir(dir: &Path, ext: &str) -> u32 {
+    if !dir.exists() {
+        return 0;
+    }
+    let mut count = 0u32;
+    for entry in walkdir::WalkDir::new(dir)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        if entry.path().extension().and_then(|e| e.to_str()) == Some(ext) {
+            count += 1;
+        }
+    }
+    count
+}
+
+fn run_stats() -> anyhow::Result<()> {
+    let root = find_repo_root()
+        .ok_or_else(|| anyhow::anyhow!(
+            "Could not find specs/ directory. Run from the repo root or use --specs-dir with compile-all"
+        ))?;
+
+    let dirs = &["specs", "compiler"];
+
+    let specs_count = count_t27_files(&root, "specs");
+    let compiler_count = count_t27_files(&root, "compiler");
+    let total_specs = specs_count + compiler_count;
+
+    let functions = count_pattern_in_dir(&root, dirs, "fn ");
+    let tests = count_pattern_in_dir(&root, dirs, "test ");
+    let invariants = count_pattern_in_dir(&root, dirs, "invariant ");
+    let benchmarks = count_pattern_in_dir(&root, dirs, "bench ");
+
+    let conformance_count = count_files_in_dir(&root.join("conformance"), "json");
+
+    let seals_dir = root.join(".trinity").join("seals");
+    let seals_count = count_files_in_dir(&seals_dir, "json");
+
+    let compiler_loc = count_lines(&root.join("bootstrap").join("src").join("compiler.rs"));
+
+    // Count CLI commands by reading the Commands enum variants
+    // Variants are lines like "    Parse {" or "    Stats," at exactly 4-space indent
+    let cli_commands = {
+        let main_rs = root.join("bootstrap").join("src").join("main.rs");
+        if let Ok(contents) = fs::read_to_string(&main_rs) {
+            let mut in_enum = false;
+            let mut count = 0u32;
+            for line in contents.lines() {
+                let trimmed = line.trim();
+                if trimmed.starts_with("enum Commands") {
+                    in_enum = true;
+                    continue;
+                }
+                if in_enum {
+                    if trimmed == "}" {
+                        break;
+                    }
+                    // Variant lines start with an uppercase letter
+                    if let Some(first) = trimmed.chars().next() {
+                        if first.is_uppercase() && (trimmed.contains('{') || trimmed.contains(',') || trimmed.ends_with('{')) {
+                            count += 1;
+                        }
+                    }
+                }
+            }
+            count
+        } else {
+            0
+        }
+    };
+
+    // Detect latest ring from experience episodes.jsonl and seal files
+    let fixed_point_ring = {
+        let mut max_ring = 0u32;
+
+        // Check .trinity/experience/episodes.jsonl (each line is a JSON object with "metadata.ring" or top-level "ring")
+        let episodes_jsonl = root.join(".trinity").join("experience").join("episodes.jsonl");
+        if episodes_jsonl.exists() {
+            if let Ok(contents) = fs::read_to_string(&episodes_jsonl) {
+                for line in contents.lines() {
+                    if let Ok(json) = serde_json::from_str::<serde_json::Value>(line) {
+                        // Check metadata.ring first, then top-level ring
+                        let ring = json.get("metadata")
+                            .and_then(|m| m.get("ring"))
+                            .and_then(|r| r.as_u64())
+                            .or_else(|| json.get("ring").and_then(|r| r.as_u64()));
+                        if let Some(r) = ring {
+                            if r as u32 > max_ring {
+                                max_ring = r as u32;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Also check seal files for ring values
+        let seals_dir = root.join(".trinity").join("seals");
+        if seals_dir.exists() {
+            for entry in walkdir::WalkDir::new(&seals_dir)
+                .into_iter()
+                .filter_map(|e| e.ok())
+            {
+                if entry.path().extension().and_then(|e| e.to_str()) == Some("json") {
+                    if let Ok(contents) = fs::read_to_string(entry.path()) {
+                        if let Ok(json) = serde_json::from_str::<serde_json::Value>(&contents) {
+                            if let Some(ring) = json.get("ring").and_then(|r| r.as_u64()) {
+                                if ring as u32 > max_ring {
+                                    max_ring = ring as u32;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        max_ring
+    };
+
+    println!("T27 Repository Statistics");
+    println!("========================");
+    println!("Spec files:     {} ({} in specs/, {} in compiler/)", total_specs, specs_count, compiler_count);
+    println!("Functions:      {}", functions);
+    println!("Tests:          {}", tests);
+    println!("Invariants:     {}", invariants);
+    println!("Benchmarks:     {}", benchmarks);
+    println!("Conformance:    {} JSON files", conformance_count);
+    println!("Seals:          {} saved", seals_count);
+    println!("Backends:       3 (Zig, Verilog, C)");
+    println!("CLI commands:   {}", cli_commands);
+    println!("Compiler LOC:   {}", compiler_loc);
+    if fixed_point_ring > 0 {
+        println!("Fixed point:    REACHED (ring-{})", fixed_point_ring);
+    } else {
+        println!("Fixed point:    NOT REACHED");
+    }
+    println!("phi^2 + 1/phi^2 = 3 | TRINITY");
+
     Ok(())
 }
 
@@ -544,7 +790,10 @@ async fn main() -> anyhow::Result<()> {
         Commands::Compile { input, backend, output } => {
             run_compile(&input, &backend, output.as_deref())?
         }
-        Commands::CompileAll { backend, output } => run_compile_all(&backend, &output)?,
+        Commands::CompileAll { backend, output, specs_dir } => {
+            run_compile_all(&backend, &output, specs_dir.as_deref())?
+        }
+        Commands::Stats => run_stats()?,
         Commands::Serve { port } => run_server(&port).await?,
     }
 
@@ -565,7 +814,10 @@ fn main() -> anyhow::Result<()> {
         Commands::Compile { input, backend, output } => {
             run_compile(&input, &backend, output.as_deref())?
         }
-        Commands::CompileAll { backend, output } => run_compile_all(&backend, &output)?,
+        Commands::CompileAll { backend, output, specs_dir } => {
+            run_compile_all(&backend, &output, specs_dir.as_deref())?
+        }
+        Commands::Stats => run_stats()?,
         Commands::Serve { .. } => {
             eprintln!("Error: 'serve' command requires 'server' feature");
             eprintln!("Build with: cargo build --release --features server");


### PR DESCRIPTION
## Summary

- **Fix compile-all**: Auto-detects the repo root by searching for `specs/` directory up from CWD (up to 3 parent levels). Previously returned 0 files when run from `bootstrap/` or any subdirectory. Added `--specs-dir` flag for explicit override.
- **Add stats command**: `t27c stats` displays repository statistics — spec files, functions, tests, invariants, benchmarks, conformance files, seals, backends, CLI commands, compiler LOC, and fixed point ring status.

### Example output
```
$ t27c stats
T27 Repository Statistics
========================
Spec files:     43 (28 in specs/, 15 in compiler/)
Functions:      363
Tests:          1121
Invariants:     641
Benchmarks:     301
Conformance:    11 JSON files
Seals:          43 saved
Backends:       3 (Zig, Verilog, C)
CLI commands:   10
Compiler LOC:   4957
Fixed point:    REACHED (ring-17)
phi^2 + 1/phi^2 = 3 | TRINITY
```

Closes #62

## Test plan
- [x] `t27c compile-all` from repo root produces 43 files
- [x] `t27c compile-all` from `bootstrap/` subdirectory auto-detects and produces 43 files
- [x] `t27c compile-all --specs-dir <path>` works with explicit path
- [x] `t27c stats` shows correct counts matching actual file/line analysis
- [x] `cargo build` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)