### PR TITLE
feat(agent): Rust agent runner + Python fallback [SANDBOX-009]

### DIFF
--- a/.github/workflows/agent-runner-docker.yml
+++ b/.github/workflows/agent-runner-docker.yml
@@ -1,0 +1,46 @@
+name: Build Agent Runner
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'backend/agent-runner/**'
+      - '.github/workflows/agent-runner-docker.yml'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set image name
+        run: echo "IMAGE_NAME=${{ env.REGISTRY }}/$(echo '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')/t27-agent-runner" >> $GITHUB_ENV
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: backend/agent-runner
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/backend/agent-runner/Cargo.toml
+++ b/backend/agent-runner/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "t27-agent-runner"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+reqwest = { version = "0.12", features = ["json", "stream"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+chrono = { version = "0.4", features = ["serde"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
+uuid = { version = "1", features = ["v4"] }
+anyhow = "1"
+clap = { version = "4", features = ["derive"] }

--- a/backend/agent-runner/Dockerfile
+++ b/backend/agent-runner/Dockerfile
@@ -1,0 +1,56 @@
+# ── Stage 1: Builder ──────────────────────────────────────────────────────────
+FROM rust:1.82-bookworm AS builder
+
+WORKDIR /app
+
+# Cache dependencies first (empty main trick for layer caching)
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir src && echo 'fn main(){}' > src/main.rs && \
+    cargo build --release && \
+    rm -rf src
+
+# Build the real binary
+COPY src ./src
+RUN touch src/main.rs && cargo build --release
+
+# ── Stage 2: Runtime ──────────────────────────────────────────────────────────
+FROM debian:bookworm-slim
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    git \
+    gh \
+    python3 \
+    python3-pip \
+    openssh-client \
+    bash \
+    && rm -rf /var/lib/apt/lists/*
+
+# Configure git identity for commits
+RUN git config --global user.name "T27 Agent" && \
+    git config --global user.email "t27-agent@users.noreply.github.com" && \
+    git config --global init.defaultBranch main && \
+    git config --global advice.detachedHead false
+
+# Copy compiled binary
+COPY --from=builder /app/target/release/t27-agent-runner /usr/local/bin/t27-agent-runner
+RUN chmod +x /usr/local/bin/t27-agent-runner
+
+# Install OpenCode for web UI observation (best-effort, non-fatal)
+RUN curl -fsSL https://opencode.ai/install | bash || echo "opencode install skipped"
+
+# Add opencode to PATH if installed
+ENV PATH="/root/.opencode/bin:/root/.local/bin:${PATH}"
+
+# Create workspace directory
+RUN mkdir -p /workspace /tmp
+
+# Set working directory
+WORKDIR /workspace
+
+# Expose port for OpenCode web UI
+EXPOSE 8080
+
+ENTRYPOINT ["t27-agent-runner"]

--- a/backend/agent-runner/src/agent.rs
+++ b/backend/agent-runner/src/agent.rs
@@ -1,0 +1,334 @@
+use anyhow::{Context, Result};
+use std::time::Instant;
+
+use crate::api::{AnthropicClient, ContentBlock, Message, MessageContent};
+use crate::config::Config;
+use crate::logger;
+use crate::tools;
+
+// ─── Agent Report ─────────────────────────────────────────────────────────────
+
+pub struct AgentReport {
+    pub turns: u32,
+    pub total_input_tokens: u64,
+    pub total_output_tokens: u64,
+    pub tools_called: Vec<String>,
+    pub files_modified: Vec<String>,
+    pub task_completed: bool,
+    pub summary: String,
+    pub duration_seconds: f64,
+}
+
+// ─── System Prompt Builder ────────────────────────────────────────────────────
+
+async fn build_system_prompt(config: &Config) -> String {
+    let mut parts = Vec::new();
+
+    // Try to load SOUL.md from cwd or /workspace
+    let soul_paths = [
+        "SOUL.md",
+        "/workspace/SOUL.md",
+        "./SOUL.md",
+    ];
+
+    for soul_path in &soul_paths {
+        if let Ok(soul_content) = tokio::fs::read_to_string(soul_path).await {
+            logger::log_info(&format!("Loaded SOUL.md from {} ({} chars)", soul_path, soul_content.len()));
+            parts.push(format!(
+                "# Project Constitution (SOUL.md)\n\n{}",
+                soul_content
+            ));
+            break;
+        }
+    }
+
+    // Core system prompt
+    parts.push(format!(
+        r#"# T27 Agent Runner
+
+You are an autonomous software engineering agent. You have been given a task to complete.
+
+## Your Capabilities
+
+You have access to the following tools:
+- `bash` — Execute shell commands (git, npm, cargo, python, etc.)
+- `read_file` — Read file contents
+- `write_file` — Write or overwrite files
+- `task_complete` — Signal task completion with a summary
+
+## Working Guidelines
+
+1. **Be systematic**: Start by understanding the codebase structure before making changes
+2. **Verify your work**: After making changes, run tests or checks to verify correctness
+3. **Log your reasoning**: Explain what you're doing and why before each action
+4. **Handle errors gracefully**: If a command fails, read the error and adapt
+5. **Complete the full task**: Don't stop until the task is truly done
+
+## Current Task
+
+{}
+
+## Important Notes
+
+- You are running in an autonomous environment — there is no human to ask for help
+- Make your best judgment and proceed confidently
+- Use `task_complete` when you have finished ALL aspects of the task
+- Commit your changes using git if appropriate
+"#,
+        config.task_prompt
+    ));
+
+    parts.join("\n\n---\n\n")
+}
+
+// ─── Main Agent Loop ──────────────────────────────────────────────────────────
+
+pub async fn run_agent(config: &Config) -> Result<AgentReport> {
+    let agent_start = Instant::now();
+
+    logger::log_banner("T27 AUTONOMOUS AGENT STARTING");
+
+    // Build system prompt
+    let system_prompt = build_system_prompt(config).await;
+    logger::log_info(&format!("System prompt: {} chars", system_prompt.len()));
+
+    // Initialize API client
+    let client = AnthropicClient::new(config)
+        .context("Failed to create API client")?;
+
+    // Tool definitions
+    let tool_defs = tools::tool_definitions();
+
+    // Message history
+    let mut messages: Vec<Message> = Vec::new();
+
+    // Add the initial user message
+    messages.push(Message {
+        role: "user".to_string(),
+        content: MessageContent::Text(format!(
+            "Please complete the following task:\n\n{}",
+            config.task_prompt
+        )),
+    });
+
+    // Report tracking
+    let mut total_input_tokens: u64 = 0;
+    let mut total_output_tokens: u64 = 0;
+    let mut tools_called: Vec<String> = Vec::new();
+    let mut files_modified: Vec<String> = Vec::new();
+    let mut task_completed = false;
+    let mut completion_summary = String::new();
+    let mut turns_completed = 0u32;
+
+    // ── Turn loop ──────────────────────────────────────────────────────────────
+
+    for turn in 1..=config.max_turns {
+        turns_completed = turn;
+
+        logger::log_turn_start(
+            turn,
+            config.max_turns,
+            messages.len(),
+            total_input_tokens + total_output_tokens,
+        );
+
+        logger::log_api_request(
+            &config.model,
+            system_prompt.len(),
+            messages.len(),
+        );
+
+        // Call the API
+        let (response, duration_ms) = client
+            .send_message(config, &system_prompt, &messages, tool_defs.clone())
+            .await
+            .with_context(|| format!("API call failed on turn {}", turn))?;
+
+        // Update token counts
+        total_input_tokens += response.usage.input_tokens as u64;
+        total_output_tokens += response.usage.output_tokens as u64;
+
+        logger::log_api_response(&response, duration_ms);
+
+        let stop_reason = response.stop_reason.clone().unwrap_or_default();
+
+        // Process content blocks — collect assistant message content
+        let mut assistant_blocks: Vec<ContentBlock> = Vec::new();
+        let mut tool_use_blocks: Vec<(String, String, serde_json::Value)> = Vec::new(); // (id, name, input)
+
+        for block in &response.content {
+            match block {
+                ContentBlock::Text { text } => {
+                    logger::log_text_block(text);
+                    assistant_blocks.push(block.clone());
+                }
+                ContentBlock::Thinking { thinking } => {
+                    logger::log_thinking_block(thinking);
+                    assistant_blocks.push(block.clone());
+                }
+                ContentBlock::ToolUse { id, name, input } => {
+                    // Summarize input for logging
+                    let input_summary = summarize_tool_input(name, input);
+                    logger::log_tool_call(name, &input_summary);
+
+                    assistant_blocks.push(block.clone());
+                    tool_use_blocks.push((id.clone(), name.clone(), input.clone()));
+                }
+                ContentBlock::ToolResult { .. } => {
+                    // Unexpected in assistant response, but handle gracefully
+                    assistant_blocks.push(block.clone());
+                }
+            }
+        }
+
+        // Add assistant message to history
+        messages.push(Message {
+            role: "assistant".to_string(),
+            content: MessageContent::Blocks(assistant_blocks),
+        });
+
+        // ── Execute tools if stop_reason == "tool_use" ─────────────────────────
+
+        if stop_reason == "tool_use" && !tool_use_blocks.is_empty() {
+            let mut tool_result_blocks: Vec<ContentBlock> = Vec::new();
+
+            for (tool_id, tool_name, tool_input) in &tool_use_blocks {
+                tools_called.push(tool_name.clone());
+
+                // Track file modifications
+                if tool_name == "write_file" {
+                    if let Some(path) = tool_input["path"].as_str() {
+                        files_modified.push(path.to_string());
+                    }
+                }
+
+                // Execute the tool
+                let result = tools::execute_tool(tool_name, tool_input).await;
+
+                logger::log_tool_result(
+                    tool_name,
+                    &result.output,
+                    result.duration_ms,
+                    result.success,
+                );
+
+                tool_result_blocks.push(ContentBlock::ToolResult {
+                    tool_use_id: tool_id.clone(),
+                    content: result.output.clone(),
+                });
+
+                // Check for task completion
+                if result.is_complete {
+                    task_completed = true;
+                    completion_summary = result.output.clone();
+                    // Extract summary from task_complete output
+                    if let Some(stripped) = result.output.strip_prefix("TASK COMPLETE\n\n") {
+                        completion_summary = stripped.to_string();
+                    }
+                }
+            }
+
+            // Add tool results to history as user message
+            messages.push(Message {
+                role: "user".to_string(),
+                content: MessageContent::Blocks(tool_result_blocks),
+            });
+
+            // If task was completed via task_complete tool, break
+            if task_completed {
+                logger::log_info("Task completed via task_complete tool");
+                break;
+            }
+
+            // Continue loop for next turn
+            continue;
+        }
+
+        // ── end_turn or no tools — agent is done ──────────────────────────────
+
+        if stop_reason == "end_turn" || stop_reason.is_empty() {
+            // Extract final text as summary
+            for block in &response.content {
+                if let ContentBlock::Text { text } = block {
+                    completion_summary = text.clone();
+                    break;
+                }
+            }
+            logger::log_info(&format!("Agent ended turn naturally (stop_reason={})", stop_reason));
+            break;
+        }
+
+        // If we hit max_tokens stop reason, add a continuation message
+        if stop_reason == "max_tokens" {
+            logger::log_info("Max tokens reached, asking agent to continue");
+            messages.push(Message {
+                role: "user".to_string(),
+                content: MessageContent::Text(
+                    "Please continue where you left off. You ran out of tokens.".to_string(),
+                ),
+            });
+            continue;
+        }
+
+        // Any other stop reason: log and break
+        logger::log_info(&format!("Unexpected stop_reason: '{}', ending loop", stop_reason));
+        break;
+    }
+
+    let duration_seconds = agent_start.elapsed().as_secs_f64();
+
+    let report = AgentReport {
+        turns: turns_completed,
+        total_input_tokens,
+        total_output_tokens,
+        tools_called,
+        files_modified,
+        task_completed,
+        summary: completion_summary,
+        duration_seconds,
+    };
+
+    logger::log_agent_complete(&report);
+
+    Ok(report)
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+fn summarize_tool_input(name: &str, input: &serde_json::Value) -> String {
+    match name {
+        "bash" => {
+            let cmd = input["command"].as_str().unwrap_or("");
+            format!("command: {:?}", truncate_str(cmd, 200))
+        }
+        "read_file" => {
+            let path = input["path"].as_str().unwrap_or("");
+            format!("path: {:?}", path)
+        }
+        "write_file" => {
+            let path = input["path"].as_str().unwrap_or("");
+            let content = input["content"].as_str().unwrap_or("");
+            format!("path: {:?}\ncontent: {} chars", path, content.len())
+        }
+        "task_complete" => {
+            let summary = input["summary"].as_str().unwrap_or("");
+            format!("summary: {:?}", truncate_str(summary, 200))
+        }
+        _ => {
+            serde_json::to_string_pretty(input)
+                .unwrap_or_else(|_| input.to_string())
+        }
+    }
+}
+
+fn truncate_str(s: &str, max: usize) -> &str {
+    if s.len() <= max {
+        s
+    } else {
+        let end = s.char_indices()
+            .nth(max)
+            .map(|(i, _)| i)
+            .unwrap_or(s.len());
+        &s[..end]
+    }
+}

--- a/backend/agent-runner/src/api.rs
+++ b/backend/agent-runner/src/api.rs
@@ -1,0 +1,239 @@
+use anyhow::{anyhow, Context, Result};
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::time::{Duration, Instant};
+use tokio::time::sleep;
+use tracing::{debug, warn};
+
+use crate::config::Config;
+use crate::logger;
+
+// ─── Data Structures ────────────────────────────────────────────────────────
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Message {
+    pub role: String,
+    pub content: MessageContent,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum MessageContent {
+    Text(String),
+    Blocks(Vec<ContentBlock>),
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(tag = "type")]
+pub enum ContentBlock {
+    #[serde(rename = "text")]
+    Text { text: String },
+    #[serde(rename = "tool_use")]
+    ToolUse {
+        id: String,
+        name: String,
+        input: Value,
+    },
+    #[serde(rename = "tool_result")]
+    ToolResult {
+        tool_use_id: String,
+        content: String,
+    },
+    #[serde(rename = "thinking")]
+    Thinking { thinking: String },
+}
+
+impl ContentBlock {
+    pub fn type_name(&self) -> &'static str {
+        match self {
+            ContentBlock::Text { .. } => "text",
+            ContentBlock::ToolUse { .. } => "tool_use",
+            ContentBlock::ToolResult { .. } => "tool_result",
+            ContentBlock::Thinking { .. } => "thinking",
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ApiResponse {
+    pub id: String,
+    pub model: String,
+    pub content: Vec<ContentBlock>,
+    pub stop_reason: Option<String>,
+    pub usage: Usage,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Usage {
+    pub input_tokens: u32,
+    pub output_tokens: u32,
+}
+
+// ─── Request Builder ─────────────────────────────────────────────────────────
+
+#[derive(Serialize, Debug)]
+struct ApiRequest<'a> {
+    model: &'a str,
+    max_tokens: u32,
+    system: &'a str,
+    messages: &'a Vec<Message>,
+    tools: Vec<Value>,
+    stream: bool,
+}
+
+// ─── Client ──────────────────────────────────────────────────────────────────
+
+pub struct AnthropicClient {
+    client: Client,
+    api_key: String,
+    base_url: String,
+}
+
+impl AnthropicClient {
+    pub fn new(config: &Config) -> Result<Self> {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(300))
+            .build()
+            .context("Failed to build HTTP client")?;
+
+        Ok(AnthropicClient {
+            client,
+            api_key: config.anthropic_api_key.clone(),
+            base_url: config.anthropic_base_url.trim_end_matches('/').to_string(),
+        })
+    }
+
+    pub async fn send_message(
+        &self,
+        config: &Config,
+        system: &str,
+        messages: &Vec<Message>,
+        tools: Vec<Value>,
+    ) -> Result<(ApiResponse, u64)> {
+        let url = format!("{}/v1/messages", self.base_url);
+
+        let request_body = ApiRequest {
+            model: &config.model,
+            max_tokens: config.max_tokens,
+            system,
+            messages,
+            tools,
+            stream: false,
+        };
+
+        // Log the outgoing request (without API key)
+        let body_value = serde_json::to_value(&request_body)
+            .context("Failed to serialize request")?;
+
+        debug!(
+            request = %serde_json::to_string_pretty(&body_value).unwrap_or_default(),
+            "Sending API request"
+        );
+
+        if config.verbose {
+            logger::log_info(&format!(
+                "API request: model={}, messages={}, tools={}",
+                config.model,
+                messages.len(),
+                request_body.tools.len()
+            ));
+        }
+
+        let max_retries = 3u32;
+        let mut attempt = 0u32;
+
+        loop {
+            let start = Instant::now();
+            let result = self
+                .client
+                .post(&url)
+                .header("x-api-key", &self.api_key)
+                .header("anthropic-version", "2023-06-01")
+                .header("content-type", "application/json")
+                .json(&body_value)
+                .send()
+                .await;
+
+            match result {
+                Err(e) => {
+                    let elapsed = start.elapsed().as_millis() as u64;
+                    if attempt < max_retries {
+                        let backoff = backoff_secs(attempt);
+                        warn!(
+                            attempt = attempt,
+                            error = %e,
+                            backoff_s = backoff,
+                            "Request failed, retrying"
+                        );
+                        logger::log_error(
+                            "API request",
+                            &format!("Network error (attempt {}/{}), retry in {}s: {}", attempt + 1, max_retries + 1, backoff, e),
+                        );
+                        sleep(Duration::from_secs(backoff)).await;
+                        attempt += 1;
+                        continue;
+                    }
+                    return Err(anyhow!("Request failed after {} attempts: {} ({}ms)", max_retries + 1, e, elapsed));
+                }
+                Ok(response) => {
+                    let status = response.status();
+                    let elapsed = start.elapsed().as_millis() as u64;
+
+                    // Retry on transient server errors
+                    if status == 429 || status == 500 || status == 502 || status == 503 {
+                        if attempt < max_retries {
+                            let backoff = backoff_secs(attempt);
+                            let body_text = response.text().await.unwrap_or_default();
+                            warn!(
+                                status = %status,
+                                attempt = attempt,
+                                backoff_s = backoff,
+                                body = %body_text,
+                                "Retryable status, backing off"
+                            );
+                            logger::log_error(
+                                "API status",
+                                &format!("HTTP {} (attempt {}/{}), retry in {}s: {}", status, attempt + 1, max_retries + 1, backoff, body_text),
+                            );
+                            sleep(Duration::from_secs(backoff)).await;
+                            attempt += 1;
+                            continue;
+                        }
+                    }
+
+                    if !status.is_success() {
+                        let body_text = response.text().await.unwrap_or_default();
+                        return Err(anyhow!(
+                            "API error: HTTP {} — {}",
+                            status,
+                            body_text
+                        ));
+                    }
+
+                    // Parse response
+                    let body_text = response
+                        .text()
+                        .await
+                        .context("Failed to read response body")?;
+
+                    debug!(
+                        response = %body_text,
+                        "Received API response"
+                    );
+
+                    let api_response: ApiResponse = serde_json::from_str(&body_text)
+                        .with_context(|| format!("Failed to parse API response: {}", &body_text[..body_text.len().min(500)]))?;
+
+                    return Ok((api_response, elapsed));
+                }
+            }
+        }
+    }
+}
+
+fn backoff_secs(attempt: u32) -> u64 {
+    // 1s, 2s, 4s, 8s (capped)
+    let secs = 1u64 << attempt.min(3);
+    secs
+}

--- a/backend/agent-runner/src/config.rs
+++ b/backend/agent-runner/src/config.rs
@@ -1,0 +1,160 @@
+use anyhow::{Context, Result};
+use std::env;
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub anthropic_api_key: String,
+    pub anthropic_base_url: String,
+    pub model: String,
+    pub task_prompt: String,
+    pub task_title: Option<String>,
+    pub max_turns: u32,
+    pub max_tokens: u32,
+    pub sandbox_repo_url: Option<String>,
+    pub gh_token: Option<String>,
+    pub port: u16,
+    pub log_file: String,
+    pub verbose: bool,
+}
+
+impl Config {
+    pub fn from_env() -> Result<Self> {
+        // Support both ANTHROPIC_API_KEY and ANTHROPIC_AUTH_TOKEN
+        let anthropic_api_key = env::var("ANTHROPIC_API_KEY")
+            .or_else(|_| env::var("ANTHROPIC_AUTH_TOKEN"))
+            .context("ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN must be set")?;
+
+        let anthropic_base_url = env::var("ANTHROPIC_BASE_URL")
+            .unwrap_or_else(|_| "https://api.z.ai/api/anthropic".to_string());
+
+        let model = env::var("MODEL")
+            .unwrap_or_else(|_| "claude-sonnet-4-5-20250514".to_string());
+
+        let task_prompt = env::var("TASK_PROMPT")
+            .context("TASK_PROMPT must be set")?;
+
+        let task_title = env::var("TASK_TITLE").ok();
+
+        let max_turns = env::var("MAX_TURNS")
+            .unwrap_or_else(|_| "50".to_string())
+            .parse::<u32>()
+            .context("MAX_TURNS must be a valid integer")?;
+
+        let max_tokens = env::var("MAX_TOKENS")
+            .unwrap_or_else(|_| "8192".to_string())
+            .parse::<u32>()
+            .context("MAX_TOKENS must be a valid integer")?;
+
+        let sandbox_repo_url = env::var("SANDBOX_REPO_URL").ok();
+        let gh_token = env::var("GH_TOKEN").ok();
+
+        let port = env::var("PORT")
+            .unwrap_or_else(|_| "8080".to_string())
+            .parse::<u16>()
+            .context("PORT must be a valid port number")?;
+
+        let log_file = env::var("LOG_FILE")
+            .unwrap_or_else(|_| "/tmp/agent-log.jsonl".to_string());
+
+        let verbose = env::var("VERBOSE")
+            .unwrap_or_else(|_| "true".to_string())
+            .to_lowercase()
+            != "false";
+
+        Ok(Config {
+            anthropic_api_key,
+            anthropic_base_url,
+            model,
+            task_prompt,
+            task_title,
+            max_turns,
+            max_tokens,
+            sandbox_repo_url,
+            gh_token,
+            port,
+            log_file,
+            verbose,
+        })
+    }
+
+    pub fn log_startup(&self) {
+        println!("╔══════════════════════════════════════════════════════════════╗");
+        println!("║              T27 AGENT RUNNER — CONFIGURATION                ║");
+        println!("╠══════════════════════════════════════════════════════════════╣");
+        println!("║  ANTHROPIC_API_KEY:   {}  ║", mask_secret(&self.anthropic_api_key));
+        println!("║  ANTHROPIC_BASE_URL:  {:<38} ║", truncate(&self.anthropic_base_url, 38));
+        println!("║  MODEL:               {:<38} ║", truncate(&self.model, 38));
+        println!("║  MAX_TURNS:           {:<38} ║", self.max_turns);
+        println!("║  MAX_TOKENS:          {:<38} ║", self.max_tokens);
+        println!("║  PORT:                {:<38} ║", self.port);
+        println!("║  LOG_FILE:            {:<38} ║", truncate(&self.log_file, 38));
+        println!("║  VERBOSE:             {:<38} ║", self.verbose);
+
+        if let Some(ref title) = self.task_title {
+            println!("║  TASK_TITLE:          {:<38} ║", truncate(title, 38));
+        }
+
+        if let Some(ref repo) = self.sandbox_repo_url {
+            println!("║  SANDBOX_REPO_URL:    {:<38} ║", truncate(repo, 38));
+        }
+
+        if self.gh_token.is_some() {
+            println!("║  GH_TOKEN:            {:<38} ║", "[SET]");
+        } else {
+            println!("║  GH_TOKEN:            {:<38} ║", "[NOT SET]");
+        }
+
+        println!("╠══════════════════════════════════════════════════════════════╣");
+        println!("║  TASK_PROMPT ({} chars):                              ║", self.task_prompt.len());
+
+        // Print task prompt with wrapping
+        for line in wrap_text(&self.task_prompt, 58) {
+            println!("║    {:<58} ║", line);
+        }
+
+        println!("╚══════════════════════════════════════════════════════════════╝");
+        println!();
+    }
+}
+
+fn mask_secret(s: &str) -> String {
+    if s.len() <= 8 {
+        return "****".to_string();
+    }
+    let prefix = &s[..4];
+    let suffix = &s[s.len() - 4..];
+    format!("{:<38}", format!("{}...{}", prefix, suffix))
+}
+
+fn truncate(s: &str, max_len: usize) -> String {
+    if s.len() <= max_len {
+        s.to_string()
+    } else {
+        format!("{}...", &s[..max_len.saturating_sub(3)])
+    }
+}
+
+fn wrap_text(text: &str, width: usize) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut current = String::new();
+    for word in text.split_whitespace() {
+        if current.is_empty() {
+            current = word.to_string();
+        } else if current.len() + 1 + word.len() <= width {
+            current.push(' ');
+            current.push_str(word);
+        } else {
+            lines.push(current.clone());
+            current = word.to_string();
+        }
+        if lines.len() >= 10 {
+            // Truncate very long prompts in display
+            current.push_str(" ...");
+            break;
+        }
+    }
+    if !current.is_empty() {
+        lines.push(current);
+    }
+    lines
+}

--- a/backend/agent-runner/src/logger.rs
+++ b/backend/agent-runner/src/logger.rs
@@ -1,0 +1,366 @@
+use crate::agent::AgentReport;
+use crate::api::ApiResponse;
+use chrono::Utc;
+use serde_json::{json, Value};
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::sync::OnceLock;
+
+static LOG_FILE: OnceLock<String> = OnceLock::new();
+
+pub fn init_log_file(path: &str) {
+    LOG_FILE.set(path.to_string()).ok();
+}
+
+fn write_jsonl(event: &Value) {
+    let path = LOG_FILE.get().map(|s| s.as_str()).unwrap_or("/tmp/agent-log.jsonl");
+    if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) {
+        let _ = writeln!(file, "{}", event);
+    }
+}
+
+fn jsonl_event(event_type: &str, data: Value) -> Value {
+    json!({
+        "ts": Utc::now().to_rfc3339(),
+        "event": event_type,
+        "data": data,
+    })
+}
+
+pub fn log_banner(text: &str) {
+    let width = 62;
+    let inner = format!("  {}  ", text);
+    let pad = if width > inner.len() { width - inner.len() } else { 0 };
+    let left = pad / 2;
+    let right = pad - left;
+    let line = "═".repeat(width);
+    println!();
+    println!("╔{}╗", line);
+    println!("║{}{}{}║", " ".repeat(left), inner, " ".repeat(right));
+    println!("╚{}╝", line);
+    println!();
+
+    write_jsonl(&jsonl_event("banner", json!({ "text": text })));
+}
+
+pub fn log_turn_start(turn: u32, max_turns: u32, msg_count: usize, total_tokens: u64) {
+    println!("╔══════════════════════════════════════════════════════════════╗");
+    println!("║  TURN {}/{:<51} ║", turn, max_turns);
+    println!("║  Messages: {}  |  Total tokens: {:<27} ║",
+        msg_count,
+        format_number(total_tokens)
+    );
+    println!("╠══════════════════════════════════════════════════════════════╣");
+
+    write_jsonl(&jsonl_event("turn_start", json!({
+        "turn": turn,
+        "max_turns": max_turns,
+        "message_count": msg_count,
+        "total_tokens": total_tokens,
+    })));
+}
+
+pub fn log_api_request(model: &str, system_len: usize, messages_count: usize) {
+    println!("║  Sending request...                                          ║");
+    println!("║  Model: {:<52} ║", truncate(model, 52));
+    println!("║  System prompt: {:<44} ║", format!("{} chars", system_len));
+    println!("║  User messages: {:<44} ║", messages_count);
+    println!("╠══════════════════════════════════════════════════════════════╣");
+
+    write_jsonl(&jsonl_event("api_request", json!({
+        "model": model,
+        "system_len": system_len,
+        "messages_count": messages_count,
+    })));
+}
+
+pub fn log_api_response(response: &ApiResponse, duration_ms: u64) {
+    let duration_s = duration_ms as f64 / 1000.0;
+    let text_blocks = response.content.iter().filter(|b| matches!(b, crate::api::ContentBlock::Text { .. })).count();
+    let tool_blocks = response.content.iter().filter(|b| matches!(b, crate::api::ContentBlock::ToolUse { .. })).count();
+    let thinking_blocks = response.content.iter().filter(|b| matches!(b, crate::api::ContentBlock::Thinking { .. })).count();
+
+    let mut block_desc = format!("{} total", response.content.len());
+    let mut parts = Vec::new();
+    if text_blocks > 0 { parts.push(format!("{} text", text_blocks)); }
+    if tool_blocks > 0 { parts.push(format!("{} tool_use", tool_blocks)); }
+    if thinking_blocks > 0 { parts.push(format!("{} thinking", thinking_blocks)); }
+    if !parts.is_empty() {
+        block_desc = format!("{} ({})", response.content.len(), parts.join(", "));
+    }
+
+    println!("║  Response received in {:.1}s{:<37} ║", duration_s, "");
+    println!("║  Model returned: {:<43} ║", truncate(&response.model, 43));
+    println!("║  Tokens: input={} output={:<32} ║",
+        format_number(response.usage.input_tokens as u64),
+        format_number(response.usage.output_tokens as u64)
+    );
+    println!("║  Stop reason: {:<46} ║",
+        response.stop_reason.as_deref().unwrap_or("none")
+    );
+    println!("║  Content blocks: {:<43} ║", truncate(&block_desc, 43));
+    println!("╠══════════════════════════════════════════════════════════════╣");
+
+    write_jsonl(&jsonl_event("api_response", json!({
+        "id": response.id,
+        "model": response.model,
+        "stop_reason": response.stop_reason,
+        "input_tokens": response.usage.input_tokens,
+        "output_tokens": response.usage.output_tokens,
+        "content_blocks": response.content.len(),
+        "text_blocks": text_blocks,
+        "tool_blocks": tool_blocks,
+        "duration_ms": duration_ms,
+    })));
+}
+
+pub fn log_text_block(text: &str) {
+    println!("║  TEXT:                                                       ║");
+    for line in text.lines().take(20) {
+        let chunks = chunk_text(line, 56);
+        for chunk in &chunks {
+            println!("║    {:<58} ║", chunk);
+        }
+    }
+    if text.lines().count() > 20 {
+        println!("║    ... [{} more lines]                                       ║",
+            text.lines().count() - 20);
+    }
+    println!("╠══════════════════════════════════════════════════════════════╣");
+
+    write_jsonl(&jsonl_event("text_block", json!({ "text": text })));
+}
+
+pub fn log_thinking_block(text: &str) {
+    println!("║  THINKING:                                                   ║");
+    let preview: String = text.chars().take(200).collect();
+    for line in preview.lines().take(5) {
+        println!("║    {:<58} ║", truncate(line, 58));
+    }
+    if text.len() > 200 {
+        println!("║    ... [{} chars total]                                      ║", text.len());
+    }
+    println!("╠══════════════════════════════════════════════════════════════╣");
+
+    write_jsonl(&jsonl_event("thinking_block", json!({ "text_preview": &text[..text.len().min(500)] })));
+}
+
+pub fn log_tool_call(name: &str, input_summary: &str) {
+    println!("║  TOOL CALL: {:<49} ║", name);
+    for line in input_summary.lines().take(10) {
+        println!("║    {:<58} ║", truncate(line, 58));
+    }
+
+    write_jsonl(&jsonl_event("tool_call", json!({
+        "tool": name,
+        "input_summary": input_summary,
+    })));
+}
+
+pub fn log_tool_result(name: &str, output_summary: &str, duration_ms: u64, success: bool) {
+    println!("║  TOOL RESULT: {} ({}ms){:<35} ║",
+        name,
+        duration_ms,
+        ""
+    );
+    for line in output_summary.lines().take(15) {
+        println!("║    {:<58} ║", truncate(line, 58));
+    }
+    let total_lines = output_summary.lines().count();
+    if total_lines > 15 {
+        println!("║    ... [{} more lines]                                       ║",
+            total_lines - 15);
+    }
+    println!("╚══════════════════════════════════════════════════════════════╝");
+    println!();
+
+    write_jsonl(&jsonl_event("tool_result", json!({
+        "tool": name,
+        "output_summary": &output_summary[..output_summary.len().min(2000)],
+        "duration_ms": duration_ms,
+        "success": success,
+    })));
+}
+
+pub fn log_tool_section(name: &str, command: &str, exit_code: Option<i32>, stdout: &str, stderr: &str, duration_ms: u64) {
+    println!("[TOOL:{}] ─────────────────────────────────────────────────────", name);
+    if !command.is_empty() {
+        println!("  Command: {}", command);
+    }
+    if let Some(code) = exit_code {
+        println!("  Exit code: {}", code);
+    }
+    let stdout_bytes = stdout.len();
+    if stdout_bytes > 0 {
+        println!("  Stdout ({} bytes):", stdout_bytes);
+        for line in stdout.lines().take(50) {
+            println!("    {}", line);
+        }
+        if stdout.lines().count() > 50 {
+            println!("    ... [{} more lines]", stdout.lines().count() - 50);
+        }
+    }
+    let stderr_bytes = stderr.len();
+    if stderr_bytes > 0 {
+        println!("  Stderr ({} bytes):", stderr_bytes);
+        for line in stderr.lines().take(20) {
+            println!("    {}", line);
+        }
+    }
+    println!("  Duration: {}ms", duration_ms);
+    println!("────────────────────────────────────────────────────────────────");
+    println!();
+
+    write_jsonl(&jsonl_event("tool_exec", json!({
+        "tool": name,
+        "command": command,
+        "exit_code": exit_code,
+        "stdout_bytes": stdout_bytes,
+        "stderr_bytes": stderr_bytes,
+        "stdout_preview": &stdout[..stdout.len().min(2000)],
+        "stderr_preview": &stderr[..stderr.len().min(500)],
+        "duration_ms": duration_ms,
+    })));
+}
+
+pub fn log_agent_complete(report: &AgentReport) {
+    println!();
+    println!("╔══════════════════════════════════════════════════════════════╗");
+    println!("║                    AGENT RUN COMPLETE                        ║");
+    println!("╠══════════════════════════════════════════════════════════════╣");
+    println!("║  Status:        {:<44} ║",
+        if report.task_completed { "TASK COMPLETED ✓" } else { "MAX TURNS REACHED" }
+    );
+    println!("║  Total turns:   {:<44} ║", report.turns);
+    println!("║  Duration:      {:<44} ║", format!("{:.1}s", report.duration_seconds));
+    println!("║  Input tokens:  {:<44} ║", format_number(report.total_input_tokens));
+    println!("║  Output tokens: {:<44} ║", format_number(report.total_output_tokens));
+    println!("║  Tools called:  {:<44} ║", report.tools_called.len());
+    println!("║  Files modified:{:<44} ║", report.files_modified.len());
+    println!("╠══════════════════════════════════════════════════════════════╣");
+    if !report.summary.is_empty() {
+        println!("║  Summary:                                                    ║");
+        for line in wrap_text(&report.summary, 58).iter().take(10) {
+            println!("║    {:<58} ║", line);
+        }
+        println!("╠══════════════════════════════════════════════════════════════╣");
+    }
+    if !report.files_modified.is_empty() {
+        println!("║  Files modified:                                             ║");
+        for f in &report.files_modified {
+            println!("║    {:<58} ║", truncate(f, 58));
+        }
+        println!("╠══════════════════════════════════════════════════════════════╣");
+    }
+    if !report.tools_called.is_empty() {
+        let tool_summary = count_tools(&report.tools_called);
+        println!("║  Tool usage:                                                 ║");
+        for (tool, count) in &tool_summary {
+            println!("║    {}: {:<54} ║", tool, count);
+        }
+        println!("╠══════════════════════════════════════════════════════════════╣");
+    }
+    println!("╚══════════════════════════════════════════════════════════════╝");
+
+    write_jsonl(&jsonl_event("agent_complete", json!({
+        "task_completed": report.task_completed,
+        "turns": report.turns,
+        "duration_seconds": report.duration_seconds,
+        "total_input_tokens": report.total_input_tokens,
+        "total_output_tokens": report.total_output_tokens,
+        "tools_called": report.tools_called,
+        "files_modified": report.files_modified,
+        "summary": report.summary,
+    })));
+}
+
+pub fn log_error(context: &str, err: &str) {
+    println!("[ERROR] {}: {}", context, err);
+    write_jsonl(&jsonl_event("error", json!({
+        "context": context,
+        "error": err,
+    })));
+}
+
+pub fn log_info(msg: &str) {
+    println!("[INFO] {}", msg);
+    write_jsonl(&jsonl_event("info", json!({ "message": msg })));
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+fn truncate(s: &str, max_len: usize) -> String {
+    // Work on char boundaries
+    let char_count = s.chars().count();
+    if char_count <= max_len {
+        s.to_string()
+    } else {
+        let end = s
+            .char_indices()
+            .nth(max_len.saturating_sub(3))
+            .map(|(i, _)| i)
+            .unwrap_or(s.len());
+        format!("{}...", &s[..end])
+    }
+}
+
+fn chunk_text(s: &str, width: usize) -> Vec<String> {
+    let mut chunks = Vec::new();
+    let mut current = String::new();
+    for ch in s.chars() {
+        current.push(ch);
+        if current.chars().count() >= width {
+            chunks.push(current.clone());
+            current.clear();
+        }
+    }
+    if !current.is_empty() {
+        chunks.push(current);
+    }
+    if chunks.is_empty() {
+        chunks.push(String::new());
+    }
+    chunks
+}
+
+fn wrap_text(text: &str, width: usize) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut current = String::new();
+    for word in text.split_whitespace() {
+        if current.is_empty() {
+            current = word.to_string();
+        } else if current.len() + 1 + word.len() <= width {
+            current.push(' ');
+            current.push_str(word);
+        } else {
+            lines.push(current.clone());
+            current = word.to_string();
+        }
+    }
+    if !current.is_empty() {
+        lines.push(current);
+    }
+    lines
+}
+
+fn format_number(n: u64) -> String {
+    let s = n.to_string();
+    let mut result = String::new();
+    for (i, ch) in s.chars().rev().enumerate() {
+        if i > 0 && i % 3 == 0 {
+            result.push(',');
+        }
+        result.push(ch);
+    }
+    result.chars().rev().collect()
+}
+
+fn count_tools(tools: &[String]) -> Vec<(String, usize)> {
+    let mut map: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    for t in tools {
+        *map.entry(t.clone()).or_insert(0) += 1;
+    }
+    let mut pairs: Vec<(String, usize)> = map.into_iter().collect();
+    pairs.sort_by(|a, b| b.1.cmp(&a.1));
+    pairs
+}

--- a/backend/agent-runner/src/main.rs
+++ b/backend/agent-runner/src/main.rs
@@ -1,0 +1,140 @@
+mod agent;
+mod api;
+mod config;
+mod logger;
+mod tools;
+
+use anyhow::{Context, Result};
+use std::process;
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // ── Init structured logging ────────────────────────────────────────────────
+    // JSON format for Railway log aggregation; human-readable goes to stdout
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .with_target(false)
+        .with_ansi(false)
+        .init();
+
+    // ── Parse config ──────────────────────────────────────────────────────────
+    let config = config::Config::from_env().context("Failed to load configuration")?;
+
+    // Init JSONL log file
+    logger::init_log_file(&config.log_file);
+
+    // Print startup config (masks secrets)
+    config.log_startup();
+
+    // ── Clone repo if requested ────────────────────────────────────────────────
+    if let Some(ref repo_url) = config.sandbox_repo_url {
+        clone_repo(repo_url, config.gh_token.as_deref()).await?;
+    }
+
+    // ── Start OpenCode web server (optional, best-effort) ─────────────────────
+    let _opencode_handle = start_opencode(config.port).await;
+
+    // ── Run agent loop ─────────────────────────────────────────────────────────
+    let report = agent::run_agent(&config).await?;
+
+    // ── Exit with appropriate status ──────────────────────────────────────────
+    if report.task_completed {
+        logger::log_info("Agent runner exiting successfully (task completed)");
+        process::exit(0);
+    } else {
+        logger::log_info(&format!(
+            "Agent runner exiting (max turns {} reached without task_complete)",
+            config.max_turns
+        ));
+        // Exit 0 even if max turns — the logs tell the real story
+        process::exit(0);
+    }
+}
+
+// ─── Repo Cloning ─────────────────────────────────────────────────────────────
+
+async fn clone_repo(repo_url: &str, gh_token: Option<&str>) -> Result<()> {
+    logger::log_banner("CLONING REPOSITORY");
+    logger::log_info(&format!("Repo URL: {}", repo_url));
+
+    // Build authenticated URL if token provided
+    let clone_url = if let Some(token) = gh_token {
+        // Insert token into https URL: https://TOKEN@github.com/...
+        if repo_url.starts_with("https://") {
+            let without_scheme = &repo_url["https://".len()..];
+            format!("https://{}@{}", token, without_scheme)
+        } else {
+            repo_url.to_string()
+        }
+    } else {
+        repo_url.to_string()
+    };
+
+    // Clone to /workspace
+    let output = tokio::process::Command::new("git")
+        .args(["clone", "--depth=1", &clone_url, "/workspace"])
+        .output()
+        .await
+        .context("Failed to spawn git clone")?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let exit_code = output.status.code().unwrap_or(-1);
+
+    logger::log_tool_section("git clone", repo_url, Some(exit_code), &stdout, &stderr, 0);
+
+    if !output.status.success() {
+        return Err(anyhow::anyhow!(
+            "git clone failed with exit code {}: {}",
+            exit_code,
+            stderr
+        ));
+    }
+
+    // Change working directory to /workspace
+    std::env::set_current_dir("/workspace")
+        .context("Failed to change to /workspace after clone")?;
+
+    logger::log_info("Repository cloned successfully, working directory: /workspace");
+    Ok(())
+}
+
+// ─── OpenCode Web Server ──────────────────────────────────────────────────────
+
+async fn start_opencode(port: u16) -> Option<tokio::process::Child> {
+    // Check if opencode binary exists
+    let which = tokio::process::Command::new("which")
+        .arg("opencode")
+        .output()
+        .await;
+
+    let opencode_available = match which {
+        Ok(out) => out.status.success(),
+        Err(_) => false,
+    };
+
+    if !opencode_available {
+        logger::log_info("opencode binary not found — skipping web UI server");
+        return None;
+    }
+
+    logger::log_info(&format!("Starting opencode web server on port {}", port));
+
+    match tokio::process::Command::new("opencode")
+        .args(["serve", "--port", &port.to_string()])
+        .spawn()
+    {
+        Ok(child) => {
+            logger::log_info(&format!("OpenCode web server started (PID {})", child.id().unwrap_or(0)));
+            Some(child)
+        }
+        Err(e) => {
+            logger::log_info(&format!("Failed to start opencode: {} — continuing without web UI", e));
+            None
+        }
+    }
+}

--- a/backend/agent-runner/src/tools.rs
+++ b/backend/agent-runner/src/tools.rs
@@ -1,0 +1,363 @@
+use serde_json::{json, Value};
+use std::path::Path;
+use std::time::Instant;
+use tokio::process::Command;
+
+use crate::logger;
+
+// ─── Tool Result ─────────────────────────────────────────────────────────────
+
+pub struct ToolResult {
+    pub output: String,
+    pub is_complete: bool,
+    pub duration_ms: u64,
+    pub success: bool,
+}
+
+// ─── Tool Definitions ────────────────────────────────────────────────────────
+
+pub fn tool_definitions() -> Vec<Value> {
+    vec![
+        json!({
+            "name": "bash",
+            "description": "Execute a shell command and capture stdout and stderr. The command runs in the current working directory. Use this for running tests, installing dependencies, running build commands, git operations, etc.",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "command": {
+                        "type": "string",
+                        "description": "The shell command to execute"
+                    },
+                    "timeout_seconds": {
+                        "type": "integer",
+                        "description": "Optional timeout in seconds (default: 120)"
+                    }
+                },
+                "required": ["command"]
+            }
+        }),
+        json!({
+            "name": "read_file",
+            "description": "Read the contents of a file from the filesystem.",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "The path to the file to read"
+                    }
+                },
+                "required": ["path"]
+            }
+        }),
+        json!({
+            "name": "write_file",
+            "description": "Write content to a file, creating parent directories as needed. Overwrites existing files.",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "The path to the file to write"
+                    },
+                    "content": {
+                        "type": "string",
+                        "description": "The content to write to the file"
+                    }
+                },
+                "required": ["path", "content"]
+            }
+        }),
+        json!({
+            "name": "task_complete",
+            "description": "Mark the task as complete and provide a summary of what was accomplished. Call this when you have finished the task successfully.",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "summary": {
+                        "type": "string",
+                        "description": "A detailed summary of what was accomplished"
+                    },
+                    "files_modified": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "List of files that were created or modified"
+                    }
+                },
+                "required": ["summary"]
+            }
+        }),
+    ]
+}
+
+// ─── Tool Executor ───────────────────────────────────────────────────────────
+
+pub async fn execute_tool(name: &str, input: &Value) -> ToolResult {
+    match name {
+        "bash" => execute_bash(input).await,
+        "read_file" => execute_read_file(input).await,
+        "write_file" => execute_write_file(input).await,
+        "task_complete" => execute_task_complete(input).await,
+        _ => ToolResult {
+            output: format!("Unknown tool: {}", name),
+            is_complete: false,
+            duration_ms: 0,
+            success: false,
+        },
+    }
+}
+
+// ─── bash ────────────────────────────────────────────────────────────────────
+
+async fn execute_bash(input: &Value) -> ToolResult {
+    let command = match input["command"].as_str() {
+        Some(c) => c.to_string(),
+        None => {
+            return ToolResult {
+                output: "Error: 'command' field required".to_string(),
+                is_complete: false,
+                duration_ms: 0,
+                success: false,
+            }
+        }
+    };
+
+    let timeout_secs = input["timeout_seconds"]
+        .as_u64()
+        .unwrap_or(120);
+
+    let start = Instant::now();
+
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(timeout_secs),
+        Command::new("sh")
+            .arg("-c")
+            .arg(&command)
+            .output(),
+    )
+    .await;
+
+    let duration_ms = start.elapsed().as_millis() as u64;
+
+    match result {
+        Err(_timeout) => {
+            let output = format!("Error: Command timed out after {}s\nCommand: {}", timeout_secs, command);
+            logger::log_tool_section("bash", &command, None, "", &format!("TIMEOUT after {}s", timeout_secs), duration_ms);
+            ToolResult {
+                output,
+                is_complete: false,
+                duration_ms,
+                success: false,
+            }
+        }
+        Ok(Err(e)) => {
+            let output = format!("Error: Failed to execute command: {}\nCommand: {}", e, command);
+            logger::log_tool_section("bash", &command, None, "", &e.to_string(), duration_ms);
+            ToolResult {
+                output,
+                is_complete: false,
+                duration_ms,
+                success: false,
+            }
+        }
+        Ok(Ok(proc_output)) => {
+            let exit_code = proc_output.status.code().unwrap_or(-1);
+            let stdout = String::from_utf8_lossy(&proc_output.stdout).to_string();
+            let stderr = String::from_utf8_lossy(&proc_output.stderr).to_string();
+
+            logger::log_tool_section("bash", &command, Some(exit_code), &stdout, &stderr, duration_ms);
+
+            let mut output_parts = Vec::new();
+            if !stdout.is_empty() {
+                output_parts.push(format!("STDOUT:\n{}", stdout));
+            }
+            if !stderr.is_empty() {
+                output_parts.push(format!("STDERR:\n{}", stderr));
+            }
+            output_parts.push(format!("Exit code: {}", exit_code));
+
+            let output = output_parts.join("\n\n");
+            let success = exit_code == 0;
+
+            ToolResult {
+                output,
+                is_complete: false,
+                duration_ms,
+                success,
+            }
+        }
+    }
+}
+
+// ─── read_file ───────────────────────────────────────────────────────────────
+
+async fn execute_read_file(input: &Value) -> ToolResult {
+    let path = match input["path"].as_str() {
+        Some(p) => p.to_string(),
+        None => {
+            return ToolResult {
+                output: "Error: 'path' field required".to_string(),
+                is_complete: false,
+                duration_ms: 0,
+                success: false,
+            }
+        }
+    };
+
+    let start = Instant::now();
+
+    match tokio::fs::read_to_string(&path).await {
+        Ok(content) => {
+            let duration_ms = start.elapsed().as_millis() as u64;
+            let size = content.len();
+
+            logger::log_tool_section(
+                "read_file",
+                &path,
+                Some(0),
+                &format!("{} bytes read", size),
+                "",
+                duration_ms,
+            );
+
+            ToolResult {
+                output: content,
+                is_complete: false,
+                duration_ms,
+                success: true,
+            }
+        }
+        Err(e) => {
+            let duration_ms = start.elapsed().as_millis() as u64;
+            let output = format!("Error reading file '{}': {}", path, e);
+
+            logger::log_tool_section("read_file", &path, Some(1), "", &e.to_string(), duration_ms);
+
+            ToolResult {
+                output,
+                is_complete: false,
+                duration_ms,
+                success: false,
+            }
+        }
+    }
+}
+
+// ─── write_file ──────────────────────────────────────────────────────────────
+
+async fn execute_write_file(input: &Value) -> ToolResult {
+    let path = match input["path"].as_str() {
+        Some(p) => p.to_string(),
+        None => {
+            return ToolResult {
+                output: "Error: 'path' field required".to_string(),
+                is_complete: false,
+                duration_ms: 0,
+                success: false,
+            }
+        }
+    };
+
+    let content = match input["content"].as_str() {
+        Some(c) => c.to_string(),
+        None => {
+            return ToolResult {
+                output: "Error: 'content' field required".to_string(),
+                is_complete: false,
+                duration_ms: 0,
+                success: false,
+            }
+        }
+    };
+
+    let start = Instant::now();
+
+    // Create parent directories if needed
+    if let Some(parent) = Path::new(&path).parent() {
+        if let Err(e) = tokio::fs::create_dir_all(parent).await {
+            let duration_ms = start.elapsed().as_millis() as u64;
+            let output = format!("Error creating directories for '{}': {}", path, e);
+            logger::log_tool_section("write_file", &path, Some(1), "", &e.to_string(), duration_ms);
+            return ToolResult {
+                output,
+                is_complete: false,
+                duration_ms,
+                success: false,
+            };
+        }
+    }
+
+    match tokio::fs::write(&path, &content).await {
+        Ok(()) => {
+            let duration_ms = start.elapsed().as_millis() as u64;
+            let size = content.len();
+            let output = format!("Successfully wrote {} bytes to '{}'", size, path);
+
+            logger::log_tool_section(
+                "write_file",
+                &path,
+                Some(0),
+                &format!("{} bytes written", size),
+                "",
+                duration_ms,
+            );
+
+            ToolResult {
+                output,
+                is_complete: false,
+                duration_ms,
+                success: true,
+            }
+        }
+        Err(e) => {
+            let duration_ms = start.elapsed().as_millis() as u64;
+            let output = format!("Error writing file '{}': {}", path, e);
+            logger::log_tool_section("write_file", &path, Some(1), "", &e.to_string(), duration_ms);
+
+            ToolResult {
+                output,
+                is_complete: false,
+                duration_ms,
+                success: false,
+            }
+        }
+    }
+}
+
+// ─── task_complete ───────────────────────────────────────────────────────────
+
+async fn execute_task_complete(input: &Value) -> ToolResult {
+    let summary = input["summary"]
+        .as_str()
+        .unwrap_or("Task completed.")
+        .to_string();
+
+    let files: Vec<String> = input["files_modified"]
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str())
+                .map(|s| s.to_string())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let output = if files.is_empty() {
+        format!("TASK COMPLETE\n\n{}", summary)
+    } else {
+        format!(
+            "TASK COMPLETE\n\n{}\n\nFiles modified:\n{}",
+            summary,
+            files.iter().map(|f| format!("  - {}", f)).collect::<Vec<_>>().join("\n")
+        )
+    };
+
+    logger::log_tool_section("task_complete", "TASK COMPLETE", Some(0), &output, "", 0);
+
+    ToolResult {
+        output,
+        is_complete: true,
+        duration_ms: 0,
+        success: true,
+    }
+}

--- a/backend/sandbox/Dockerfile
+++ b/backend/sandbox/Dockerfile
@@ -1,18 +1,17 @@
 FROM node:22-bookworm-slim
 
-# Build args
 ARG OPENCODE_VERSION="latest"
 
-# Install system dependencies
+# System deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
     bash ca-certificates curl g++ git gh make openssh-client python3 \
     && rm -rf /var/lib/apt/lists/*
 
-# Configure git
+# Git config
 RUN git config --global user.name "T27 SWE Agent" \
   && git config --global user.email "t27-agent@users.noreply.github.com"
 
-# Setup SSH for GitHub
+# SSH for GitHub
 RUN mkdir -p /root/.ssh && chmod 700 /root/.ssh \
   && ssh-keyscan github.com >> /root/.ssh/known_hosts
 
@@ -24,15 +23,15 @@ RUN curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone
 
 WORKDIR /home/sandbox/workspace
 
+# Copy agent scripts
 COPY init.sh /usr/local/bin/sandbox-init.sh
-RUN chmod +x /usr/local/bin/sandbox-init.sh
-
+COPY agent-runner.py /usr/local/bin/agent-runner.py
 COPY healthcheck.sh /usr/local/bin/healthcheck.sh
-RUN chmod +x /usr/local/bin/healthcheck.sh
+RUN chmod +x /usr/local/bin/sandbox-init.sh /usr/local/bin/healthcheck.sh
 
 ENV PATH="/root/.opencode/bin:/root/.local/bin:${PATH}"
 
-HEALTHCHECK --interval=10s --timeout=3s --start-period=30s \
+HEALTHCHECK --interval=10s --timeout=3s --start-period=60s \
   CMD /usr/local/bin/healthcheck.sh
 
 EXPOSE 8080

--- a/backend/sandbox/agent-runner.py
+++ b/backend/sandbox/agent-runner.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""
+T27 Autonomous Agent Runner
+Executes tasks via Z.AI/Anthropic API with tool use (bash, read, write).
+Runs as a loop: prompt → think → execute tools → observe → repeat.
+
+Env vars:
+  ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN — Z.AI key
+  ANTHROPIC_BASE_URL — default https://api.z.ai/api/anthropic
+  TASK_PROMPT — what to do
+  MAX_TURNS — max agent turns (default 50)
+"""
+
+import json, os, subprocess, sys, time, urllib.request, urllib.error
+from pathlib import Path
+from datetime import datetime, timezone
+
+# ── Config ──
+API_KEY = os.environ.get("ANTHROPIC_AUTH_TOKEN") or os.environ.get("ANTHROPIC_API_KEY", "")
+BASE_URL = os.environ.get("ANTHROPIC_BASE_URL", "https://api.z.ai/api/anthropic")
+MODEL = os.environ.get("MODEL", "claude-sonnet-4-5-20250514")
+MAX_TURNS = int(os.environ.get("MAX_TURNS", "50"))
+MAX_TOKENS = int(os.environ.get("MAX_TOKENS", "8192"))
+TASK_PROMPT = os.environ.get("TASK_PROMPT", "")
+LOG_FILE = os.environ.get("LOG_FILE", "/tmp/agent-log.jsonl")
+
+def log(msg):
+    ts = datetime.now(timezone.utc).strftime("%H:%M:%S")
+    print(f"[{ts}] {msg}", flush=True)
+
+def log_json(entry):
+    with open(LOG_FILE, "a") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+# ── Tools ──
+TOOLS = [
+    {
+        "name": "bash",
+        "description": "Execute a bash command and return stdout/stderr. Use for: listing files, running tests, git operations, any shell command.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "command": {"type": "string", "description": "The bash command to execute"}
+            },
+            "required": ["command"]
+        }
+    },
+    {
+        "name": "read_file",
+        "description": "Read the contents of a file. Use for reading source code, configs, specs, docs.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string", "description": "File path to read"}
+            },
+            "required": ["path"]
+        }
+    },
+    {
+        "name": "write_file",
+        "description": "Write content to a file. Creates parent directories if needed.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string", "description": "File path to write"},
+                "content": {"type": "string", "description": "Content to write"}
+            },
+            "required": ["path", "content"]
+        }
+    },
+    {
+        "name": "task_complete",
+        "description": "Call this when the task is fully complete. Include a summary of what was done.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "summary": {"type": "string", "description": "Summary of completed work"}
+            },
+            "required": ["summary"]
+        }
+    }
+]
+
+def execute_tool(name, input_data):
+    """Execute a tool and return the result string."""
+    if name == "bash":
+        cmd = input_data.get("command", "")
+        log(f"  BASH: {cmd[:120]}")
+        try:
+            result = subprocess.run(
+                cmd, shell=True, capture_output=True, text=True, timeout=120, cwd=os.getcwd()
+            )
+            output = result.stdout
+            if result.stderr:
+                output += f"\nSTDERR:\n{result.stderr}"
+            if result.returncode != 0:
+                output += f"\n[exit code: {result.returncode}]"
+            return output[:10000]
+        except subprocess.TimeoutExpired:
+            return "[ERROR: command timed out after 120s]"
+        except Exception as e:
+            return f"[ERROR: {e}]"
+
+    elif name == "read_file":
+        path = input_data.get("path", "")
+        log(f"  READ: {path}")
+        try:
+            content = Path(path).read_text(errors="replace")
+            return content[:20000]
+        except Exception as e:
+            return f"[ERROR: {e}]"
+
+    elif name == "write_file":
+        path = input_data.get("path", "")
+        content = input_data.get("content", "")
+        log(f"  WRITE: {path} ({len(content)} chars)")
+        try:
+            p = Path(path)
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(content)
+            return f"Written {len(content)} chars to {path}"
+        except Exception as e:
+            return f"[ERROR: {e}]"
+
+    elif name == "task_complete":
+        summary = input_data.get("summary", "")
+        log(f"  COMPLETE: {summary[:200]}")
+        return "TASK_COMPLETE"
+
+    return f"[ERROR: unknown tool {name}]"
+
+
+# ── API Call ──
+def call_api(messages):
+    """Call Z.AI/Anthropic API."""
+    body = json.dumps({
+        "model": MODEL,
+        "max_tokens": MAX_TOKENS,
+        "tools": TOOLS,
+        "messages": messages,
+    }).encode()
+
+    headers = {
+        "Content-Type": "application/json",
+        "x-api-key": API_KEY,
+        "anthropic-version": "2023-06-01",
+    }
+
+    req = urllib.request.Request(f"{BASE_URL}/v1/messages", data=body, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode() if e.fp else ""
+        log(f"  API ERROR {e.code}: {error_body[:300]}")
+        return {"error": {"message": error_body, "status": e.code}}
+    except Exception as e:
+        log(f"  API ERROR: {e}")
+        return {"error": {"message": str(e)}}
+
+
+# ── System Prompt ──
+def build_system():
+    parts = [
+        "You are an autonomous SWE agent working in the T27 project.",
+        "You have tools: bash (run commands), read_file, write_file, task_complete.",
+        "Always read SOUL.md first — it is the constitutional law of this project.",
+        "Follow the PHI LOOP: spec → gen → test → verdict → experience → commit.",
+        "When done, call task_complete with a summary.",
+        "Be thorough but efficient. Prefer small targeted changes.",
+    ]
+    # Add SOUL.md content if exists
+    soul = Path("SOUL.md")
+    if soul.exists():
+        parts.append(f"\n--- SOUL.md (excerpt) ---\n{soul.read_text()[:3000]}")
+    return "\n".join(parts)
+
+
+# ── Main Loop ──
+def main():
+    if not API_KEY:
+        log("ERROR: No API key set (ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN)")
+        sys.exit(1)
+
+    if not TASK_PROMPT:
+        log("ERROR: No TASK_PROMPT set")
+        sys.exit(1)
+
+    log("═" * 50)
+    log("  T27 AUTONOMOUS AGENT")
+    log("═" * 50)
+    log(f"Model: {MODEL}")
+    log(f"Base URL: {BASE_URL}")
+    log(f"Task: {TASK_PROMPT[:200]}")
+    log(f"Max turns: {MAX_TURNS}")
+    log(f"CWD: {os.getcwd()}")
+    log("═" * 50)
+
+    system = build_system()
+    messages = [{"role": "user", "content": TASK_PROMPT}]
+
+    for turn in range(1, MAX_TURNS + 1):
+        log(f"\n{'─'*40} Turn {turn}/{MAX_TURNS} {'─'*40}")
+
+        response = call_api([{"role": "user", "content": system + "\n\nUser task:\n" + TASK_PROMPT}] if turn == 1 else messages)
+
+        if "error" in response:
+            log(f"API error, retrying in 10s...")
+            time.sleep(10)
+            continue
+
+        # Extract response content
+        assistant_content = response.get("content", [])
+        stop_reason = response.get("stop_reason", "")
+        model = response.get("model", "?")
+        usage = response.get("usage", {})
+
+        log(f"  Model: {model} | Tokens: in={usage.get('input_tokens',0)} out={usage.get('output_tokens',0)} | Stop: {stop_reason}")
+
+        # Log to file
+        log_json({"turn": turn, "model": model, "usage": usage, "stop_reason": stop_reason,
+                   "content_types": [c.get("type") for c in assistant_content]})
+
+        # Add assistant response to messages
+        messages.append({"role": "assistant", "content": assistant_content})
+
+        # Process text blocks
+        for block in assistant_content:
+            if block.get("type") == "text":
+                text = block.get("text", "")
+                log(f"  TEXT: {text[:300]}")
+
+        # Process tool calls
+        if stop_reason == "tool_use":
+            tool_results = []
+            task_done = False
+
+            for block in assistant_content:
+                if block.get("type") == "tool_use":
+                    tool_name = block.get("name", "")
+                    tool_input = block.get("input", {})
+                    tool_id = block.get("id", "")
+
+                    result = execute_tool(tool_name, tool_input)
+
+                    if result == "TASK_COMPLETE":
+                        task_done = True
+                        tool_results.append({
+                            "type": "tool_result",
+                            "tool_use_id": tool_id,
+                            "content": "Task marked as complete."
+                        })
+                    else:
+                        tool_results.append({
+                            "type": "tool_result",
+                            "tool_use_id": tool_id,
+                            "content": result
+                        })
+
+            messages.append({"role": "user", "content": tool_results})
+
+            if task_done:
+                log("\n" + "═" * 50)
+                log("  TASK COMPLETED SUCCESSFULLY")
+                log("═" * 50)
+                return 0
+
+        elif stop_reason == "end_turn":
+            log("Agent finished (end_turn)")
+            return 0
+
+        else:
+            log(f"Unexpected stop_reason: {stop_reason}")
+
+    log(f"\nMax turns ({MAX_TURNS}) reached")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/sandbox/init.sh
+++ b/backend/sandbox/init.sh
@@ -1,21 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
-
-WORKSPACE_DIR="/home/sandbox/workspace"
 log() { echo "[sandbox-init] $*"; }
 
-# ──────────────────────────────────────────────
-# 1. GitHub auth
-# ──────────────────────────────────────────────
+WORKSPACE_DIR="/home/sandbox/workspace"
+
+# ── 1. GitHub auth ──
 if [[ -n "${GH_TOKEN:-}" ]]; then
-  log "GitHub CLI auth..."
   echo "${GH_TOKEN}" | gh auth login --with-token 2>/dev/null
   git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
+  log "GitHub authenticated."
 fi
 
-# ──────────────────────────────────────────────
-# 2. Clone repo
-# ──────────────────────────────────────────────
+# ── 2. Clone repo ──
 WORK_DIR="${WORKSPACE_DIR}"
 if [[ -n "${SANDBOX_REPO_URL:-}" ]]; then
   REPO_NAME="$(basename "${SANDBOX_REPO_URL}" .git)"
@@ -28,107 +24,56 @@ if [[ -n "${SANDBOX_REPO_URL:-}" ]]; then
   [[ -d "${TARGET_DIR}" ]] && WORK_DIR="${TARGET_DIR}"
 fi
 cd "${WORK_DIR}"
-log "Working directory: ${WORK_DIR}"
+log "CWD: ${WORK_DIR}"
 
-# ──────────────────────────────────────────────
-# 3. Minimal opencode.json
-# ──────────────────────────────────────────────
+# ── 3. Write opencode config ──
 DEFAULT_MODEL="anthropic/claude-sonnet-4-5"
 SMALL_MODEL="anthropic/claude-haiku-3-5"
 [[ -z "${ANTHROPIC_API_KEY:-}" ]] && [[ -n "${OPENAI_API_KEY:-}" ]] && DEFAULT_MODEL="openai/gpt-4o" && SMALL_MODEL="openai/gpt-4o-mini"
-
 MCP_BLOCK=""
 [[ -n "${RAILWAY_API_TOKEN:-}" ]] && MCP_BLOCK='"mcp":{"railway":{"type":"local","command":["npx","-y","@railway/mcp-server"],"environment":{"RAILWAY_API_TOKEN":"'"${RAILWAY_API_TOKEN}"'"}}},'
-
 cat > opencode.json <<ENDJSON
-{
-  "\$schema": "https://opencode.ai/config.json",
-  "model": "${DEFAULT_MODEL}",
-  "small_model": "${SMALL_MODEL}",
-  ${MCP_BLOCK}
-  "server": {"port": ${PORT:-8080}, "hostname": "0.0.0.0"}
-}
+{"\$schema":"https://opencode.ai/config.json","model":"${DEFAULT_MODEL}","small_model":"${SMALL_MODEL}",${MCP_BLOCK}"server":{"port":${PORT:-8080},"hostname":"0.0.0.0"}}
 ENDJSON
 mkdir -p "${HOME}/.config/opencode"
 cp opencode.json "${HOME}/.config/opencode/opencode.json"
 
-# ──────────────────────────────────────────────
-# 4. Start OpenCode web (background for UI)
-# ──────────────────────────────────────────────
-log "Starting OpenCode web UI..."
+# ── 4. Start OpenCode web (background, for browser observation) ──
 if command -v opencode &>/dev/null; then
+  log "Starting OpenCode web UI on :${PORT:-8080}..."
   opencode web --hostname 0.0.0.0 --port "${PORT:-8080}" &
   WEB_PID=$!
+  for i in $(seq 1 30); do
+    curl -sf "http://localhost:${PORT:-8080}/global/health" >/dev/null 2>&1 && break
+    sleep 2
+  done
+  log "Web UI ready (PID ${WEB_PID})"
 else
+  log "OpenCode not found, starting code-server..."
   code-server --bind-addr "0.0.0.0:${PORT:-8080}" --auth none . &
   WEB_PID=$!
 fi
 
-# Wait for server ready
-for i in $(seq 1 30); do
-  curl -sf "http://localhost:${PORT:-8080}/global/health" >/dev/null 2>&1 && break
-  sleep 2
-done
-log "Web UI ready (PID ${WEB_PID})"
-
-# ──────────────────────────────────────────────
-# 5. Autonomous task via CLI (if TASK_PROMPT set)
-# ──────────────────────────────────────────────
-if [[ -n "${TASK_PROMPT:-}" ]] && command -v opencode &>/dev/null; then
+# ── 5. Run agent ──
+if [[ -n "${TASK_PROMPT:-}" ]]; then
   log "═══════════════════════════════════════"
-  log "  AUTONOMOUS TASK MODE"
+  log "  AUTONOMOUS AGENT MODE"
   log "═══════════════════════════════════════"
-  log "Task: ${TASK_PROMPT:0:200}..."
 
-  # Build full prompt with project context
-  FULL_PROMPT="${TASK_PROMPT}"
-  [[ -f "SOUL.md" ]] && FULL_PROMPT="You are working in the T27 project. Read SOUL.md first — it is the constitutional law. Then: ${TASK_PROMPT}"
-  [[ -f "CLAUDE.md" ]] && FULL_PROMPT="${FULL_PROMPT}. Also follow CLAUDE.md conventions."
-  [[ -f "docs/AGENTS.md" ]] && FULL_PROMPT="${FULL_PROMPT}. Agent specs are in docs/AGENTS.md."
-
-  # Run autonomous task via opencode CLI (uses same server)
-  # --attach connects to the running web server
-  # --format json gives structured output
-  log "Launching task via CLI (attached to web server)..."
-  opencode run \
-    --attach "http://localhost:${PORT:-8080}" \
-    --model "${DEFAULT_MODEL}" \
-    --title "${TASK_TITLE:-autonomous-phi-loop}" \
-    --format json \
-    "${FULL_PROMPT}" \
-    > /tmp/task-output.json 2>&1 &
-  TASK_PID=$!
-  log "Task PID: ${TASK_PID}"
-  log "Watch progress: https://${RAILWAY_PUBLIC_DOMAIN:-localhost:${PORT:-8080}}"
-
-  # Log task output in background
-  (
-    wait "${TASK_PID}" 2>/dev/null
-    EXIT_CODE=$?
-    log "═══════════════════════════════════════"
-    log "  TASK COMPLETED (exit: ${EXIT_CODE})"
-    log "═══════════════════════════════════════"
-    if [[ -f /tmp/task-output.json ]]; then
-      log "Output saved to /tmp/task-output.json"
-      python3 -c "
-import json
-try:
-    with open('/tmp/task-output.json') as f:
-        for line in f:
-            line = line.strip()
-            if not line: continue
-            try:
-                d = json.loads(line)
-                if d.get('type') == 'text':
-                    print(f'[RESULT] {d.get(\"text\",\"\")[:500]}')
-            except: pass
-except: pass
-" 2>/dev/null
-    fi
-  ) &
+  if command -v t27-agent-runner &>/dev/null; then
+    # Rust agent runner (preferred)
+    log "Using Rust agent runner..."
+    t27-agent-runner &
+    AGENT_PID=$!
+    log "Agent PID: ${AGENT_PID}"
+  else
+    # Python fallback
+    log "Rust runner not found, using Python fallback..."
+    python3 /usr/local/bin/agent-runner.py &
+    AGENT_PID=$!
+    log "Python agent PID: ${AGENT_PID}"
+  fi
 fi
 
-# ──────────────────────────────────────────────
-# 6. Keep alive
-# ──────────────────────────────────────────────
+# ── 6. Keep alive ──
 wait "${WEB_PID}"


### PR DESCRIPTION
Closes #87

## Tested and working NOW

Python agent-runner.py successfully completes autonomous tasks via Z.AI:
```
Turn 1: find .tri files → bash: find ./specs -name '*.tri'
Turn 2: count files → bash: wc -l → 1 file
Turn 3: read queen health → read_file: .trinity/state/queen-health.json
Turn 4: create report → task_complete: GREEN, all domains 1.0
```

## Rust Agent Runner (future, needs CI build)
Full `backend/agent-runner/` Rust project with:
- Detailed ASCII box logs per turn (model, tokens, stop reason, tools)
- JSONL structured log to `/tmp/agent-log.jsonl`
- Exponential backoff retry on API errors
- Docker build workflow for `ghcr.io/ghashtag/t27-agent-runner`

## How to use
Set `TASK_PROMPT` env var on sandbox → agent auto-runs on container start.
Web UI (OpenCode) runs in parallel for observation.