### PR TITLE
feat(ci): Docker build + push for sandbox and API images [SANDBOX-004]

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,0 +1,59 @@
+name: Deploy Control Plane API
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'backend/api/**'
+      - '.github/workflows/deploy-api.yml'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ghcr.io/ghashtagg/t27-api
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Install dependencies
+        working-directory: backend/api
+        run: npm ci
+      - name: Run tests
+        working-directory: backend/api
+        run: npx vitest run
+
+  build-and-push:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: backend/api
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/sandbox-docker.yml
+++ b/.github/workflows/sandbox-docker.yml
@@ -1,0 +1,44 @@
+name: Build & Push Sandbox Image
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'backend/sandbox/**'
+      - '.github/workflows/sandbox-docker.yml'
+  workflow_dispatch:  # allow manual trigger
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ghcr.io/ghashtagg/t27-sandbox
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: backend/sandbox
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/backend/api/Dockerfile
+++ b/backend/api/Dockerfile
@@ -1,18 +1,26 @@
+FROM node:22-alpine AS build
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --ignore-scripts
+
+COPY tsconfig.json ./
+COPY drizzle.config.ts ./
+COPY src ./src
+
+RUN npm run build
+
+# ── Production stage ──
 FROM node:22-alpine
 
 WORKDIR /app
 
-RUN corepack enable && corepack prepare npm@latest --activate
+COPY package.json package-lock.json ./
+RUN npm ci --ignore-scripts --omit=dev
 
-COPY package.json ./
-COPY tsconfig.json ./
-COPY drizzle.config.ts ./
-
-RUN npm install
-
-COPY src ./src
-
-RUN npm run build
+COPY --from=build /app/dist ./dist
+COPY migrations ./migrations
 
 EXPOSE 3000
 


### PR DESCRIPTION
Closes #76

## Two new GitHub Actions workflows

**sandbox-docker.yml** — builds `ghcr.io/ghashtagg/t27-sandbox`
- Triggers on push to `backend/sandbox/**`
- OpenCode web + code-server + git/gh/python
- Manual trigger available

**deploy-api.yml** — builds `ghcr.io/ghashtagg/t27-api`
- Runs 73 vitest unit tests first
- Multi-stage Dockerfile (build + production)
- Triggers on push to `backend/api/**`

Both use GHCR with `GITHUB_TOKEN` auth and BuildKit cache.