### PR TITLE
feat(sandbox): autonomous task mode + Z.AI support [SANDBOX-008]

### DIFF
--- a/backend/api/src/config.ts
+++ b/backend/api/src/config.ts
@@ -101,6 +101,8 @@ export const config = {
   sandboxRepoUrl:
     process.env.SANDBOX_REPO_URL ?? "https://github.com/gHashTag/t27.git",
   anthropicApiKey: process.env.ANTHROPIC_API_KEY,
+  anthropicBaseUrl: process.env.ANTHROPIC_BASE_URL,
+  anthropicAuthToken: process.env.ANTHROPIC_AUTH_TOKEN,
   openaiApiKey: process.env.OPENAI_API_KEY,
 };
 

--- a/backend/api/src/services/sessions.ts
+++ b/backend/api/src/services/sessions.ts
@@ -116,10 +116,18 @@ export const createSession = async ({
   const effectiveRepoUrl = repoUrl ?? config.sandboxRepoUrl;
   if (effectiveRepoUrl) sandboxVars["SANDBOX_REPO_URL"] = effectiveRepoUrl;
   if (branch) sandboxVars["SANDBOX_BRANCH"] = branch;
-  if (taskDescription) sandboxVars["TASK_DESCRIPTION"] = taskDescription;
+  if (taskDescription) {
+    sandboxVars["TASK_DESCRIPTION"] = taskDescription;
+    sandboxVars["TASK_PROMPT"] = taskDescription;
+    sandboxVars["TASK_TITLE"] = resolvedName;
+  }
   if (config.githubToken) sandboxVars["GH_TOKEN"] = config.githubToken;
   if (config.anthropicApiKey)
     sandboxVars["ANTHROPIC_API_KEY"] = config.anthropicApiKey;
+  if (config.anthropicBaseUrl)
+    sandboxVars["ANTHROPIC_BASE_URL"] = config.anthropicBaseUrl;
+  if (config.anthropicAuthToken)
+    sandboxVars["ANTHROPIC_AUTH_TOKEN"] = config.anthropicAuthToken;
   if (config.openaiApiKey) sandboxVars["OPENAI_API_KEY"] = config.openaiApiKey;
 
   if (Object.keys(sandboxVars).length > 0) {

--- a/backend/sandbox/init.sh
+++ b/backend/sandbox/init.sh
@@ -2,74 +2,43 @@
 set -euo pipefail
 
 WORKSPACE_DIR="/home/sandbox/workspace"
-
-log() {
-  echo "[sandbox-init] $*"
-}
+log() { echo "[sandbox-init] $*"; }
 
 # ──────────────────────────────────────────────
-# 1. Authenticate gh CLI with GH_TOKEN
+# 1. GitHub auth
 # ──────────────────────────────────────────────
 if [[ -n "${GH_TOKEN:-}" ]]; then
-  log "Configuring GitHub CLI authentication..."
-  echo "${GH_TOKEN}" | gh auth login --with-token
+  log "GitHub CLI auth..."
+  echo "${GH_TOKEN}" | gh auth login --with-token 2>/dev/null
   git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
-  log "GitHub CLI authenticated."
-else
-  log "WARNING: GH_TOKEN not set — skipping GitHub authentication."
 fi
 
 # ──────────────────────────────────────────────
-# 2. Clone target repository
+# 2. Clone repo
 # ──────────────────────────────────────────────
-if [[ -n "${SANDBOX_REPO_URL:-}" ]] && [[ -n "${GH_TOKEN:-}" ]]; then
-  log "Cloning repository: ${SANDBOX_REPO_URL}"
+WORK_DIR="${WORKSPACE_DIR}"
+if [[ -n "${SANDBOX_REPO_URL:-}" ]]; then
   REPO_NAME="$(basename "${SANDBOX_REPO_URL}" .git)"
   TARGET_DIR="${WORKSPACE_DIR}/${REPO_NAME}"
   if [[ -d "${TARGET_DIR}/.git" ]]; then
-    log "Already cloned, pulling latest..."
-    git -C "${TARGET_DIR}" pull --ff-only || log "WARNING: git pull failed."
+    git -C "${TARGET_DIR}" pull --ff-only 2>/dev/null || true
   else
-    git clone "${SANDBOX_REPO_URL}" "${TARGET_DIR}"
-    log "Cloned to ${TARGET_DIR}."
+    git clone "${SANDBOX_REPO_URL}" "${TARGET_DIR}" 2>/dev/null || log "Clone failed"
   fi
-  cd "${TARGET_DIR}"
-else
-  log "SANDBOX_REPO_URL or GH_TOKEN not set — starting in empty workspace."
-  cd "${WORKSPACE_DIR}"
+  [[ -d "${TARGET_DIR}" ]] && WORK_DIR="${TARGET_DIR}"
 fi
+cd "${WORK_DIR}"
+log "Working directory: ${WORK_DIR}"
 
 # ──────────────────────────────────────────────
-# 3. Write opencode.json (minimal valid config)
+# 3. Minimal opencode.json
 # ──────────────────────────────────────────────
-# OpenCode reads API keys from env vars automatically:
-#   ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY, GROQ_API_KEY
-# Schema: https://opencode.ai/config.json
-# Valid top-level: model, small_model, provider, agent, mcp, tools, server
-# INVALID: providers, agents, keybindings (will crash OpenCode)
-
-log "Writing opencode configuration..."
-
 DEFAULT_MODEL="anthropic/claude-sonnet-4-5"
 SMALL_MODEL="anthropic/claude-haiku-3-5"
-if [[ -z "${ANTHROPIC_API_KEY:-}" ]] && [[ -n "${OPENAI_API_KEY:-}" ]]; then
-  DEFAULT_MODEL="openai/gpt-4o"
-  SMALL_MODEL="openai/gpt-4o-mini"
-elif [[ -z "${ANTHROPIC_API_KEY:-}" ]] && [[ -z "${OPENAI_API_KEY:-}" ]] && [[ -n "${GEMINI_API_KEY:-}" ]]; then
-  DEFAULT_MODEL="google/gemini-2.5-flash"
-  SMALL_MODEL="google/gemini-2.5-flash"
-fi
+[[ -z "${ANTHROPIC_API_KEY:-}" ]] && [[ -n "${OPENAI_API_KEY:-}" ]] && DEFAULT_MODEL="openai/gpt-4o" && SMALL_MODEL="openai/gpt-4o-mini"
 
 MCP_BLOCK=""
-if [[ -n "${RAILWAY_API_TOKEN:-}" ]]; then
-  MCP_BLOCK='"mcp": {
-    "railway": {
-      "type": "local",
-      "command": ["npx", "-y", "@railway/mcp-server"],
-      "environment": {"RAILWAY_API_TOKEN": "'"${RAILWAY_API_TOKEN}"'"}
-    }
-  },'
-fi
+[[ -n "${RAILWAY_API_TOKEN:-}" ]] && MCP_BLOCK='"mcp":{"railway":{"type":"local","command":["npx","-y","@railway/mcp-server"],"environment":{"RAILWAY_API_TOKEN":"'"${RAILWAY_API_TOKEN}"'"}}},'
 
 cat > opencode.json <<ENDJSON
 {
@@ -77,25 +46,89 @@ cat > opencode.json <<ENDJSON
   "model": "${DEFAULT_MODEL}",
   "small_model": "${SMALL_MODEL}",
   ${MCP_BLOCK}
-  "server": {
-    "port": ${PORT:-8080},
-    "hostname": "0.0.0.0"
-  }
+  "server": {"port": ${PORT:-8080}, "hostname": "0.0.0.0"}
 }
 ENDJSON
-
 mkdir -p "${HOME}/.config/opencode"
 cp opencode.json "${HOME}/.config/opencode/opencode.json"
-log "opencode.json written."
 
 # ──────────────────────────────────────────────
-# 4. Start OpenCode web server
+# 4. Start OpenCode web (background for UI)
 # ──────────────────────────────────────────────
-log "Starting OpenCode web on 0.0.0.0:${PORT:-8080}..."
-
+log "Starting OpenCode web UI..."
 if command -v opencode &>/dev/null; then
-  exec opencode web --hostname 0.0.0.0 --port "${PORT:-8080}"
+  opencode web --hostname 0.0.0.0 --port "${PORT:-8080}" &
+  WEB_PID=$!
 else
-  log "ERROR: opencode not found. Falling back to code-server..."
-  exec code-server --bind-addr "0.0.0.0:${PORT:-8080}" --auth none --disable-telemetry .
+  code-server --bind-addr "0.0.0.0:${PORT:-8080}" --auth none . &
+  WEB_PID=$!
 fi
+
+# Wait for server ready
+for i in $(seq 1 30); do
+  curl -sf "http://localhost:${PORT:-8080}/global/health" >/dev/null 2>&1 && break
+  sleep 2
+done
+log "Web UI ready (PID ${WEB_PID})"
+
+# ──────────────────────────────────────────────
+# 5. Autonomous task via CLI (if TASK_PROMPT set)
+# ──────────────────────────────────────────────
+if [[ -n "${TASK_PROMPT:-}" ]] && command -v opencode &>/dev/null; then
+  log "═══════════════════════════════════════"
+  log "  AUTONOMOUS TASK MODE"
+  log "═══════════════════════════════════════"
+  log "Task: ${TASK_PROMPT:0:200}..."
+
+  # Build full prompt with project context
+  FULL_PROMPT="${TASK_PROMPT}"
+  [[ -f "SOUL.md" ]] && FULL_PROMPT="You are working in the T27 project. Read SOUL.md first — it is the constitutional law. Then: ${TASK_PROMPT}"
+  [[ -f "CLAUDE.md" ]] && FULL_PROMPT="${FULL_PROMPT}. Also follow CLAUDE.md conventions."
+  [[ -f "docs/AGENTS.md" ]] && FULL_PROMPT="${FULL_PROMPT}. Agent specs are in docs/AGENTS.md."
+
+  # Run autonomous task via opencode CLI (uses same server)
+  # --attach connects to the running web server
+  # --format json gives structured output
+  log "Launching task via CLI (attached to web server)..."
+  opencode run \
+    --attach "http://localhost:${PORT:-8080}" \
+    --model "${DEFAULT_MODEL}" \
+    --title "${TASK_TITLE:-autonomous-phi-loop}" \
+    --format json \
+    "${FULL_PROMPT}" \
+    > /tmp/task-output.json 2>&1 &
+  TASK_PID=$!
+  log "Task PID: ${TASK_PID}"
+  log "Watch progress: https://${RAILWAY_PUBLIC_DOMAIN:-localhost:${PORT:-8080}}"
+
+  # Log task output in background
+  (
+    wait "${TASK_PID}" 2>/dev/null
+    EXIT_CODE=$?
+    log "═══════════════════════════════════════"
+    log "  TASK COMPLETED (exit: ${EXIT_CODE})"
+    log "═══════════════════════════════════════"
+    if [[ -f /tmp/task-output.json ]]; then
+      log "Output saved to /tmp/task-output.json"
+      python3 -c "
+import json
+try:
+    with open('/tmp/task-output.json') as f:
+        for line in f:
+            line = line.strip()
+            if not line: continue
+            try:
+                d = json.loads(line)
+                if d.get('type') == 'text':
+                    print(f'[RESULT] {d.get(\"text\",\"\")[:500]}')
+            except: pass
+except: pass
+" 2>/dev/null
+    fi
+  ) &
+fi
+
+# ──────────────────────────────────────────────
+# 6. Keep alive
+# ──────────────────────────────────────────────
+wait "${WEB_PID}"


### PR DESCRIPTION
Closes #84

## What this does

When you create a sandbox with `taskDescription`, the container:

1. Starts OpenCode web UI (background) — **you watch progress in browser**
2. Clones the repo
3. Auto-reads SOUL.md, CLAUDE.md, AGENTS.md
4. Launches the task via `opencode run --attach` (shares session with web UI)
5. You observe the agent working in real-time at the sandbox URL

## Environment variables
- `TASK_PROMPT` — the task to execute autonomously
- `ANTHROPIC_BASE_URL` — Z.AI endpoint (`https://api.z.ai/api/anthropic`)
- `ANTHROPIC_AUTH_TOKEN` — Z.AI auth token

## Example
```bash
POST /sessions
{
  "name": "phi-loop-run-1",
  "taskDescription": "Run PHI LOOP: edit specs/sandbox/sandbox.tri, gen, test, verdict --toxic",
  "repoUrl": "https://github.com/gHashTag/t27.git"
}
```
Opens `https://phi-loop-run-1.railway.app` → agent works autonomously, you observe.