### PR TITLE
fix(ci): GHCR namespace + tsc build [SANDBOX-005]

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -10,7 +10,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ghcr.io/ghashtagg/t27-api
 
 permissions:
   contents: read
@@ -43,6 +42,9 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set image name (lowercase owner)
+        run: echo "IMAGE_NAME=${{ env.REGISTRY }}/$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')/t27-api" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/sandbox-docker.yml
+++ b/.github/workflows/sandbox-docker.yml
@@ -6,11 +6,10 @@ on:
     paths:
       - 'backend/sandbox/**'
       - '.github/workflows/sandbox-docker.yml'
-  workflow_dispatch:  # allow manual trigger
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ghcr.io/ghashtagg/t27-sandbox
 
 permissions:
   contents: read
@@ -28,6 +27,9 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set image name (lowercase owner)
+        run: echo "IMAGE_NAME=${{ env.REGISTRY }}/$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')/t27-sandbox" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/backend/api/.env.example
+++ b/backend/api/.env.example
@@ -18,7 +18,7 @@ RAILWAY_PROJECT_ID=your_railway_project_id
 RAILWAY_ENVIRONMENT_ID=your_railway_environment_id
 
 # Docker image used for each sandbox service
-RAILWAY_SERVICE_IMAGE=ghcr.io/ghashtagg/t27-sandbox:latest
+RAILWAY_SERVICE_IMAGE=ghcr.io/ghashtag/t27-sandbox:latest
 
 # Railway GraphQL endpoint (optional, has default)
 RAILWAY_GRAPHQL_URL=https://backboard.railway.com/graphql/v2

--- a/backend/api/src/config.ts
+++ b/backend/api/src/config.ts
@@ -67,7 +67,7 @@ export const config = {
   railwayEnvironmentId: requiredEnv("RAILWAY_ENVIRONMENT_ID"),
   railwayServiceImage:
     process.env.RAILWAY_SERVICE_IMAGE ??
-    "ghcr.io/ghashtagg/t27-sandbox:latest",
+    "ghcr.io/ghashtag/t27-sandbox:latest",
   railwayGraphqlUrl:
     process.env.RAILWAY_GRAPHQL_URL ??
     "https://backboard.railway.com/graphql/v2",

--- a/backend/api/tsconfig.json
+++ b/backend/api/tsconfig.json
@@ -10,5 +10,6 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/__tests__"]
 }

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -62,7 +62,7 @@ services:
       RAILWAY_API_TOKEN: ${RAILWAY_API_TOKEN:-placeholder}
       RAILWAY_PROJECT_ID: ${RAILWAY_PROJECT_ID:-placeholder}
       RAILWAY_ENVIRONMENT_ID: ${RAILWAY_ENVIRONMENT_ID:-placeholder}
-      RAILWAY_SERVICE_IMAGE: ${RAILWAY_SERVICE_IMAGE:-ghcr.io/ghashtagg/t27-sandbox:latest}
+      RAILWAY_SERVICE_IMAGE: ${RAILWAY_SERVICE_IMAGE:-ghcr.io/ghashtag/t27-sandbox:latest}
 
       # ── Local mode: proxy to local sandbox containers ──
       LOCAL_MODE: "true"


### PR DESCRIPTION
Closes #78

Fixes both Docker build failures from PR #77:

**1. GHCR namespace not found**
`ghcr.io/ghashtagg/` → dynamically computed from `github.repository_owner` (lowercase). Resolves to `ghcr.io/ghashtag/`.

**2. tsc build fails on test files**
Test files use vitest globals and mock types that aren't in the production tsconfig. Added `"exclude": ["src/__tests__"]` to `tsconfig.json`. Vitest has its own TS handling via `vitest.config.ts`.