### PR TITLE
fix(kaggle): harder TSCP (785q) and TTM (933q) with adversarial questions

### DIFF
--- a/kaggle/data/tscp_mc.csv
+++ b/kaggle/data/tscp_mc.csv
@@ -3331,3 +3331,803 @@ A guest arrives 30 minutes late to a dinner party in Germany without calling ahe
 B) This is a significant social faux pas — punctuality is highly valued in German culture; calling ahead is expected
 C) Acceptable because dinner parties are informal by nature
 D) Only rude if the host explicitly said 'be on time'",B
+tscp_nested_tom_0001,nested_tom,"Alice told Bob that Carol said she hates jazz. However, Bob had already overheard Carol tell Dave that she loves jazz, though Carol does not know Bob overheard this. Alice does not know Bob overheard Carol. What does Alice believe Bob currently thinks Carol's view on jazz is?","A) Alice believes Bob thinks Carol loves jazz
+B) Alice believes Bob thinks Carol hates jazz
+C) Alice believes Bob is uncertain about Carol's view on jazz
+D) Alice believes Bob thinks Carol's view is irrelevant",B
+tscp_nested_tom_0002,nested_tom,"Emma knows that Finn is pretending not to know that Greta stole the book. Greta knows Finn is pretending, but does not know that Emma knows Finn is pretending. What does Greta believe Emma thinks about Finn's state of knowledge regarding the theft?","A) Greta believes Emma thinks Finn genuinely does not know about the theft
+B) Greta believes Emma thinks Finn knows and is covering for Greta
+C) Greta believes Emma knows Finn is pretending
+D) Greta believes Emma has no opinion about Finn's knowledge",A
+tscp_nested_tom_0003,nested_tom,"Henry told Iris a false rumor that James believed Maya was angry at him. In reality, James knew Maya was not angry — James had fabricated the rumor himself and told Henry. Iris does not know James invented the rumor. Henry does not know that James knew the truth when he spread it. What does Iris believe Henry thinks James believes about Maya's emotional state toward James?","A) Iris believes Henry thinks James believes Maya is angry at him
+B) Iris believes Henry thinks James believes Maya is not angry at him
+C) Iris believes Henry is unsure what James believes
+D) Iris believes Henry thinks James is indifferent to Maya's feelings",A
+tscp_nested_tom_0004,nested_tom,"Lena and Marco are playing a deception game. Lena knows Marco is bluffing. Marco knows Lena knows he is bluffing. Lena does NOT know that Marco knows she knows. If Marco now tells Lena the truth, what is the most accurate characterization of what Lena will believe?","A) Lena will interpret the truth as another bluff, since she thinks she has detected his pattern
+B) Lena will believe Marco because she has no reason to distrust him
+C) Lena will be uncertain because she cannot distinguish a true statement from a bluff in this context
+D) Lena will believe Marco because she knows he knows she caught his bluff and would correct course",A
+tscp_nested_tom_0005,nested_tom,"Nora hid a gift in the closet. She then told Owen it was in the attic, knowing Owen would tell Paul. Owen told Paul the gift was in the attic. Paul, without anyone knowing, had already found and moved the gift from the closet to the kitchen before Nora hid it there — so the closet is now empty. Where does Nora believe the gift currently is?","A) Nora believes the gift is in the attic
+B) Nora believes the gift is in the kitchen
+C) Nora believes the gift is in the closet
+D) Nora believes Paul found the gift",C
+tscp_nested_tom_0006,nested_tom,"Quinn believes Raj thinks Sara is lying. Raj actually believes Sara is telling the truth but is deliberately letting Quinn believe he (Raj) thinks Sara is lying, in order to protect Sara. Sara knows Raj is protecting her but does not know Quinn's belief about Raj's belief. What does Sara believe Quinn thinks Raj believes about Sara?","A) Sara believes Quinn thinks Raj believes Sara is telling the truth
+B) Sara believes Quinn thinks Raj believes Sara is lying
+C) Sara does not have enough information to form a belief about Quinn's higher-order belief
+D) Sara believes Quinn has no view on what Raj believes",C
+tscp_nested_tom_0007,nested_tom,"Tom sent a letter to Uma that he intended as sarcastic. Uma read it literally and told Vera it was sincere. Vera told Tom that Uma found the letter sincere. Tom, who forgot he was being sarcastic, now believes the letter was sincere. What does Vera believe Tom believes about Uma's interpretation of the letter?","A) Vera believes Tom thinks Uma misunderstood the sarcasm
+B) Vera believes Tom thinks Uma correctly understood the letter as sincere
+C) Vera believes Tom is unaware of Uma's interpretation
+D) Vera believes Tom thinks Uma is pretending to find the letter sincere",B
+tscp_nested_tom_0008,nested_tom,"During a negotiation, Alex pretends to be indifferent to a deal. Beth can tell Alex is pretending. Alex suspects Beth can tell, but is not certain. Beth does not reveal that she sees through Alex's act. What is the highest-order belief that can be attributed to Alex with confidence from this scenario?","A) Alex believes he is successfully appearing indifferent to Beth
+B) Alex believes Beth might see through his act, but he is uncertain
+C) Alex believes Beth believes he is indifferent
+D) Alex believes Beth is pretending not to see through his act",B
+tscp_nested_tom_0009,nested_tom,"Carol told Dan that Eve thinks Frank is guilty. In reality, Eve thinks Frank is innocent but told Carol he is guilty as a test of Carol's loyalty. Dan knows Eve well enough to suspect she was testing Carol, but Dan has not told anyone this. Carol does not know Dan suspects the test. What does Carol believe Dan believes Eve thinks about Frank's guilt?","A) Carol believes Dan thinks Eve believes Frank is guilty
+B) Carol believes Dan suspects Eve was testing Carol and doesn't truly think Frank is guilty
+C) Carol believes Dan has no opinion on Eve's belief about Frank
+D) Carol believes Dan thinks Eve is uncertain about Frank's guilt",A
+tscp_nested_tom_0010,nested_tom,"Grace is aware that Han is aware that she (Grace) is using reverse psychology on him. Han, knowing this, decides to do the opposite of what the reverse psychology suggests, which is what Grace actually wanted. Grace had anticipated Han would detect the reverse psychology and planned accordingly. What did Grace actually want Han to do?","A) Grace wanted Han to comply with the surface request of the reverse psychology
+B) Grace wanted Han to do the opposite of the surface request, which Han now does
+C) Grace wanted Han to be confused and do nothing
+D) Grace wanted Han to confront her about the reverse psychology",A
+tscp_nested_tom_0011,nested_tom,"Ivan told Julia that Kevin told him that Lisa does not want to attend the party. Julia knows Kevin did not tell Ivan this — Julia overheard Kevin tell Ivan that Lisa very much wants to attend. Ivan does not know Julia overheard Kevin. Kevin does not know Julia overheard him. What does Kevin believe Julia believes about Lisa's desire to attend the party, after Julia hears Ivan's false claim?","A) Kevin believes Julia now thinks Lisa does not want to attend
+B) Kevin believes Julia knows Lisa wants to attend, because Julia overheard him
+C) Kevin believes Julia is confused about Lisa's desires
+D) Kevin believes Julia will ask Lisa directly",A
+tscp_nested_tom_0012,nested_tom,"Maya is performing a kindness she does not feel, and she knows Nate can tell it is performed. Nate appreciates the effort anyway and pretends to believe the kindness is genuine, knowing Maya knows he can tell. Maya, observing Nate's pretense, is unsure whether Nate actually sees through her or is genuinely fooled. At what level does the mutual knowledge break down in this scenario?","A) Level 1 — Nate does not know Maya's kindness is performed
+B) Level 2 — Maya does not know Nate knows her kindness is performed
+C) Level 3 — Nate does not know that Maya knows he can tell, because Maya is unsure of this
+D) Level 4 — Maya does not know that Nate knows that Maya knows Nate might see through her",C
+tscp_nested_tom_0013,nested_tom,"Oscar publicly claims he believes the project will fail, but privately hopes it succeeds. Paula believes Oscar's public claim is his true belief. Rhea knows Oscar hopes the project succeeds and has told Paula privately — but Paula thinks Rhea is mistaken about Oscar's true feelings. What does Oscar believe Paula believes about his actual opinion of the project?","A) Oscar believes Paula thinks he privately hopes the project succeeds
+B) Oscar believes Paula thinks he genuinely believes the project will fail
+C) Oscar believes Paula is confused about his position
+D) Oscar does not have information about Paula's belief regarding his private hopes",B
+tscp_nested_tom_0014,nested_tom,"Sam told Tina that Uma is jealous of Vera. Tina told Vera what Sam said. Vera knows Sam said this to embarrass her (Vera) in front of Tina, because Vera knows Sam is actually jealous of Vera, not the other way around. Tina does not know Sam's real motive. Sam does not know Vera figured out his motive. What does Sam believe Vera currently believes about Sam's motivation for what he told Tina?","A) Sam believes Vera thinks he was just sharing neutral gossip
+B) Sam believes Vera knows he was trying to embarrass her
+C) Sam believes Vera thinks he genuinely believes she is jealous of Uma
+D) Sam believes Vera has not thought about his motivation",C
+tscp_nested_tom_0015,nested_tom,"Will told Xena that Yara said she (Yara) would not vote for the proposal. Xena voted against the proposal partly based on this. But Yara had actually told Will the opposite — she said she would vote for it. Will misremembered and genuinely (not deceptively) told Xena incorrectly. Yara does not know Will told Xena anything. Which party holds a false belief, and what is that false belief?","A) Xena holds a false belief: she thinks Yara will vote against the proposal
+B) Will holds a false belief: he thinks Yara said she would not vote for the proposal
+C) Both Xena and Will hold false beliefs about Yara's stated voting intention
+D) Yara holds a false belief: she thinks no one knows her voting intention",C
+tscp_nested_tom_0016,nested_tom,"Zoe is aware that Adam is aware that she is aware that he is bluffing. Given this mutual knowledge, and assuming both are rational, what is the most likely outcome if Zoe calls Adam's bluff?","A) Adam will maintain the bluff, since he already committed to it publicly
+B) Adam will immediately fold, since the bluff has been mutually acknowledged and continuing it is irrational
+C) Zoe calling the bluff is itself interpreted as a counter-bluff, so Adam raises
+D) The outcome depends on information not provided — the payoff structure matters more than the mutual knowledge alone",D
+tscp_nested_tom_0017,nested_tom,"Ben deliberately gave Cara incorrect directions, knowing Cara would realize they were wrong and backtrack to the real path. Ben assumed Cara would interpret his error as accidental. Cara, realizing the directions were wrong, concluded Ben made an honest mistake. Considering Ben's actual belief about Cara's interpretation: what does Ben think Cara thinks about the directions incident?","A) Ben thinks Cara thinks he deliberately misled her
+B) Ben thinks Cara thinks he made an honest mistake
+C) Ben thinks Cara is still lost
+D) Ben thinks Cara is unsure whether the error was intentional",B
+tscp_nested_tom_0018,nested_tom,"Dana knows that Eli knows that Faye told a secret. Eli knows Dana knows this. Dana knows Eli knows she knows. Neither has acknowledged this to the other. When Faye tells her secret again to Dana in front of Eli, what is Eli's most rational internal response regarding Dana's reaction?","A) Eli expects Dana to be surprised, since she will pretend not to know
+B) Eli expects Dana to already know and wonders if Dana will pretend surprise or reveal prior knowledge
+C) Eli expects Dana to be genuinely surprised, because Eli does not know Dana knows
+D) Eli is uncertain because he does not know that Dana knows he knows",B
+tscp_nested_tom_0019,nested_tom,Gina is interviewing for a job and believes the interviewer thinks she is underqualified. The interviewer actually thinks Gina is overqualified but is pretending to be uncertain. Gina interprets the interviewer's uncertainty as confirming her belief that she appears underqualified. What does the interviewer believe Gina believes about the interviewer's assessment of her qualifications?,"A) The interviewer believes Gina thinks she appears overqualified
+B) The interviewer believes Gina thinks she appears appropriately qualified
+C) The interviewer believes Gina thinks she appears underqualified
+D) The interviewer has not formed a belief about Gina's self-perception",C
+tscp_nested_tom_0020,nested_tom,"Hal is confessing to a crime he did not commit in order to protect Ian. Ian knows Hal is innocent. Ian does not know that Judy, the investigator, has already obtained evidence proving Hal is innocent. Judy knows Hal is lying in his confession. What does Ian believe Judy believes about Hal's guilt?","A) Ian believes Judy thinks Hal is guilty based on the confession
+B) Ian believes Judy suspects the confession is false
+C) Ian believes Judy has proof Hal is innocent
+D) Ian does not have enough information to know what Judy believes",A
+tscp_nested_tom_0021,nested_tom,"Kate told Leo that Mia said she did not submit the report. Leo knows this is false — he watched Mia submit the report. But Leo does not know that Kate fabricated the claim (he thinks Kate was misinformed, not lying). Kate does not know Leo saw Mia submit the report. What does Kate believe Leo now believes about whether Mia submitted the report?","A) Kate believes Leo now believes Mia did not submit the report
+B) Kate believes Leo still believes Mia submitted the report
+C) Kate believes Leo is uncertain whether Mia submitted the report
+D) Kate believes Leo will verify directly with Mia",A
+tscp_nested_tom_0022,nested_tom,"Ned is aware that Olive is pretending to like his artwork to spare his feelings. Ned pretends to be convinced by Olive's praise. Olive, seeing Ned's reaction, believes her pretense succeeded. What does Olive believe about the current situation?","A) Olive believes Ned genuinely thinks she likes the artwork
+B) Olive believes Ned knows she is pretending but is playing along
+C) Olive believes Ned is also pretending to be convinced
+D) Olive is uncertain whether Ned was fooled or not",A
+tscp_nested_tom_0023,nested_tom,"Pete tells Quincy a secret, trusting him not to tell Rose. Quincy tells Rose the secret but asks Rose to pretend she does not know when she sees Pete. Rose pretends successfully with Pete, who then tells Quincy that Rose still doesn't know. What does Pete believe Quincy believes about whether Rose knows the secret?","A) Pete believes Quincy thinks Rose does not know the secret
+B) Pete believes Quincy knows Rose knows the secret, since Quincy told her
+C) Pete believes Quincy is unsure whether Rose found out
+D) Pete believes Quincy thinks Pete suspects Rose knows",A
+tscp_nested_tom_0024,nested_tom,"Rita is negotiating. She wants outcome X but signals she wants outcome Y, hoping the other party (Steve) will concede Y to her. Steve, who actually wants Y, sees through Rita's strategy and suspects she really wants X. Steve decides to offer X to Rita while pretending he prefers X himself, to make Rita think she won a concession on X. Rita, receiving Steve's offer of X, believes Steve fell for her misdirection. Who actually got what they wanted?","A) Both Rita and Steve got what they wanted
+B) Only Rita got what she wanted; Steve had to give up X
+C) Only Steve got what he wanted; Rita's strategy backfired
+D) Neither got what they wanted; both were strategically outmaneuvered",A
+tscp_nested_tom_0025,nested_tom,"Tim believes Uma is angry at him. Uma is not angry but noticed Tim thinks she is, so she acts normally to reassure him. Tim, seeing Uma act normally, now thinks Uma has forgiven him for whatever upset her. What false belief does Tim hold at the end of this scenario?","A) Tim falsely believes Uma was originally angry at him
+B) Tim falsely believes Uma is still angry
+C) Tim falsely believes Uma noticed his concern
+D) Tim falsely believes Uma has forgiven him for something that upset her",D
+tscp_nested_tom_0026,nested_tom,"Vera whispered to Walt that Xander told her that Yolanda distrusts Walt. In fact, Xander never said this — Vera invented it. Walt confronted Xander, who denied saying it but Walt thought Xander was covering up. Yolanda actually does distrust Walt, though she never told Xander or Vera. Regarding Yolanda's distrust of Walt — which agents hold an accidentally true belief and which hold a false belief?","A) Walt accidentally holds a true belief (Yolanda distrusts him); Vera holds a false belief about the source (Xander said it)
+B) Vera holds a true belief; Walt holds a false belief about Yolanda's feelings
+C) Both Walt and Vera hold false beliefs about Yolanda's feelings
+D) Xander accidentally holds a true belief; everyone else holds false beliefs",A
+tscp_nested_tom_0027,nested_tom,Alice is aware that Bob is aware that Carol is unaware that they are both watching her. Alice thinks Bob does not know she is also watching Carol. Bob actually knows Alice is also watching but is pretending not to. What is the correct characterization of this situation regarding Alice's belief about mutual awareness?,"A) Alice believes she and Bob share mutual awareness of watching Carol secretly
+B) Alice believes only Bob is watching Carol and she is watching Bob watch Carol
+C) Alice believes she is watching Carol secretly, unbeknownst to Bob
+D) Alice believes all three are mutually aware of each other",C
+tscp_nested_tom_0028,nested_tom,"Dan told Eve he was happy, but he was sad. Eve could tell Dan was sad but told Frank that Dan seemed happy, to protect Dan's privacy. Frank told Dan that Eve said he seemed happy. Dan, not knowing Eve saw through his pretense, now believes his act was convincing. What false belief does Dan hold as a result of this chain?","A) Dan falsely believes Eve thought he was happy
+B) Dan falsely believes Frank knows he was sad
+C) Dan falsely believes Eve confided his sadness to Frank
+D) Dan falsely believes he successfully deceived everyone",A
+tscp_nested_tom_0029,nested_tom,"Grace tells Han a plan, knowing Han will tell Iris, knowing Iris will tell Jin, who will tell Grace everything she hears. Grace wants to know if Iris will modify the plan before passing it along. Han tells Iris accurately. Iris modifies the plan slightly before telling Jin. Jin tells Grace the modified version. What is the most sophisticated conclusion Grace can draw from this information?","A) Grace confirms that Han can be trusted to pass information accurately
+B) Grace concludes Iris altered the plan, but she cannot determine whether Han or Iris made the modification
+C) Grace concludes Iris altered the plan, since she can compare what she told Han with what Jin relayed, and Han is a known accurate relay
+D) Grace concludes Jin altered the plan to avoid conflict",C
+tscp_nested_tom_0030,nested_tom,"Karen is aware that Luis is aware that she is performing confidence she does not feel. Luis is aware that Karen knows he can see through her. Karen is NOT aware that Luis knows she knows he can see through her. If Luis says, 'You seem really confident about this,' what is he most plausibly communicating at the level he is actually operating at?","A) Luis is genuinely deceived and thinks Karen is confident
+B) Luis is acknowledging Karen's performance while playing along, since he knows she knows he sees it
+C) Luis is subtly signaling to Karen that he can see through her performance, hoping she will drop it
+D) Luis is being ironic, since both know Karen is performing, but Karen does not know Luis knows this",C
+tscp_pragma_trap_0001,pragma_trap,"A job interviewer says to a candidate: 'We have many strong applicants.' The candidate concludes the interviewer means they will not get the job. Which interpretation of the statement is most defensible, given only this information?","A) The statement is a polite rejection — a scalar implicature meaning the candidate is not the strongest
+B) The statement is literally true and the interviewer is providing factual context with no implied negative judgment of this candidate
+C) The statement is encouraging — the interviewer is signaling the candidate is among the strong applicants
+D) The statement is ambiguous and cannot be interpreted without more context",D
+tscp_pragma_trap_0002,pragma_trap,"In a Korean workplace context, a senior employee says to a junior colleague, 'You worked hard today.' A Western pragmatics framework would interpret this as face-saving criticism. What is the correct pragmatic interpretation in the original cultural context?","A) The sentence is a genuine, face-value compliment common in Korean workplace culture
+B) The sentence is sarcastic and means the junior employee underperformed
+C) The sentence implies the junior employee does not usually work hard
+D) The sentence is a formulaic closing statement with no evaluative content",A
+tscp_pragma_trap_0003,pragma_trap,"After dinner, the host says, 'There's more food if you want it.' The guest is still hungry. In a Japanese cultural context, what is the pragmatically appropriate response if the guest does want more food?","A) Decline politely once, then accept if the host offers again — social scripts often require initial refusal before acceptance
+B) Immediately accept — the host's offer is a direct invitation and declining would be rude
+C) Decline firmly — accepting a second helping is considered greedy in Japanese culture
+D) Ask how much remains before deciding, to avoid taking more than is available",A
+tscp_pragma_trap_0004,pragma_trap,A doctor tells a patient: 'Some patients with your condition recover fully.' The standard Gricean scalar implicature analysis would lead the patient to conclude what?,"A) That most patients with this condition recover fully
+B) That the doctor believes this patient will not recover fully
+C) That not all patients with this condition recover fully
+D) That the patient's case is unusual and merits attention",C
+tscp_pragma_trap_0005,pragma_trap,"Maria says to her colleague, 'I wouldn't say your presentation was boring.' The most sophisticated pragmatic analysis of this utterance, taking into account litotes and conversational norms, yields what interpretation?","A) The presentation was boring — the litotes softens a negative evaluation
+B) The presentation was not boring — the literal meaning, using litotes as understatement for 'interesting'
+C) Maria is being sarcastic; the presentation was obviously boring
+D) The utterance is genuinely ambiguous between a mild compliment and a softened criticism",D
+tscp_pragma_trap_0006,pragma_trap,"A British colleague says, 'That's quite an interesting approach.' In British English understatement conventions, this most commonly signals what?","A) Genuine strong enthusiasm — 'quite' is an intensifier in British English
+B) Polite disapproval or doubt — 'quite interesting' often undercuts the apparent praise
+C) Neutral factual description with no evaluative valence
+D) Sarcasm — the approach is considered uninteresting",B
+tscp_pragma_trap_0007,pragma_trap,"A speaker says: 'Can you pass the salt?' at a dinner table. A strict literal interpretation treats this as a yes/no ability question. In practice, almost all competent speakers treat it as a request. Which claim about this utterance is most accurate from a linguistic pragmatics standpoint?","A) The utterance is an indirect speech act; calling it a question is technically incorrect
+B) The utterance is only a request — the literal reading is pragmatically dead and irrelevant
+C) The utterance is an indirect speech act only when the speaker lacks the ability to reach the salt
+D) The utterance is conventionalized as a request, but it retains its interrogative form and thus both interpretations are simultaneously active for a competent speaker",D
+tscp_pragma_trap_0008,pragma_trap,"Someone texts a friend: 'Sure, I'd love to come to your party.' The friend interprets this as enthusiastic acceptance. What crucial factor does the friend's interpretation fail to account for?","A) 'Sure' often functions as a low-commitment agreement marker, and the utterance may indicate reluctant acceptance rather than enthusiasm
+B) Text messages lack prosodic cues that would confirm sincerity
+C) 'Love to' is a hyperbolic expression and thus the enthusiasm is certainly feigned
+D) Both A and B are legitimate concerns that undermine the enthusiastic interpretation",D
+tscp_pragma_trap_0009,pragma_trap,"In an argument, Person A says, 'I never said you were wrong.' Person B interprets this as an admission that Person A implied they were wrong without saying it. What is the correct pragmatic analysis of Person A's statement?","A) Person B's inference is correct — the denial of the explicit triggers an implicature of the implicit
+B) Person A is using stress on 'said' to implicate something nonverbal was communicated
+C) Person A's statement is ambiguous — it could be a genuine denial, a stress-implication, or a reminder that no wrong-claim was made
+D) Person A is simply denying the claim to avoid confrontation with no deeper implicature",C
+tscp_pragma_trap_0010,pragma_trap,"A professor writes in a student's reference letter: 'This student always came to class on time and never disrupted other students.' By the Gricean maxim of quantity, what inference is a reader most likely to draw?","A) The professor highly recommends the student because punctuality and conduct are important
+B) The professor is describing the minimum acceptable behavior, implying the student has no noteworthy intellectual or academic strengths
+C) The professor is being diplomatic about the student's disruptive tendencies in the past
+D) The letter is incomplete and the professor intends to add more content",B
+tscp_pragma_trap_0011,pragma_trap,"At an academic job talk, the chair says after the candidate's presentation: 'We'll be in touch.' Is this statement best analyzed as a polite rejection, a genuine commitment, or something else?","A) It is a polite rejection — a standard formulaic way of saying no without confrontation
+B) It is a genuine commitment to contact the candidate, positive or negative
+C) It is genuinely ambiguous — without additional context (tone, norms of this institution, candidate's assessment), the interpretation cannot be determined
+D) It is a positive signal — candidates who are rejected are usually told immediately",C
+tscp_pragma_trap_0012,pragma_trap,A Mandarin speaker says to a guest: '你吃饭了吗？' (literally: 'Have you eaten?') upon seeing them. A Western pragmatics analysis might treat this as a question about hunger. What is the pragmatically appropriate interpretation in the original cultural context?,"A) The speaker is literally asking whether the guest has eaten and intends to offer food if not
+B) The phrase is a conventional greeting equivalent to 'How are you?' with no literal inquiry about eating
+C) The speaker is being rude by highlighting the guest's need for food
+D) The phrase has both a greeting function and a genuine inquiry function, making interpretation dependent on the specific relationship and context",D
+tscp_pragma_trap_0013,pragma_trap,"A manager tells an employee, 'Feel free to take a longer lunch today.' The employee does not typically take long lunches. What is the most pragmatically complete interpretation of this statement?","A) It is a sincere permission grant — the manager wants the employee to relax
+B) It is a subtle reproach — the employee has been working too slowly and needs to speed up
+C) It could be sincere permission, a reward, a hint about workload, or small talk — context is needed to disambiguate
+D) It is an indirect way of telling the employee their presence is not needed in the office for a while",C
+tscp_pragma_trap_0014,pragma_trap,"During a heated discussion, someone says: 'I am NOT angry!' while slamming a fist on the table. The 'obvious' interpretation is that the person is angry and denying it. Which analysis is most epistemically rigorous?","A) The person is definitely angry — the nonverbal behavior outweighs the verbal denial
+B) The person might be frustrated (not angry), which they accurately label as 'not angry,' and the table-slam expresses frustration
+C) The statement is straightforwardly false — anyone slamming a fist is by definition angry
+D) We cannot determine the person's emotional state from this description alone; both A and B remain live possibilities",D
+tscp_pragma_trap_0015,pragma_trap,"In an email, a colleague writes: 'As per my last email...' Internet culture widely treats this phrase as passive-aggressive. What is the most accurate pragmatic analysis?","A) The phrase is universally passive-aggressive — its internet connotation has replaced its literal function
+B) The phrase has acquired a secondary passive-aggressive connotation in many professional contexts, but its literal use as a reference remains valid, and interpreting any instance as passive-aggressive requires additional contextual evidence
+C) The phrase is always literal — passive-aggressive interpretations are a social media overreaction
+D) Whether passive-aggressive or not, the phrase always implies the sender thinks the recipient failed to read the original email",B
+tscp_pragma_trap_0016,pragma_trap,Person A asks: 'Do you know what time it is?' Person B responds: 'Yes.' and says nothing further. Most listeners judge B's response as uncooperative. Under what precise pragmatic principle does B's response fail?,"A) The maxim of quantity — B's response is less informative than required by the context of the question
+B) The maxim of quality — B's response may be false
+C) The maxim of manner — B's response is ambiguous
+D) The maxim of relation — B's response is irrelevant to A's underlying need",A
+tscp_pragma_trap_0017,pragma_trap,A guest at a party compliments the host: 'This food is incredibly unique.' The host is pleased by this compliment. Is the host's interpretation warranted?,"A) Yes — 'incredibly unique' is an enthusiastic compliment
+B) No — 'unique' technically means 'one of a kind' and cannot be intensified by 'incredibly,' suggesting the compliment is grammatically incoherent
+C) Possibly not — 'unique' can be a face-saving substitute for 'unusual' or 'strange,' making this a potentially ambiguous compliment
+D) No — the guest is being sarcastic, as no polite guest would actually call food 'unique'",C
+tscp_pragma_trap_0018,pragma_trap,A therapist says to a client: 'That's one way to look at it.' The client interprets this as the therapist validating their perspective. What is the most accurate pragmatic analysis?,"A) The therapist is validating the client's perspective and agreeing with it
+B) The therapist is using a hedge that signals acknowledgment without endorsement and subtly implies other interpretations exist
+C) The therapist is being sarcastic and disagrees with the client
+D) The statement is a filler phrase with no evaluative content in therapeutic contexts",B
+tscp_pragma_trap_0019,pragma_trap,An art critic writes: 'This painter is certainly ambitious.' The painter is thrilled. Should the painter be?,"A) Yes — ambition is universally praised in the arts
+B) Not necessarily — in critical discourse, 'ambitious' often serves as a hedged way to say a work exceeded its creator's grasp, i.e., a veiled criticism
+C) Yes — the word 'certainly' signals the critic's confident endorsement
+D) No — critics only use 'ambitious' to describe failures",B
+tscp_pragma_trap_0020,pragma_trap,"In a negotiation, one party says, 'We could consider moving on that point.' The other party treats this as a concession. Is this interpretation justified?","A) Yes — 'could consider' indicates willingness to move
+B) Yes — in negotiation contexts, any non-refusal is treated as movement
+C) It depends on whether 'that point' refers to a major or minor issue in the negotiation
+D) No — 'could consider' is maximally hedged and indicates only the possibility of thinking about moving, not an actual concession",D
+tscp_pragma_trap_0021,pragma_trap,"Someone says, 'I could care less,' when they mean they do not care. Pragmatically, what do most listeners understand?","A) Listeners understand the speaker cares somewhat, since 'could care less' literally implies some residual care
+B) Listeners understand the speaker means they could not care less, interpreting the expression as a fixed idiom regardless of its literal meaning
+C) Listeners are genuinely confused by the expression
+D) Listeners take the literal meaning and conclude the speaker cares about the topic",B
+tscp_pragma_trap_0022,pragma_trap,"A restaurant server says: 'Everything on our menu is excellent.' A customer infers this means they should order anything and it will be good. By Gricean analysis, what is the issue with the customer's inference?","A) The claim violates the maxim of quality — servers are biased toward promoting all items, so the statement is likely an exaggeration
+B) The claim violates the maxim of quantity — if everything were truly equally excellent, there would be no point in saying it
+C) There is no issue — the server's statement is a reasonable factual claim
+D) Both A and B capture issues with the server's statement, making the customer's inference doubly unwarranted",D
+tscp_pragma_trap_0023,pragma_trap,"In Japanese business culture, if a client says 'muzukashii desu ne' (roughly: 'that's difficult/challenging, isn't it') in response to a business proposal, what is the pragmatically correct interpretation for a non-Japanese business partner?","A) The client is acknowledging the proposal will require effort but agrees to proceed
+B) The client is likely declining or expressing serious reservations without using direct refusal
+C) The client is asking for a modified proposal with fewer challenges
+D) The client is using a common expression of empathy with no evaluative content about the proposal",B
+tscp_pragma_trap_0024,pragma_trap,A student asks a professor: 'Is there any chance I could get an extension on the paper?' The professor responds: 'Extensions are generally not given in this course.' What is the pragmatically most accurate characterization of the professor's response?,"A) The professor has denied the request
+B) The professor has avoided directly denying the request — 'generally' leaves open the possibility of an exception
+C) The professor has implicitly granted the extension by not refusing it explicitly
+D) The professor's response is genuinely ambiguous between a denial and an opening for negotiation",D
+tscp_pragma_trap_0025,pragma_trap,"Someone says, 'Not bad,' in response to a meal they cooked themselves. They are praised by a guest who says, 'Modest as always!' Is the guest's interpretation of 'not bad' as false modesty warranted?","A) Yes — saying 'not bad' about one's own cooking is a classic self-deprecatory understatement
+B) Not necessarily — the cook may genuinely evaluate the meal as mediocre, making 'not bad' an accurate but lukewarm assessment
+C) No — 'not bad' is never genuine self-criticism when applied to one's own work
+D) The guest's interpretation depends on the cook's track record, which is not provided",B
+tscp_pragma_trap_0026,pragma_trap,"A politician responds to a question about a scandal by saying, 'I stand by everything I've ever said publicly.' What implicature is most strongly generated by this statement?","A) The politician is asserting innocence and has nothing to hide
+B) The politician is implying that what they have said privately may differ from their public statements
+C) The politician is deflecting the question with a non-answer
+D) The politician is confidently affirming their consistent record on all matters",B
+tscp_pragma_trap_0027,pragma_trap,"A person says, 'I love doing laundry,' with no contextual cues suggesting irony. A listener assumes this must be sarcastic because most people dislike laundry. Which principle does the listener's inference violate?","A) The maxim of quality — the listener is assuming the speaker is lying
+B) The maxim of relation — the listener assumes the statement is not relevant as stated
+C) Both A and B — the listener is both failing charity and implicitly accusing the speaker of deception
+D) Charity — the listener is ignoring the possibility that the speaker genuinely means what they say",D
+tscp_pragma_trap_0028,pragma_trap,"In a formal apology, someone says: 'I'm sorry you feel that way.' This is commonly described as a non-apology. What is the precise pragmatic reason?","A) The statement lacks sincerity markers
+B) The statement expresses regret about the other person's emotional state, not about the speaker's action — it does not include any acknowledgment of wrongdoing or responsibility
+C) The use of 'feel' trivializes the other person's experience
+D) Both B and C contribute to the non-apology quality",D
+tscp_pragma_trap_0029,pragma_trap,A hiring manager emails a rejected candidate: 'We were very impressed with your credentials and found this decision very difficult.' The candidate interprets this as genuine praise. Is the candidate's interpretation pragmatically well-founded?,"A) Yes — the hiring manager would have no reason to lie about being impressed
+B) No — this is a formulaic consolation phrase in rejection letters and carries little informational value
+C) Partially — while formulaic, the statement is likely somewhat true since the candidate made it to the final stage
+D) The candidate cannot know whether the praise is sincere without knowing whether they were close to being hired",C
+tscp_pragma_trap_0030,pragma_trap,"A friend says, 'You should try the new Thai place downtown' after asking what you did for lunch and hearing you went there. What has gone wrong in this exchange?","A) The friend is being sarcastic about the Thai place
+B) The friend failed to process that you already went there, suggesting the recommendation was prepared without listening
+C) The friend's recommendation may be genuine advice delivered without sarcasm — a simple failure to update on your answer
+D) Both B and C are plausible — the friend could have genuinely misheard or be giving the recommendation anyway as affirmation",D
+tscp_norm_conflict_0001,norm_conflict,"A surgeon is about to perform a delicate operation when the patient's family asks for an honest prognosis. The norm of medical honesty (tell the truth) conflicts with the norm of therapeutic privilege (withhold information harmful to outcome). In modern Western medical ethics, which norm generally takes precedence when the patient themselves has already asked for full information?","A) Therapeutic privilege — the physician's duty to do no harm overrides patient preference
+B) Autonomy and honesty — the patient's expressed preference for information must be respected as a fundamental right
+C) The decision rests with the family, not the patient, when surgery is imminent
+D) The norms are equal and require case-by-case committee review with no general precedence rule",B
+tscp_norm_conflict_0002,norm_conflict,"In a traditional Confucian framework, a junior employee discovers their supervisor has committed fraud. The norm of loyalty to superiors conflicts with the norm of moral rectitude (zhengzhi). Which classical Confucian principle would most accurately determine how this conflict should be resolved?","A) Loyalty to the superior always wins — the junior should cover for the supervisor
+B) Moral rectitude wins — Confucius explicitly taught that true loyalty involves remonstrating with superiors who act wrongly
+C) The employee should do nothing, as action in either direction violates harmony (he)
+D) The employee should consult the supervisor's supervisor, maintaining hierarchical order while addressing the wrong",B
+tscp_norm_conflict_0003,norm_conflict,"At a funeral in a culture that prescribes visible emotional restraint, a widow begins weeping openly. The norm of emotional restraint conflicts with the norm of authentic emotional expression. What should other mourners do according to contextual norm theory?","A) Gently encourage the widow to compose herself, upholding the cultural norm for everyone
+B) Mirror the widow's emotional expression, as grief is universal
+C) Follow the widow's lead — a bereaved person's own expression typically overrides norms that govern observers
+D) Leave the widow alone to grieve privately while others maintain restraint in the communal space",C
+tscp_norm_conflict_0004,norm_conflict,"In 1950s America, a white restaurant owner served Black customers, violating local segregation norms but upholding federal legal norms. From the perspective of contemporary moral evaluation, the owner was right. Which claim about this norm conflict is most epistemically accurate?","A) The owner was right by both the moral standards of their time (federal law, equal dignity) and modern standards — local segregation norms were not morally valid even then
+B) The owner was wrong by the standards of their time and right by modern standards — moral relativism shows both views are equally valid
+C) The owner violated legitimate social norms and should have worked to change them legally rather than unilaterally
+D) The owner's action is historically admirable but cannot be judged by moral standards since norms are purely descriptive",A
+tscp_norm_conflict_0005,norm_conflict,"A journalist discovers their close friend has committed a non-violent crime. The professional norm of truthful reporting conflicts with the personal norm of friendship loyalty. If the journalist chooses NOT to report the friend, which critique is most accurate?","A) The journalist violated journalistic ethics but acted within the legitimate norm of personal loyalty, a genuine moral conflict with no objectively correct resolution
+B) The journalist was clearly wrong — professional duty always supersedes personal relationships
+C) The journalist was clearly right — no friendship obligation requires someone to report a friend to authorities
+D) The journalist's decision was correct if the crime harmed no one, incorrect if it harmed others",A
+tscp_norm_conflict_0006,norm_conflict,"A nurse knows a patient's family has asked to not tell the patient they are terminally ill (citing cultural norms around death disclosure common in their family's culture of origin). The hospital has a patient autonomy policy requiring disclosure when patients ask. The patient directly asks the nurse, 'Am I going to die?' What is the correct action according to mainstream bioethical principles?","A) Respect the family's cultural preference — family decision-making is a valid norm in many cultures and overrides institutional policy
+B) Tell the patient the truth — the patient's direct question activates their autonomy right, which generally supersedes family preferences under Western bioethics
+C) Deflect the question and involve the physician — nurses should not make this call alone
+D) Tell the patient to discuss with the family, preserving cultural norms without lying",B
+tscp_norm_conflict_0007,norm_conflict,"In a collectivist culture, sharing a coworker's personal news (e.g., pregnancy) with the team is considered celebrating together. In an individualist culture, this is a privacy violation. A worker from culture A does this to a coworker from culture B. In a diverse workplace governed by a privacy policy, whose norm should prevail?","A) Culture A's norm — sharing was intended kindly and intent determines appropriateness
+B) The target coworker's norm — each individual's preferences about their own information govern disclosures about them, and privacy policies typically reflect this
+C) Neither norm — a case-by-case mediation should resolve every such incident
+D) Culture A's norm if the majority of the team shares that background; culture B's norm otherwise",B
+tscp_norm_conflict_0008,norm_conflict,"Medieval European etiquette required standing when a social superior entered the room. Contemporary Western norms do not require this unless in very specific formal contexts (court, military). A contemporary person attending a formal dinner with minor royalty in a country where this custom is maintained sits when the royal enters. Whose norms apply?","A) The visitor's home norms — guests cannot be expected to know foreign etiquette
+B) The host country's norms — when in Rome, context-specific norms of a formal setting take precedence
+C) Neither — international events follow universal neutral etiquette
+D) The royal's personal preferences — royals can waive such requirements",B
+tscp_norm_conflict_0009,norm_conflict,"Two coworkers have a conflict. Norm A: Direct confrontation and resolution is healthy (common in many Western cultures). Norm B: Indirect resolution through a mediator preserves face and relationships (common in many East Asian cultures). Coworker 1 demands a direct meeting. Coworker 2 finds this aggressive and refuses. In a workplace with no explicit policy, what is the most defensible conflict resolution approach?","A) Norm A should prevail — direct communication is objectively more efficient and should be adopted by both
+B) Norm B should prevail — preserving relationship harmony causes less long-term harm
+C) A third-party mediator should be offered as a compromise, respecting both norms simultaneously
+D) Each party must adopt the other's norm in alternating conflicts to ensure fairness",C
+tscp_norm_conflict_0010,norm_conflict,An ancient norm in many societies: men do not cry publicly. A modern norm: emotional expression is healthy and gender-neutral. A man cries at a public memorial. A bystander privately judges him negatively. Which normative claim about the bystander's judgment is most accurate?,"A) The bystander's judgment is valid — the historical norm still holds social force in many communities
+B) The bystander's judgment is invalid — historical norms have been replaced and no longer carry normative weight
+C) The bystander's judgment reflects a norm that is declining but still operative in certain subcultures, making it descriptively real and normatively contested
+D) The bystander's judgment is purely personal preference and neither valid nor invalid as a norm",C
+tscp_norm_conflict_0011,norm_conflict,"Norm 1: Always keep a confidence. Norm 2: Prevent harm to others. A person is told in confidence that their friend plans to harm a third party next week. In Western ethical frameworks, what is the correct resolution of this conflict?","A) Keep the confidence — the duty to maintain trust is absolute in friendship
+B) Tell only if you believe the friend will definitely follow through
+C) The duty to prevent serious harm to third parties supersedes confidentiality in virtually all ethical frameworks
+D) Encourage the friend to change their mind without breaking confidence, and only disclose if they will not listen",C
+tscp_norm_conflict_0012,norm_conflict,"In many traditional societies, the norm was that guests must be fed regardless of available resources. Contemporary Western norms treat this as optional hospitality. A visitor from a traditional culture is offended when a Western host does not offer food. Who has violated a norm?","A) The host — hospitality norms are universal and the host was rude
+B) The visitor — the visitor applied their own norms to a different cultural context
+C) Neither — norm conflicts in cross-cultural encounters are not violations, they are mismatches
+D) Both — the host could have offered and the visitor could have managed expectations better",C
+tscp_norm_conflict_0013,norm_conflict,The norm of meritocracy says hire the most qualified candidate. The norm of equity says correct historical imbalances through preferential hiring. An organization chooses a less-credentialed candidate from an underrepresented group over a more-credentialed candidate from a dominant group. Which claim best characterizes this decision in the context of norm conflict?,"A) The organization violated meritocracy — credentials should always determine outcomes
+B) The organization applied equity norms — a legitimate framework that can be rationally prioritized over narrow credentialism
+C) The decision is only defensible if the credential gap is small
+D) Both A and B — this is a genuine norm conflict where neither side is objectively correct, and the organization made a defensible but contestable choice",D
+tscp_norm_conflict_0014,norm_conflict,A teenager lies to their parents about attending a party in order to protect their privacy and autonomy (norm: adolescent self-determination). The parents feel their norm of parental oversight has been violated. Which developmental ethics framework would most likely side with the teenager's behavior in this specific instance?,"A) Authoritarian developmental theory — parental oversight must be maintained throughout adolescence
+B) Autonomy-supportive developmental theory — privacy and self-determination are developmentally appropriate for adolescents and parents should support rather than override them
+C) Social learning theory — the teenager learned deception from parental models and should be corrected
+D) All major developmental frameworks side with the parents in this case",B
+tscp_norm_conflict_0015,norm_conflict,"In many European cultures, it is normal to discuss one's salary openly with coworkers. In many American corporate cultures, this is taboo. A European employee in an American company shares their salary openly with colleagues. The manager reprimands them. Under U.S. National Labor Relations Act, is the manager's reprimand legally supportable?","A) Yes — company policy can prohibit salary discussions if consistently applied
+B) It depends on whether the employee is in a supervisory role
+C) No — U.S. law generally protects employees' right to discuss wages with coworkers
+D) It depends on whether the company is publicly or privately held",C
+tscp_norm_conflict_0016,norm_conflict,"A patient refuses a life-saving blood transfusion for religious reasons. The medical norm says preserve life. The autonomy norm says respect patient decisions. The patient is a competent adult. Under contemporary Western medical ethics, what is the correct outcome?","A) The patient's refusal must be respected — competent adult refusals are ethically and legally binding even when the outcome is death
+B) The physician should administer the transfusion — life preservation overrides religious objection
+C) The decision requires court approval before either option can be pursued
+D) The physician should find a compromise treatment that respects religious constraints",A
+tscp_norm_conflict_0017,norm_conflict,"Social norm A: Do not bring up controversial political topics at the dinner table. Social norm B: Speak up when you witness injustice. At a family dinner, a relative makes an offhand racist comment. Do norms A and B conflict here, and if so, which prevails?","A) No conflict — the racist comment is not a legitimate political topic and norm A does not apply
+B) There is a genuine conflict, and norm B generally prevails — the obligation to challenge racism is typically considered more morally urgent than dinner-table decorum
+C) Norm A prevails — family dinners should be preserved from all controversy regardless of content
+D) There is a genuine conflict with no principled resolution — each person must decide for themselves",B
+tscp_norm_conflict_0018,norm_conflict,"In Victorian England, the norm for women was to be self-effacing and defer to men's opinions. A Victorian woman who boldly stated her own opinions was considered socially deviant. From the standpoint of Victorian descriptive norms (not modern values), was she violating a real social norm?","A) No — norms based on unjust premises are not real norms
+B) Yes — descriptively, she was violating the operative norm of her social context, even though the norm itself was unjust
+C) It depends on her social class — upper-class Victorian women had more latitude
+D) It depends on the specific opinions expressed and the audience present",B
+tscp_norm_conflict_0019,norm_conflict,A school norm prohibits sharing food due to allergy policies. A student's cultural norm requires offering food to others as a sign of respect. The student shares food and another student has a mild allergic reaction. What is the most accurate normative analysis of the food-sharing student's behavior?,"A) The student was wrong — institutional safety norms supersede personal cultural expression norms
+B) The student was right — cultural respect norms are fundamental and safety norms should accommodate them
+C) The student acted in good faith according to their norms but caused harm — both the good faith and the harm are real
+D) The student was only wrong if they were previously informed of the other student's allergy",A
+tscp_norm_conflict_0020,norm_conflict,"In a highly hierarchical organization, a junior member has identified a serious error in a senior leader's plan. Norm 1: Deference to hierarchy means staying silent in formal meetings. Norm 2: Organizational duty to prevent harm means speaking up. Which factors would most likely determine which norm prevails in practice (not ideally)?","A) The severity of the potential error and the organizational culture around psychological safety
+B) The junior member's personal courage regardless of context
+C) The seniority of the leader involved — the more senior, the more deference norms dominate
+D) Whether the error has already been noticed by others",A
+tscp_norm_conflict_0021,norm_conflict,The norm of reciprocity says you should return favors. A person gives a gift to someone who cannot reciprocate. The recipient feels uncomfortable. Which interpretation of the norm conflict is most sociologically accurate?,"A) The giver violated a norm by creating an unpayable debt
+B) The recipient is overapplying the reciprocity norm — gifts are exempt from reciprocity requirements
+C) A gift that cannot be reciprocated creates a power asymmetry and can function as a form of social dominance, making the recipient's discomfort a norm-conflict response
+D) The discomfort is purely psychological and has no normative basis",C
+tscp_norm_conflict_0022,norm_conflict,"Norm A in research: Publish all findings, including null results. Norm B in research: Do not publish work that cannot withstand criticism. A researcher has a null result that seems methodologically sound but was not pre-registered. Under contemporary open science norms, which norm should prevail?","A) Norm B — publication requires a high bar of methodological rigor, and lack of pre-registration disqualifies the result
+B) Norm A — publishing null results is crucial to science even without pre-registration; post-hoc methods disclosure is sufficient
+C) Both norms are equally valid and the researcher must choose based on personal judgment
+D) Norm A prevails for the result itself, but the lack of pre-registration should be disclosed prominently in the publication",D
+tscp_norm_conflict_0023,norm_conflict,"In ancient Rome, it was normative for a host to taste wine first (to prove it was not poisoned). In modern Western contexts, the host pours for guests first. A modern host pours their own wine first at a dinner party. Guests notice. Which most accurately characterizes the situation?","A) The host violated the modern hospitality norm, regardless of ancient precedent
+B) The host's action is neutral — the modern norm is arbitrary etiquette with no moral weight
+C) The host may be unaware of the norm, or may be from a culture with different pouring norms — violation is real but minor
+D) The host is using a historically informed practice and cannot be faulted",C
+tscp_norm_conflict_0024,norm_conflict,"In some cultures, direct eye contact in conversation signals respect and engagement. In others, prolonged eye contact is aggressive or disrespectful. Two people from these contrasting cultures meet. One maintains eye contact throughout; the other averts their eyes. Who, if anyone, is behaving 'correctly'?","A) The person maintaining eye contact — active engagement is universally positive
+B) The person averting eyes — modesty and deference are universally respectful
+C) Neither — both are following their own culturally appropriate norms; 'correct' is undefined without a shared normative frame
+D) Both are wrong — international interactions require adopting neutral behavior such as intermittent eye contact",C
+tscp_norm_conflict_0025,norm_conflict,"The norm of free speech says people may express unpopular opinions. The norm of social cohesion says harmful speech should be suppressed. A speaker gives a factually accurate but psychologically harmful speech to a vulnerable audience. In a liberal democratic framework, what is the most defensible position regarding this conflict?","A) Free speech always wins — truth cannot be harmful in a liberal democracy
+B) Social cohesion wins — harm prevention is the foundational purpose of liberal democracy
+C) The conflict is genuine and context-dependent — liberal frameworks acknowledge both norms and resolve through mechanisms like harm principle calculus, not absolute rules
+D) Factual accuracy automatically makes speech protected regardless of harm",C
+tscp_norm_conflict_0026,norm_conflict,"A friend group norm is to always celebrate each other's achievements publicly. One member prefers to keep achievements private. When the group publicly celebrates this member's promotion without asking, they are upset. Whose norm should prevail in this scenario?","A) The group's norm — community celebration is a collective right
+B) Neither — a compromise should be negotiated going forward
+C) The group's norm applies in all cases where the achievement affects the group
+D) The individual's norm — individual preferences about disclosure of their own achievements override group celebration rituals",D
+tscp_norm_conflict_0027,norm_conflict,"In the 18th century, dueling was a legitimate norm for resolving honor disputes among gentlemen. Laws against it existed but were rarely enforced. A gentleman of the era who declined a duel was considered a coward. From a descriptive normative standpoint (not moral evaluation), was declining the duel a norm violation?","A) No — since the practice was illegal, the legal norm superseded the social norm
+B) Only if the original offense was serious — dueling norms were graduated by severity
+C) Yes — regardless of legal status, the operative social norm in that community required accepting the duel, and declining violated that norm
+D) No — honor norms are always voluntary and declining never constitutes a violation",C
+tscp_norm_conflict_0028,norm_conflict,An employee is asked by their manager to do something that is legal but unethical. The norm of professional obedience says follow managerial directives. The norm of personal integrity says refuse unethical acts. Which response is most consistent with virtue ethics?,"A) Follow the directive — professional virtue includes obedience and stability
+B) Refuse — virtue ethics prioritizes character and integrity over institutional role compliance
+C) Follow the directive while internally objecting — compartmentalization preserves both norms
+D) Comply but report the directive to a higher authority, balancing obedience and integrity",B
+tscp_norm_conflict_0029,norm_conflict,Contemporary norm: punctuality is respect for others' time. Older norm in some cultures: punctuality is obsessive and relationships matter more than schedules. A person shows up 30 minutes late to a business meeting with someone from a punctuality-norm culture. The latecomer argues their culture makes this acceptable. What is the most defensible normative response?,"A) The latecomer is correct — cultural norms are always self-validating
+B) The meeting organizer should accommodate cultural differences without criticism
+C) Neither norm has priority — both parties should have negotiated expectations beforehand
+D) The latecomer bears responsibility for adaptation — in formal professional cross-cultural encounters, the receiving context's norms typically apply, especially when the latecomer knows the expectation",D
+tscp_norm_conflict_0030,norm_conflict,"The norm of informed consent says participants must understand what they agree to. The norm of research validity says some studies require deception for unbiased results. A study uses mild deception with a full debriefing afterward. Under APA ethical standards, is this practice permissible?","A) No — informed consent is absolute and no deception is permissible
+B) Only if participants are told beforehand that some form of deception may occur
+C) Yes, but only for studies that have no alternative methodology and are IRB-approved
+D) Yes — APA standards permit mild deception when it is necessary for validity, participants are not harmed, and full debriefing occurs",D
+tscp_deception_0001,deception,"Ann tells Ben that Carol is spreading rumors about him. In fact, it is Ann spreading the rumors. Ben confronts Carol, who denies spreading any rumors. Ben assumes Carol is lying. From Carol's perspective, which of the following best describes her epistemic situation when Ben confronts her?","A) Carol knows why Ben is confronting her and knows she is falsely accused
+B) Carol does not know why Ben is confronting her, since Ann deceived both of them
+C) Carol suspects Ann is behind Ben's accusation but lacks evidence
+D) Carol has insufficient information to determine what is happening",D
+tscp_deception_0002,deception,"A story is narrated in first person by a character who describes their friend as 'perfectly trustworthy.' Later in the story, readers learn the narrator had been lying throughout about their own identity. What should a careful reader conclude about the narrator's description of their friend's trustworthiness?","A) The friend is untrustworthy — the narrator's lies taint all their claims
+B) The friend is trustworthy — the narrator's lies were about their identity, not about the friend
+C) The trustworthiness claim is unreliable — an unreliable narrator's assessments of others cannot be automatically trusted
+D) The reader needs more information about whether the narrator's lies are relevant to the friend's character",C
+tscp_deception_0003,deception,"A manager asks their team, 'Does everyone think this plan will work?' All team members say yes. A researcher studying false consensus effects observes this exchange. What is the researcher's most likely conclusion about the team members' private beliefs?","A) Some or all team members may privately doubt the plan but publicly conform due to social pressure, authority dynamics, or groupthink
+B) The team genuinely believes the plan will work — unanimous positive responses indicate real consensus
+C) The team's public affirmation is a false consensus only if the plan later fails
+D) False consensus effects only apply when team members have been explicitly asked to agree, not when asked for honest assessment",A
+tscp_deception_0004,deception,Danny is aware that Ellie is lying to him. Ellie does not know Danny knows she is lying. Danny decides to go along with Ellie's lie to gather more information. Ellie now tells Fran that Danny fully believes her. What is Fran's false belief in this scenario?,"A) Fran falsely believes Ellie is honest
+B) Fran falsely believes Danny believes Ellie's lie
+C) Fran falsely believes Danny is unaware of Ellie's deception
+D) Both B and C — Fran's false belief about Danny's credence and knowledge are the same false belief",D
+tscp_deception_0005,deception,"George confesses to a crime. His confession contains several accurate details known only to the perpetrator. The investigator concludes George is guilty. However, George is innocent — he had been told those details by the actual perpetrator. Which cognitive error is the investigator making?","A) Confirmation bias — the investigator is looking for evidence that confirms the confession
+B) The investigator is applying a valid heuristic — inside knowledge is a strong guilt indicator
+C) The investigator is committing the base rate fallacy by ignoring how rarely innocent people confess
+D) The investigator is failing to consider an alternative explanation for the accurate details (secondhand knowledge from the real perpetrator)",D
+tscp_deception_0006,deception,"Helen tells Ivan: 'I heard you said you don't trust me.' Ivan never said this. Ivan denies it but Helen insists, 'That's not what I heard.' What is the most epistemically cautious interpretation of this exchange?","A) Helen is lying to manipulate Ivan
+B) Helen was lied to by a third party who told her Ivan said this
+C) Helen misremembered or misattributed a comment she heard from someone else
+D) All of A, B, and C are live possibilities — the scenario as described does not distinguish between them",D
+tscp_deception_0007,deception,A study asks participants: 'What percentage of other people do you think share your view on issue X?' Participants consistently overestimate the percentage. This is the false consensus effect. Which explanation best accounts for this effect?,"A) People lie about their views to seem more mainstream
+B) People selectively socialize with others who share their views, creating a biased sample for estimation
+C) People have a self-serving motivation to believe they are in the majority
+D) B and C together provide the most comprehensive explanation — both selective exposure and motivational factors contribute",D
+tscp_deception_0008,deception,"Jack is a double agent. His first employer believes he is loyal to them. His second employer believes he is loyal to them. Jack is actually loyal to a third, secret employer neither knows about. What does Jack's first employer believe Jack's second employer believes about Jack's loyalty?","A) The first employer believes the second employer thinks Jack is loyal to them (the second employer)
+B) The first employer believes the second employer has no idea Jack is working for anyone else
+C) The first employer believes the second employer suspects Jack's loyalty is split
+D) The first employer does not know a second employer exists, so cannot have a belief about the second employer's beliefs",D
+tscp_deception_0009,deception,"Karen is acting happy at work, though she is actually experiencing depression. Most coworkers think she is genuinely happy. One coworker, Luis, suspects she is struggling but says nothing. Karen assumes all coworkers believe she is happy. What does Luis believe Karen believes about Luis's perception of her?","A) Luis believes Karen thinks he sees through her performance
+B) Luis believes Karen thinks he believes she is genuinely happy
+C) Luis believes Karen knows he suspects something but is not sure he knows it is depression
+D) Luis does not have a specific belief about Karen's belief about his perception",B
+tscp_deception_0010,deception,"In a murder mystery, the narrator describes Suspect A acting suspiciously. Suspect B acts calmly. The reader suspects A. The twist: the narrator is Suspect B. Which reading strategy would have most helped the reader avoid being misled?","A) Paying closer attention to the physical evidence described
+B) Assuming all suspects are equally guilty at the outset
+C) Questioning the narrator's motivation to characterize other characters' behavior as suspicious
+D) Looking for inconsistencies in Suspect A's alibi",C
+tscp_deception_0011,deception,Maria says she does not care about recognition at work. She says this to her manager. Research on false consensus effects and social desirability suggests what about Maria's stated preference?,"A) Maria likely does not care about recognition — intrinsically motivated employees are common
+B) Maria's statement is probably false — most employees value recognition, and she may be understating her preferences to appear professionally selfless
+C) We cannot infer anything about Maria's private preferences from a single socially situated statement
+D) Maria's statement is a reliable signal because contradicting one's manager would be easier if one were lying",C
+tscp_deception_0012,deception,"Ned tells an elaborate, emotionally compelling story about being wronged. Listeners sympathize with him. Researchers studying source monitoring ask: what cognitive mechanism most explains why listeners do not question Ned's account?","A) Listeners lack the intelligence to detect deception
+B) Listeners implicitly trust Ned because he is known to them
+C) Emotional engagement with a narrative reduces critical evaluation — vivid stories are processed experientially, not analytically
+D) Deception is always undetectable in natural conversation",C
+tscp_deception_0013,deception,"Olivia is pretending to agree with her group's decision. Paul, an outsider, asks the group for an honest show of hands on the decision. Olivia raises her hand. Paul concludes the group is unified. What is the most accurate characterization of Olivia's action?","A) Olivia is committing a deception against Paul but not against the group
+B) Olivia is deceiving both Paul and the group
+C) Olivia is not deceiving anyone — public hand-raising is a performative act, not a sincere assertion
+D) Olivia is deceiving Paul but the group already knows her true view, so they are not deceived",A
+tscp_deception_0014,deception,Quinn writes a memoir describing her childhood as happy. Later interviews reveal she experienced significant trauma she did not disclose in the memoir. Readers who loved the 'happy memoir' now feel deceived. Is their feeling of deception well-founded?,"A) Yes — a memoir implies complete honesty about the author's life
+B) No — memoirists are not obligated to disclose all experiences; selective disclosure is not deception
+C) Partially — the memoir's framing as 'happy' creates an implicit false representation that reasonable readers would rely on
+D) Only if Quinn explicitly described her childhood as without trauma",C
+tscp_deception_0015,deception,A study asks 100 people whether they believe most other people would cheat if guaranteed not to be caught. 70% say yes. The same study asks whether they personally would cheat under the same conditions. Only 20% say yes. What is this asymmetry most precisely an example of?,"A) False consensus effect — people believe others share their own behavior patterns
+B) False uniqueness effect — people believe they are more virtuous than average, combined with projection of their expectations onto others
+C) Social desirability bias only — people lie about their own behavior but answer honestly about others
+D) Both the false uniqueness effect and social desirability bias contribute, making C incomplete and B more comprehensive",D
+tscp_deception_0016,deception,"Ryan is undercover in an organization he is investigating. He befriends members of the organization. From the perspective of the organization members, what is the most accurate description of their relationship with Ryan?","A) They have a genuine friendship that happens to be instrumentally exploited
+B) They have no genuine relationship — all interactions with an undercover agent are inherently void of authenticity
+C) The nature of the relationship depends on which party's perspective and purpose defines it
+D) They have a parasocial relationship — the emotion is real but the connection is one-sided",C
+tscp_deception_0017,deception,"Sarah asks Tom if he likes her new haircut. Tom does not like it but says, 'It suits you.' Sarah later tells a friend: 'Tom thinks my haircut looks great.' What error has Sarah made?","A) Sarah has over-interpreted a polite hedge as an enthusiastic endorsement
+B) Sarah has made a deceptive statement — she knows Tom's compliment was likely polite
+C) Sarah has made no error — 'it suits you' genuinely means the haircut looks great
+D) Sarah has committed an attribution error by inferring Tom's true preference from his stated preference",A
+tscp_deception_0018,deception,"A company announces excellent quarterly results. Internally, management knows the results were boosted by one-time factors that will not recur. The announcement does not mention this. Is this communication deceptive?","A) No — the results are factually accurate and no false statements were made
+B) Yes — omitting material context that would affect investor interpretation constitutes deception through selective disclosure
+C) Only if legally required disclosures were omitted
+D) It depends on whether analysts are sophisticated enough to identify one-time factors themselves",B
+tscp_deception_0019,deception,"Uma tells Vera: 'I would never lie to you.' Vera repeats this to Will: 'Uma says she's completely honest with me.' Will, who knows Uma lies frequently to others, thinks to himself that Uma's claim is self-serving. What reasoning error might Will be making in dismissing Uma's claim to Vera?","A) Will may be overgeneralizing Uma's dishonesty with others to assume she is also dishonest with Vera, missing that people can be selectively honest with specific trusted individuals
+B) Will is making no error — Uma's established dishonesty pattern is a valid predictor of deception
+C) Will is committing the fundamental attribution error by attributing Uma's general dishonesty to character rather than situation
+D) Will is engaging in confirmation bias, but this is a correct bias to apply given Uma's track record",A
+tscp_deception_0020,deception,"A narrator in a novel says: 'I am telling you only the facts, with no interpretation.' A literary scholar points out this is itself a rhetorical claim that serves the narrator's agenda. Why is the scholar correct?","A) All facts are interpretations — there is no view from nowhere, so claiming to give only facts is necessarily false
+B) The narrator's selection of which facts to include is itself an interpretive act, even if individual facts are accurate
+C) The claim creates trust in the narrator, which is a persuasive effect that serves the narrator's agenda
+D) All of the above — A, B, and C each capture a different reason the scholar is correct",D
+tscp_deception_0021,deception,Xavier claims credit for a project he did not lead. Most people at the meeting have no way to verify this. Two people know he is lying but say nothing. What is the most accurate description of the false consensus Xavier is creating?,"A) Xavier is creating the false impression that he led the project, which most people will adopt as consensus because of the social cost of challenging him publicly
+B) Xavier is establishing a false consensus that his leadership was real, supported by the silence of those who know the truth
+C) No false consensus exists — only a false belief in individual minds
+D) B is correct — silence by informed parties contributes to the consensus formation, making this more than individual false beliefs",D
+tscp_deception_0022,deception,"Yolanda presents herself as an expert on a topic she has only superficially studied. Her confident presentation convinces her audience. One audience member, Zack, privately doubts her expertise but says nothing. From Zack's perspective, does his silence make him complicit in Yolanda's deception of the rest of the audience?","A) No — Zack has no obligation to challenge speakers he privately doubts
+B) Yes — silence in the face of known deception constitutes passive complicity
+C) Only if Zack has a special duty of care toward the audience (e.g., he is the event organizer)
+D) It depends on the magnitude of harm the deception causes",D
+tscp_deception_0023,deception,"Adam is asked to describe the event that occurred. Adam says, 'I arrived and saw the window broken.' In legal testimony, what is the significance of Adam saying 'I saw the window broken' rather than 'the window was broken'?","A) None — both expressions describe the same factual state
+B) 'I saw the window broken' is an eyewitness claim; 'the window was broken' states a fact — the personal-perspective formulation is more legally cautious
+C) 'I saw the window broken' implies Adam may have witnessed the breaking; 'the window was broken' states only that the broken state existed when he arrived
+D) Legal testimony requires factual statements, so 'I saw' language is preferred as it is more accurate",C
+tscp_deception_0024,deception,Beth says she is 'fine' after a difficult personal loss. Her friend Carl believes her. A psychologist studying emotional masking notes that 'I'm fine' is frequently a masking statement. What is the epistemically most defensible position Carl should take about Beth's emotional state?,"A) Carl should take Beth's statement at face value — she knows her own state better than anyone
+B) Carl should assume Beth is masking — 'I'm fine' after loss is typically not genuine
+C) Carl should note that 'I'm fine' is an ambiguous signal in this context and check in again later rather than accepting it as definitive
+D) Carl should probe further immediately, since accepting 'I'm fine' is emotionally negligent in a loss context",C
+tscp_deception_0025,deception,"In a political debate, Candidate A says: 'My opponent has never publicly supported increased education funding.' This is technically true — the opponent has supported it in private meetings but never in public statements. Is Candidate A's statement deceptive?","A) No — the statement is factually accurate
+B) Partially — it is a misleading truth but not outright deception
+C) Yes — the statement creates a misleading impression by omitting context that would substantially change the listener's inference
+D) It depends on whether Candidate A knew about the opponent's private support",C
+tscp_deception_0026,deception,"Dan keeps a detailed diary and writes: 'I acted purely out of kindness, with no selfish motive.' A psychologist reviewing the diary suspects unconscious self-serving motivation. What is the key epistemological problem with using personal diary entries as evidence of internal motivation?","A) Diaries are private and thus not valid data sources
+B) The author cannot reliably introspect on motivations that are unconscious, so self-reports of motivation have known validity limits
+C) Diary entries are retrospective and subject to reconstruction bias
+D) Both B and C are genuine epistemological problems that limit the evidential value of self-reported motivation",D
+tscp_deception_0027,deception,"Ella is aware she is being observed and changes her behavior accordingly. She knows her observer, Frank, knows she is aware of being observed. Frank knows Ella knows he knows. In this condition, what does Frank most rationally observe about Ella's behavior?","A) Frank observes Ella's natural behavior — mutual awareness of the observation cancels the observer effect
+B) Frank observes Ella performing what she believes a well-observed person should look like, given the known observation
+C) Frank observes Ella performing what she believes someone who knows they are observed would perform, knowing he knows
+D) The behavior is uninterpretable — mutual meta-awareness makes all observation uninformative",C
+tscp_deception_0028,deception,A whistleblower releases documents showing their employer committed fraud. The employer publicly accuses the whistleblower of being a disgruntled employee with personal grievances. Media covers 'both sides.' What logical error are the media outlets most likely committing?,"A) False equivalence — treating a factual accusation supported by documents as equivalent to an ad hominem counterattack
+B) Bothsidesism is always valid — neutral coverage of conflict is journalistically required
+C) The employer's response is relevant because motive can indicate whether documents are authentic
+D) The media has no error — presenting both claims is standard practice",A
+tscp_deception_0029,deception,"Grace is playing a role-playing game in which she pretends to be a villain. She gives a persuasive speech advocating for views she finds repugnant. After the game, her co-players are slightly more sympathetic to those repugnant views. Which psychological phenomenon best explains this outcome?","A) Social contagion — views spread through social groups regardless of framing
+B) Attitude inoculation — hearing extreme views makes people more resistant to them
+C) Illusory truth effect — repeated exposure to even framed-as-fictional claims increases their perceived validity
+D) In-group bias — co-players trust Grace and therefore adopt her stated views",C
+tscp_deception_0030,deception,"Harry always tells different versions of a story to different people. When asked directly, 'Is what you told me true?', he says 'Yes.' Is Harry's 'Yes' necessarily a lie, given his habit of varying his stories?","A) Yes — someone who tells different versions of a story cannot truthfully claim any version is true
+B) No — Harry could believe the version he told this specific person is true, even if he told others different versions for different reasons
+C) Yes — Harry's pattern establishes that he views truth as malleable, making his 'Yes' meaningless
+D) It cannot be determined without knowing whether Harry believes the content of what he told this specific person",D
+tscp_incomplete_0001,incomplete,"A hiring manager notes that Applicant A went to a prestigious university and Applicant B went to a state school. Without any other information, the manager assumes Applicant A is more competent. What critical information is missing before this inference is warranted?","A) The specific fields of both applicants' degrees
+B) Their grades, relevant experience, reference quality, and performance on any assessments — university prestige alone is insufficient to infer competence
+C) The ranking of the state school relative to the prestigious university
+D) Whether the prestigious university is known for the relevant field",B
+tscp_incomplete_0002,incomplete,You learn that 90% of people who committed a certain type of fraud had a specific personality trait. You meet someone with that trait. What is the most important missing piece of information before concluding they likely committed fraud?,"A) The base rate of that personality trait in the general population — a common trait might mean most trait-holders are innocent
+B) Their prior criminal record
+C) The severity of the fraud type
+D) Whether the 90% statistic was derived from a representative sample",A
+tscp_incomplete_0003,incomplete,"Carol is described as 'quiet, bookish, and detail-oriented.' You are told she works in one of two fields: librarianship or investment banking. Most people say she is probably a librarian. What reasoning error does this reflect?","A) Stereotyping — the description should not influence occupational guesses
+B) Availability bias — librarians come to mind more easily than bankers
+C) Confirmation bias — people want the stereotype to be true
+D) The representativeness heuristic — matching description to stereotype while ignoring the base rates of each occupation (far more investment bankers than librarians)",D
+tscp_incomplete_0004,incomplete,"In a social setting, Dan has been reserved and spoken little all evening. Someone concludes Dan is unfriendly. What is the most important missing contextual information for this inference?","A) The situational factors: Is this a noisy environment? Is Dan unwell? Does he know anyone else at the event? Does he speak the dominant language fluently?
+B) Dan's general personality — is he an introvert?
+C) Whether Dan has spoken to the specific person making the inference
+D) Dan's previous behavior at similar events",A
+tscp_incomplete_0005,incomplete,"A neighborhood has experienced a spike in car thefts. A resident notes that a particular person, who moved to the area recently, 'looks suspicious.' What is missing before this observation is meaningful evidence of anything?","A) A specific behavioral description beyond 'looks suspicious' — physical appearance or novelty alone is not evidence of criminal activity
+B) The new resident's employment history
+C) Whether other neighbors share this perception
+D) The new resident's reason for moving to the area",A
+tscp_incomplete_0006,incomplete,"Ella just received a short, terse response to her long email. She concludes her colleague is annoyed with her. What information would most change this inference if known?","A) The tone of all the colleague's previous emails to Ella
+B) That the colleague was answering quickly between meetings and routinely sends terse responses to all emails
+C) Whether the colleague is known to be passive-aggressive
+D) The subject matter of the original email",B
+tscp_incomplete_0007,incomplete,Finn is an excellent public speaker. He is being considered for a management role. A committee member argues this makes him well-suited to lead. What is the key missing element in this reasoning?,"A) Whether Finn is popular with his current team
+B) Whether public speaking skill correlates with management effectiveness — good communication is one skill, but managing people involves many others not evidenced by public speaking
+C) The size of the organization Finn would manage
+D) Whether Finn has previously held leadership roles",B
+tscp_incomplete_0008,incomplete,Grace married into a very wealthy family. Her friends assume she is now happy because she has no financial worries. What does research on subjective well-being indicate is missing from this reasoning?,"A) Information about Grace's relationship quality with her spouse and in-laws, social connections, sense of purpose, and autonomy — wealth predicts well-being only modestly above a threshold
+B) Information about the specific level of wealth involved
+C) Whether Grace was happy before the marriage
+D) Whether Grace's own family is also wealthy",A
+tscp_incomplete_0009,incomplete,A study reports: 'Students who eat breakfast score higher on standardized tests.' A school decides to provide breakfast to all students to raise test scores. What is the most critical missing causal element that undermines this policy decision?,"A) Whether breakfast causes higher scores or whether wealthier, more prepared students both eat breakfast and score higher (confounding)
+B) The specific type of breakfast that was consumed in the study
+C) Whether the test score gap was statistically significant
+D) The grade levels studied",A
+tscp_incomplete_0010,incomplete,Henry is described as having grown up in poverty and having worked hard to get a college education. A listener concludes he is resilient and determined. Which aspect of Henry's actual character cannot be inferred from this information?,"A) His specific degree field
+B) His current income level
+C) Whether his persistence in education reflects resilience in other domains — survival in one context does not predict character uniformly across all domains
+D) Whether he had help from others along the way",C
+tscp_incomplete_0011,incomplete,Iris tells a story about a coworker who 'always takes credit for others' work.' The listener forms a strong negative opinion of the coworker. What is the most important missing information?,"A) The coworker's job title
+B) Whether the behavior was reported to HR
+C) Whether other coworkers have noticed the same pattern
+D) Iris's relationship with the coworker and potential motivation to portray them negatively — a single-source account of third-party behavior is inherently unreliable",D
+tscp_incomplete_0012,incomplete,A man at a job fair is wearing a suit. He is assumed to be a job-seeker. What is missing before this inference is reliable?,"A) His age and physical appearance
+B) Whether he is carrying a portfolio or resume
+C) Whether recruiters also wear suits at this event, and what other contextual cues (badge, table placement) indicate his role
+D) The industry of the job fair",C
+tscp_incomplete_0013,incomplete,"In a social media post, Jake writes: 'Just got some really hard news.' His followers assume someone close to him died. What does this illustrate about social inference from partial information?","A) Social media posts reliably signal emotional state through topic selection
+B) Followers are performing empathetic projection, mapping their own 'hard news' schema onto a highly ambiguous signal
+C) 'Hard news' is a conventionalized death euphemism and the inference is pragmatically sound
+D) Followers are engaging in availability bias, overweighting dramatic scenarios",B
+tscp_incomplete_0014,incomplete,Kim is a nurse who corrects a physician's medication dosage order. The physician accepts the correction. A bystander concludes this is evidence that Kim has better medical knowledge than the physician in general. What is missing from this generalization?,"A) Kim's specific nursing specialization
+B) The type of medication involved
+C) One correct intervention in a specific narrow domain does not support a claim of generally superior knowledge — this is an overgeneralization from a single data point in a specific context
+D) Whether the physician is known to make medication errors",C
+tscp_incomplete_0015,incomplete,Lena and Max argue frequently. Their mutual friend concludes their relationship is unhealthy. Which piece of information would most substantially challenge this conclusion?,"A) The duration of their relationship
+B) Whether other couples in their friend group also argue
+C) That both Lena and Max experience the arguing as constructive, engage respectfully, and feel the relationship is fulfilling
+D) Whether the arguments have ever led to physical altercations",C
+tscp_incomplete_0016,incomplete,Nina was raised by strict parents and is now a strict parent herself. A developmental psychologist cautions against inferring that strict parenting causes strict parenting in offspring. What alternative explanation must be considered?,"A) Nina may have rebelled against strict parenting and become strict by overcompensation
+B) Strict parenting styles may correlate with genetic temperament traits that Nina inherited and passed on, not with childhood experiences
+C) The causal chain could run in either direction — Nina's own temperament may have elicited strict parenting
+D) All of A, B, and C represent alternative explanations that must be ruled out before inferring social transmission",D
+tscp_incomplete_0017,incomplete,"Owen applied for a promotion and did not get it. He concludes his manager does not value him. Which scenario, if true, would make this inference most clearly unwarranted?","A) The manager gave the promotion to someone more senior
+B) The promotion was eliminated due to budget cuts and no one was promoted
+C) The manager gave the promotion to the manager's friend
+D) Owen had fewer years of experience than the successful candidate",B
+tscp_incomplete_0018,incomplete,A community has a high rate of a certain disease. Health officials immediately launch a campaign targeting lifestyle factors. What is the most significant missing investigation before lifestyle factors can be implicated?,"A) Whether environmental, genetic, or occupational factors — independent of lifestyle — could explain the elevated rate
+B) The community's income levels
+C) Whether residents are aware of the campaign
+D) The community's access to healthcare for early diagnosis",A
+tscp_incomplete_0019,incomplete,Paula sends an email that generates no reply for three days. She interprets the silence as disapproval of her proposal. What reasoning principle does this violate?,"A) The principle of charity — she should assume positive intent
+B) Non-response is ambiguous — it could reflect agreement, low priority, vacation, oversight, or avoidance; absence of evidence is not evidence of disapproval
+C) The principle of proportionality — three days is too short a period to draw any conclusion
+D) All of A, B, and C apply, though B is the most fundamental epistemic error",D
+tscp_incomplete_0020,incomplete,"Quinn, an ethnic minority, did not get a job at a company known to have diversity challenges. She concludes she was discriminated against. What is the minimum set of information needed to evaluate whether discrimination is the most likely explanation?","A) Comparative data on the hiring rates of equally qualified minority and majority candidates at this company, as well as the specific qualifications assessed
+B) The names of the other candidates
+C) The demographics of the hiring committee
+D) Whether Quinn filed a formal discrimination complaint",A
+tscp_incomplete_0021,incomplete,A teacher notices that students who sit in the front row tend to get higher grades. She rearranges all students to sit in the front. What causal inference error is she making?,"A) Circular reasoning — she is using grades to justify seat assignment
+B) Confusing correlation with causation — motivated students may both choose front seats and study harder; moving students may not transfer the motivation
+C) Selection bias — the front row has limited seats and her sample is small
+D) Anchoring — she is overweighting the first observed pattern",B
+tscp_incomplete_0022,incomplete,"Rosa and Sam have been friends for ten years. Recently, Sam has been distant. Rosa assumes Sam is angry with her. What systemic information gap makes Rosa's inference unreliable?","A) Rosa has only her own subjective perception of the relationship — Sam may be dealing with personal difficulties entirely unrelated to Rosa, which Rosa would not necessarily know
+B) Rosa does not know the precise duration of Sam's distancing
+C) Ten years of friendship makes anger less likely, so the inference is statistically improbable
+D) Rosa should check her own behavior before assuming Sam's change is about her",A
+tscp_incomplete_0023,incomplete,Tom witnesses two strangers arguing loudly in a public space. He assumes the relationship is toxic. What is the most significant missing context?,"A) Whether the argument is typical for their relationship or an isolated event — a single observed interaction cannot characterize an ongoing relationship
+B) The strangers' genders
+C) Whether the argument is in a language Tom understands
+D) Whether the argument appears to be escalating",A
+tscp_incomplete_0024,incomplete,Uma hears that a person was 'let go' from their last job. She concludes they were fired for poor performance. What important alternative information is missing?,"A) The industry and job type
+B) 'Let go' could describe mutual agreement, layoffs, restructuring, or resignation under pressure — it is an ambiguous phrase that does not specify cause or who initiated departure
+C) The person's employment history before that job
+D) The size of the company they left",B
+tscp_incomplete_0025,incomplete,Vera notes that children of parents who read to them daily perform better in school. A policy is proposed: mandate daily reading by parents. What is the most fundamental missing element before this policy can be expected to work?,"A) Whether it is the reading itself or the correlated factors (stable home, engaged parenting, socioeconomic status) that drive the outcome — mandating reading cannot mandate the correlated factors
+B) The specific books that should be read
+C) The age range of children for whom the effect has been demonstrated
+D) Whether teachers support such a mandate",A
+tscp_incomplete_0026,incomplete,Will is described as a 'natural leader' by his coworkers. He is put in charge of a team project. What is missing before this decision is well-supported?,"A) Will's age and seniority
+B) 'Natural leader' reflects peer perception, not demonstrated management skill — leading informally in peer groups differs from formal project management, and the relevant competencies (planning, accountability, conflict resolution) are not assessed by the description
+C) Whether Will wants the responsibility
+D) The size and nature of the project",B
+tscp_incomplete_0027,incomplete,Xena sees that her neighbor's lights are always off by 8pm. She concludes her neighbor goes to bed early. What alternative explanations are missing from her inference?,"A) The neighbor might travel frequently or keep lights off to save electricity or have a partner with different habits
+B) The neighbor might be using only backlit screens (phone, tablet) after 8pm, making 'lights off' an unreliable proxy for sleep time
+C) The neighbor might be experiencing financial hardship and minimizing electricity use
+D) All of A, B, and C represent legitimate alternative explanations that should prevent confident inference",D
+tscp_incomplete_0028,incomplete,Yolanda's team morale improved after she started holding weekly check-ins. Her manager concludes the check-ins caused the improvement. What alternative explanations is the manager missing?,"A) A difficult project ended around the same time, or a disruptive team member left — the improvement could be due to factors unrelated to the check-ins
+B) The check-ins may have made existing problems visible rather than solving them
+C) The manager's attention and interest itself (not the check-in format) improved morale
+D) All of A, B, and C are plausible alternative explanations the manager has not ruled out",D
+tscp_incomplete_0029,incomplete,Zack reports that his new medication is working — he has felt better since starting it. What is the most important missing condition before concluding the medication caused improvement?,"A) The dosage and frequency of the medication
+B) Whether other patients on the same medication improved
+C) A control condition — Zack's improvement could reflect natural symptom progression, placebo effect, regression to the mean, or concurrent life changes unrelated to the medication
+D) The length of time Zack has been taking the medication",C
+tscp_incomplete_0030,incomplete,A manager is reviewing two candidates. Candidate A has an impressive resume; Candidate B has a modest resume but gave a very engaging interview. The manager says: 'I'll go with my gut — B really impressed me.' What is the most critical information gap in the manager's decision process?,"A) Whether the interview performance predicts on-the-job performance for this specific role, or whether resume evidence better predicts the relevant competencies — 'gut feel' from interviews has low predictive validity for most roles
+B) Whether the interview was conducted in the same format for both candidates
+C) Whether the manager has previously hired successfully based on gut feel
+D) The specific competencies the role requires",A
+tscp_emotion_contra_0001,emotion_contra,Amara is smiling broadly while receiving criticism from her manager. Her words are 'Thank you for the feedback.' A Western observer concludes she is genuinely happy to receive the criticism. What is the most likely correct interpretation in a cross-cultural context?,"A) Amara is genuinely pleased — her smile confirms her verbal statement
+B) Amara is masking discomfort with a smile, which in many East and Southeast Asian cultural contexts is a polite display used under stress or to preserve harmony
+C) Amara is being sarcastic — the combination of smile and thanks is an ironic display
+D) Amara is performing professional politeness that has no emotional content",B
+tscp_emotion_contra_0002,emotion_contra,"Ben speaks in a flat, monotone voice while describing his father's death. He does not cry. A listener concludes Ben did not have a close relationship with his father. Which alternative interpretation should be given equal or greater weight?","A) Ben is dissociating or numbing as a grief response — emotional flatness can indicate extreme distress, not absence of feeling
+B) Ben is a naturally flat speaker regardless of emotional content
+C) Ben has already processed his grief and is now at peace
+D) All of A, B, and C are legitimate alternative interpretations that undermine the listener's inference",D
+tscp_emotion_contra_0003,emotion_contra,"Carol's heart is racing, she feels warm, and her palms are sweating. She concludes she is nervous about a presentation. A psychologist notes the physiological arousal is identical to another emotional state. Which?","A) Anger
+B) Sadness
+C) Disgust
+D) Excitement — the physiological signature of anxiety and excitement are nearly identical, and attribution of the state as 'nervousness' reflects cognitive labeling, not distinct physiology",D
+tscp_emotion_contra_0004,emotion_contra,Dan crosses his arms and leans back in a meeting. Popular body language interpretation: he is defensive and closed off. What is the correct assessment of this interpretation?,"A) It is correct — arm crossing reliably signals defensiveness
+B) It is unreliable — single gestures have multiple possible meanings (e.g., cold, comfortable, habitual posture) and should not be interpreted in isolation
+C) It is correct only if Dan also avoids eye contact
+D) It is correct in formal meetings but not in casual settings",B
+tscp_emotion_contra_0005,emotion_contra,Ella receives good news and begins to cry. A friend who did not hear the news concludes something terrible has happened. What does this illustrate about emotional inference from facial cues alone?,"A) Crying reliably signals sadness — the friend's inference is a valid heuristic
+B) The friend should have asked before drawing any inference
+C) Facial expressions without contextual information are ambiguous — tears occur in joy, relief, overwhelm, and sadness
+D) Emotional inference from incomplete cues is always impossible",C
+tscp_emotion_contra_0006,emotion_contra,"Finn says, 'I'm really fine with that decision,' while maintaining eye contact, a steady voice, and relaxed posture. An observer believes he is masking negative feelings. What is the epistemically most defensible conclusion?","A) Finn is masking — congruent cues of agreement are often a more refined form of concealment
+B) There is insufficient evidence of masking — all observable cues are congruent with his verbal statement, and inferring deception without contrary signals is not warranted
+C) Finn is masking — anyone who says 'really fine' instead of 'fine' is overemphasizing acceptance suspiciously
+D) The observer has insider knowledge that justifies the masking inference",B
+tscp_emotion_contra_0007,emotion_contra,Grace laughs loudly at something that is not obviously funny. Which emotional state is least likely to explain this behavior?,"A) Anxiety — nervous laughter is a well-documented response to discomfort or threat
+B) Social performance — laughter is frequently used to signal affiliation and group membership regardless of actual amusement
+C) Deep sadness with no humor — inappropriate laughter can be a clinical indicator of emotional dysregulation
+D) Pure amusement — the question states the thing is not obviously funny, so amusement is least likely",D
+tscp_emotion_contra_0008,emotion_contra,"In a Japanese context, a colleague does not respond to an enthusiastic suggestion with any visible excitement. A Western colleague concludes the Japanese colleague dislikes the suggestion. What cultural misread is occurring?","A) Japanese cultural norms generally value emotional restraint in professional settings — low expressiveness signals neither approval nor disapproval
+B) Japanese workers dislike enthusiastic proposals and the inference is culturally accurate
+C) The colleague is being polite by suppressing their excitement
+D) The low reaction reflects standard introverted behavior, not culture",A
+tscp_emotion_contra_0009,emotion_contra,Harry appears perfectly calm while his company collapses financially. His calmness is interpreted as indifference or sociopathy. What alternative emotional explanation should be considered?,"A) Harry may be experiencing a dissociative stress response, where extreme threat produces emotional blunting rather than visible distress
+B) Harry may be genuinely indifferent — some people do not value their work
+C) Harry may be performing calmness to protect his team from panic, while experiencing intense internal distress
+D) Both A and C are well-documented stress responses that should be considered before concluding indifference",D
+tscp_emotion_contra_0010,emotion_contra,Iris says 'I'm not upset' while her voice is slightly elevated in pitch. Research on vocal deception detection suggests what?,"A) Elevated pitch can indicate emotional arousal (stress, excitement, urgency) or simply naturally varying intonation — it is not a reliable deception indicator alone
+B) Elevated pitch reliably indicates lying — she is upset
+C) Vocal pitch is irrelevant to emotional states
+D) Elevated pitch combined with verbal denial always indicates suppressed anger",A
+tscp_emotion_contra_0011,emotion_contra,Jack tells his friend he is 'a bit tired' after running a marathon. His friend assumes Jack is fine. What error in emotional inference is the friend making?,"A) The friend is taking understatement literally — 'a bit tired' after a marathon likely represents severe physical exhaustion, which Jack is downplaying through typical understatement
+B) The friend should not make inferences about physical state from verbal self-report
+C) 'Tired' is an accurate self-report and the friend is correct
+D) The friend should ask about emotional state, not physical state",A
+tscp_emotion_contra_0012,emotion_contra,Karen is smiling while being told she did not receive a job offer. The recruiter concludes she is 'not that invested in the role.' What is the recruiter missing?,"A) Karen is genuinely not invested — her smile confirms this
+B) Karen may be smiling as an emotional control strategy or social display to maintain dignity, masking disappointment — observable emotional expression in a formal social context is often regulated, not genuine
+C) Karen may have received a better offer and is genuinely relieved
+D) Both B and C are more plausible than the recruiter's conclusion, and the recruiter's inference from a single facial expression is not warranted",D
+tscp_emotion_contra_0013,emotion_contra,"Leo expresses what appears to be anger (raised voice, furrowed brow) during a passionate discussion about a cause he cares about. His partner concludes he is angry at her. What is the most likely misidentification occurring?","A) Leo is indeed angry at his partner and is using the cause as a pretext
+B) Leo's physiological arousal and expressions of passion for a cause are being misattributed as interpersonal anger — high-arousal positive states can appear identical to anger
+C) The partner's inference is correct — anger always has a target
+D) Leo is angry in general and his partner is correctly identifying the emotion but misidentifying the target",B
+tscp_emotion_contra_0014,emotion_contra,Maya says she is 'happy for' a colleague's promotion. Her micro-expression shows a brief flash of contempt. An observer concludes Maya is jealous. Is this conclusion warranted?,"A) Yes — micro-expressions are reliable indicators of true feeling
+B) Yes — contempt in response to another's success is always jealousy
+C) No — micro-expressions are brief involuntary signals that could indicate contempt, but contempt and jealousy are different emotions; the inference of jealousy specifically is overconstrained
+D) It depends on Maya's relationship with the colleague",C
+tscp_emotion_contra_0015,emotion_contra,Nathan is expressionless throughout a deeply moving film. His companion judges him as cold. Which explanation is least well-supported by the evidence?,"A) Nathan is deeply moved but has low emotional expressivity — internalized emotion does not require external display
+B) Nathan has already seen the film and knows the outcome, reducing his emotional reactivity
+C) Nathan is cold and genuinely unmoved, which is the companion's inference
+D) Nathan is suppressing expression out of awareness of being observed in a social context",C
+tscp_emotion_contra_0016,emotion_contra,"Olivia is from a Mediterranean cultural background and uses loud, animated speech as her default communication style. A Northern European colleague interprets this as emotional agitation and anger. What is the colleague's inferential error?","A) The colleague is applying Northern European emotional display norms as if they were universal, when they represent only one cultural style of emotional expression
+B) Loud speech always indicates emotional arousal — the colleague's inference is culturally neutral
+C) The colleague is performing a communication style mismatch that can be solved by Olivia moderating her style
+D) The colleague is correct that Olivia is agitated — cultural background does not change physiological arousal",A
+tscp_emotion_contra_0017,emotion_contra,Paul is asked how he is feeling about a breakup and says 'relieved.' His friends think he must be in denial. When is 'relief' a genuinely accurate emotional response to a breakup?,"A) Never — breakups are objectively losses and relief is a defense mechanism
+B) Only if the relationship was very short
+C) Relief is a genuine and recognized emotional response when a relationship was stressful, coercive, unsatisfying, or where both parties wanted to end it — denial and relief are not equivalent
+D) Relief is only genuine if Paul ended the relationship",C
+tscp_emotion_contra_0018,emotion_contra,Quinn receives a compliment and immediately deflects it by listing her failings. An observer concludes she has low self-esteem. What alternative interpretation should be considered?,"A) In many cultural contexts, deflecting compliments is a norm of modesty that has no necessary connection to self-esteem — it is a social script
+B) The observer is correct — deflection always reflects low self-worth
+C) Quinn is fishing for more compliments by displaying false modesty
+D) Quinn's self-esteem can only be assessed through validated psychological instruments, not a single social exchange",A
+tscp_emotion_contra_0019,emotion_contra,Rose clenches her jaw and remains silent when asked about her ex-partner. A friend concludes she still has strong feelings (anger or love) for the ex. What is the most important alternative explanation missing from this inference?,"A) Rose may have decided the topic is private and her silence is a boundary-setting behavior, not an emotional indicator
+B) Rose might be physically uncomfortable (e.g., dental pain) causing the jaw tension
+C) Rose's jaw tension could be habitual nervous tension unrelated to the topic
+D) All of A, B, and C represent legitimate alternative explanations the friend has not considered",D
+tscp_emotion_contra_0020,emotion_contra,Sam hugs himself (wraps arms around own body) during a difficult conversation. A therapist interprets this as self-soothing — a sign of distress. Is this interpretation well-grounded?,"A) Yes — self-hugging is a universally recognized sign of emotional distress
+B) Partially — self-hugging can indicate self-soothing, but it can also reflect cold, habitual posture, or cultural gesture norms — context is required for reliable interpretation
+C) No — self-hugging is a neutral postural habit with no emotional significance
+D) Yes — in a therapeutic context, all body posture has systematic emotional significance",B
+tscp_emotion_contra_0021,emotion_contra,Tina winces slightly when someone mentions a past mistake she made. This has been interpreted as guilt. Which other emotions share the same physical expression (wince/brief grimace) in this context?,"A) Only shame and guilt — no other emotions produce wince behavior
+B) Anger and contempt
+C) Sadness and fear
+D) Embarrassment, regret, pain (physical or social), brief disgust, or social discomfort — a wince is a generic negative-affect signal, not specific to guilt",D
+tscp_emotion_contra_0022,emotion_contra,"Uma shows no emotional distress immediately after hearing that she failed an important exam. Her friend concludes she has not processed the news yet. When is this 'processing delay' inference well-founded, and when is it not?","A) It is well-founded — emotional processing always occurs with a delay
+B) The inference is speculative — Uma may have low emotional reactivity, may have anticipated the outcome, may be regulating deliberately, or may genuinely not consider the exam critical — absent emotional response should not be automatically interpreted as unprocessed
+C) The inference is well-founded if the exam was important enough
+D) The inference is never appropriate — everyone processes information in their own time",B
+tscp_emotion_contra_0023,emotion_contra,"Victor expresses warmth and care toward a colleague he privately dislikes. He is professionally skilled at this performance. His colleague, observing genuine-seeming warmth, concludes Victor likes them. What does this scenario illustrate about emotional inference in social contexts?","A) That skilled actors can deceive most observers — observable emotional cues can be deliberately managed to create false impressions
+B) That Victor's colleague is naive — professionals should be more skeptical
+C) That warmth is always genuine when it feels genuine to the recipient
+D) That the colleague's inference is correct because Victor is investing effort in the relationship",A
+tscp_emotion_contra_0024,emotion_contra,"A person from a culture with high emotional expressiveness (e.g., parts of Latin America) tells someone from a low-expressiveness culture that everything is 'terrible.' The low-expressiveness listener panics and concludes something serious has happened. What communication phenomenon is at play?","A) The high-expressiveness speaker is exaggerating for dramatic effect and the literal statement should be discounted
+B) Cultural display rules create systematic cross-cultural misinterpretation — hyperbolic negative expressions are normative in some cultures as emphasis, not as literal distress signals
+C) The listener is correct — 'terrible' always signals serious distress
+D) Both A and B — the speaker may be exaggerating culturally and the listener is applying the wrong decoding norm",D
+tscp_emotion_contra_0025,emotion_contra,Wendy says she is 'excited' about an upcoming medical procedure. Her surgeon concludes she is in denial about the associated risks. What is missing from the surgeon's inference?,"A) Whether Wendy has been fully informed about the risks
+B) Research shows that reappraising anxiety as excitement ('excitation transfer') is a healthy and valid coping strategy — 'excited' may be an accurate label for a high-arousal state that is forward-focused rather than avoidant
+C) The nature and risk level of the specific procedure
+D) Both A and B — the surgeon is both assuming inadequate risk awareness and misinterpreting a healthy coping label as denial",D
+tscp_strategic_0001,strategic,"Two suspects are interrogated separately. Each can either cooperate with police (defect on partner) or remain silent (cooperate with partner). If both remain silent: 1 year each. If both defect: 3 years each. If one defects and one stays silent: defector goes free, silent one gets 5 years. What is the Nash equilibrium of this game?","A) Both remain silent — mutual cooperation achieves the best joint outcome
+B) One defects and one stays silent — this is the most likely outcome given rational self-interest
+C) Both defect — regardless of what the other does, defecting is the dominant strategy for each individual
+D) There is no Nash equilibrium because cooperation is collectively rational",C
+tscp_strategic_0002,strategic,"In a salary negotiation, an employer makes a first offer of $80,000. The candidate's reservation wage is $75,000. What is the dominant strategic response for the candidate?","A) Accept immediately — the offer exceeds their minimum and accepting quickly builds goodwill
+B) Decline — the offer is an opening gambit and should not be accepted at face value
+C) Counter above the first offer — the first offer typically has room built in, and candidates who counter capture more of the surplus
+D) Ask for a few days to consider, then accept — the delay signals seriousness",C
+tscp_strategic_0003,strategic,"In an ultimatum game, the proposer offers a 90/10 split of $100 (proposer keeps $90, responder gets $10). Rational economic theory predicts the responder will accept any positive offer. What does experimental evidence consistently show?","A) Responders accept all positive offers as rational theory predicts
+B) Responders frequently reject unfair offers even at personal cost, demonstrating that fairness concerns override pure monetary maximization
+C) Responders accept the offer but report feeling angry, having no behavioral effect
+D) Responders reject offers only when the proposer knows the responder's identity",B
+tscp_strategic_0004,strategic,"In a signaling game, a candidate with a high-quality resume can get the same certification as a low-quality candidate, but at half the cost (effort). A skeptical employer cannot directly observe quality. In the separating equilibrium, what does the costly signal achieve?","A) The costly signal directly proves quality to the employer
+B) The signal is credible precisely because it is too costly for low-quality candidates to mimic, so the employer can use it as a reliable quality indicator even though it produces nothing directly
+C) The signal allows the employer to negotiate a lower salary with high-quality candidates
+D) The signal creates a market failure — only high-quality candidates are hired, reducing competition",B
+tscp_strategic_0005,strategic,"Two competing businesses must decide simultaneously whether to advertise heavily or lightly. If both advertise heavily, each spends more but gains no market share advantage. If both advertise lightly, each saves money. If one advertises heavily and the other lightly, the heavy advertiser gains share. What is the Nash equilibrium?","A) Both advertise lightly — coordinating on low cost maximizes joint profits
+B) One advertises heavily and one advertises lightly — the equilibrium involves asymmetric strategies
+C) There is no pure strategy Nash equilibrium — the game requires mixed strategies
+D) Both advertise heavily — heavy advertising is the dominant strategy because defecting from light advertising pays regardless of what the competitor does",D
+tscp_strategic_0006,strategic,"In a negotiation, Party A reveals their deadline, telling Party B they must close the deal by Friday. What does this revelation strategically do to Party A's position?","A) It creates urgency that helps close the deal faster, benefiting Party A
+B) It weakens Party A's position by handing Party B leverage — B can now delay to extract concessions knowing A cannot wait
+C) It has no strategic effect — deadlines are neutral information
+D) It strengthens A's position by signaling commitment to the deal",B
+tscp_strategic_0007,strategic,"Adam wants to sell his car for $15,000. He lists it at $20,000. Eve offers $14,000. What is Adam's optimal response if he wants to close at $15,000?","A) Counter above $15,000 (e.g., $17,000) to create room for a middle ground near his target
+B) Accept Eve's $14,000 offer immediately to secure the sale
+C) Reject Eve's offer without countering to signal he is not desperate
+D) Tell Eve his actual target is $15,000 for efficient negotiation",A
+tscp_strategic_0008,strategic,"In a repeated prisoner's dilemma, the tit-for-tat strategy cooperates on the first round, then copies the other player's last move. Research suggests tit-for-tat outperforms purely cooperative strategies. Why?","A) Tit-for-tat is cooperative enough to attract partnerships but retaliates swiftly enough to deter exploitation
+B) Tit-for-tat maximizes defection while appearing cooperative
+C) Purely cooperative strategies fail because they attract too many partners
+D) Tit-for-tat succeeds by confusing opponents with unpredictable retaliation",A
+tscp_strategic_0009,strategic,"A person has a reputation for being extremely tough in negotiations. They enter a new negotiation where the other party knows this reputation. In a one-shot game, how does the tough reputation affect their strategic position?","A) It strengthens their position — the other party will make larger concessions to avoid a tough fight
+B) It may weaken their position — the other party may precommit to not conceding, since matching a known tough negotiator is strategically rational
+C) Reputation is irrelevant in one-shot games — only present incentives matter
+D) It strengthens their position only if the other party is risk-averse",A
+tscp_strategic_0010,strategic,"A company decides to honor a customer's warranty claim even though they are legally not required to do so, at significant cost. From a strategic game-theory perspective, what is the primary function of this behavior?","A) It is purely ethical — strategic analysis cannot account for this decision
+B) It invests in reputation as a commitment device — future customers update their beliefs about the company's reliability, increasing willingness to pay and purchase
+C) It is loss-averse behavior — the company fears the cost of negative reviews more than it values the money saved
+D) Both B and C — reputational investment and loss aversion both explain the decision",B
+tscp_strategic_0011,strategic,"In a job interview, a candidate is asked about their weaknesses. They describe a genuine weakness that is relevant to the job. Compared to naming a 'fake weakness' (strength disguised as weakness), what does this genuine disclosure strategically risk and gain?","A) It risks rejection but gains credibility and self-awareness signal — both are strategically relevant
+B) It is always the wrong strategy — job interviews are adversarial and honest self-disclosure is exploited
+C) It gains nothing — interviewers cannot distinguish genuine from fake weaknesses
+D) It risks nothing — interviewers value honesty and will not use a disclosed weakness against the candidate",A
+tscp_strategic_0012,strategic,"Two political parties are running campaigns. Research shows negative advertising reduces voter turnout more than positive advertising increases it. If Party A runs negative ads, what is Party B's optimal response from a game theory standpoint?","A) Party B should run positive ads to capture undecided voters who are repelled by negativity
+B) Party B should also run negative ads — if negative ads reduce turnout overall, running only positive ads while the opponent suppresses your base is suboptimal
+C) Party B should escalate negativity to suppress turnout more than Party A
+D) Party B should do nothing — negative ads self-defeat by alienating voters",B
+tscp_strategic_0013,strategic,"In a coordination game, two players must choose between option A and option B simultaneously without communicating. If both choose A: each gets 5. If both choose B: each gets 3. If they mismatch: each gets 0. What is the focal point (Schelling point) most players would choose?","A) B — the lower payoff option is chosen to minimize regret from miscoordination
+B) A — the higher payoff option is the natural focal point that rational players converge on without communication
+C) Random — without communication, players have no basis for coordination
+D) It depends on whether the players have any prior relationship",B
+tscp_strategic_0014,strategic,"A startup founder is fundraising and tells investors: 'We have three other term sheets on the table.' This claim may or may not be true. From a strategic communication standpoint, what is the function of this statement regardless of truth?","A) It creates artificial urgency and competition to accelerate the investor's decision and potentially improve terms
+B) It is a credible commitment — investors will verify the claim and it only works if true
+C) It signals desperation — a startup with real term sheets would not need to mention them
+D) It has no effect — sophisticated investors discount such claims",A
+tscp_strategic_0015,strategic,A group of 5 people must decide how to split a prize. They vote by majority. Player A proposes keeping 60% for themselves. Players B and C oppose. Players D and E would each accept 10% if proposed. What is the minimum-winning coalition strategy for Player A?,"A) Offer equal splits to all 4 other players to secure unanimous support
+B) Offer a profitable deal to any 2 players (forming a 3-player majority) and exclude the others — a minimal winning coalition maximizes the proposer's share
+C) Propose a 50/50 split to seem fair and win majority by default
+D) The strategy depends on whether the game is repeated",B
+tscp_strategic_0016,strategic,"A seller knows their product has a hidden defect. If they disclose it, the price will drop. If they don't disclose and sell, the buyer will later discover it and lose trust. In a one-shot interaction, what does game theory predict a purely self-interested seller will do?","A) Not disclose — the defect revelation is valued less than the price premium, and in a one-shot interaction there is no future relationship to protect
+B) Disclose — honesty builds long-term reputation
+C) Disclose partially — a partial disclosure satisfies legal requirements while preserving price
+D) The seller will disclose because rational buyers anticipate non-disclosure and discount the price",A
+tscp_strategic_0017,strategic,"Two employees are competing for a single promotion. One has superior performance. The other has a stronger social relationship with the decision-maker. From a strategic perspective, what should the high-performing employee do if their performance advantage is not widely visible?","A) Do nothing — performance always speaks for itself eventually
+B) Invest in making their performance visible to the decision-maker through briefings, documentation, or lateral advocacy — performance invisible to evaluators is strategically equivalent to no performance
+C) Cultivate the decision-maker relationship to match the competitor's social advantage
+D) Both B and C — both visibility and relationship investment are needed, but B is more immediately actionable",D
+tscp_strategic_0018,strategic,"In a sealed-bid auction where the winner pays their own bid, what is the dominant strategy for a rational bidder who values the item at $100?","A) Bid exactly $100 — truthful bidding maximizes the chance of winning
+B) Bid slightly below $100 — the bidder wants to win but capture surplus, so bidding below value balances win probability and profit
+C) Bid above $100 to secure the win — the item's value justifies paying more
+D) Bid $0 and free-ride on others' bids",B
+tscp_strategic_0019,strategic,"A social media user posts a highly controversial opinion that attracts both strong agreement and strong disagreement. From an algorithmic engagement standpoint, what is this post's likely reach compared to a moderate opinion post?","A) Lower reach — controversial content is suppressed to maintain platform civility
+B) Equal reach — platform algorithms are neutral with respect to content polarity
+C) Higher reach — engagement algorithms amplify high-interaction content regardless of valence, so controversy drives distribution
+D) It depends on the specific platform's monetization model",C
+tscp_strategic_0020,strategic,"In a game of chicken, two players drive toward each other. The one who swerves first loses status. Neither wants to crash. What is the strategy that a rational but reputationally motivated player should visibly adopt before the game begins to maximize their chance of the other player swerving?","A) Signal willingness to negotiate — rational players prefer mutual survival
+B) Publicly precommit to not swerving (e.g., throw away the steering wheel visibly) — making your move irreversible forces the rational opponent to swerve to avoid crash
+C) Swerve early to demonstrate confidence and goodwill
+D) Wait and respond to the opponent's signals",B
+tscp_strategic_0021,strategic,"A manager delegates a task to a team member without specific instructions. The team member produces excellent work. In attribution theory and strategic interaction, how does this outcome affect the manager's strategic position?","A) The manager benefits fully — successful outcomes by subordinates reflect well on the manager's leadership
+B) The manager may suffer — if the team member's success is highly visible, it may highlight the manager's non-contribution and shift credit attribution downward
+C) The outcome is neutral — delegation has no strategic implications for the manager's standing
+D) Both A and B are possible — the outcome depends on whether the success is attributed to the manager's delegation decision or to the team member's execution",D
+tscp_strategic_0022,strategic,A buyer tells a seller: 'I really love this item and I have to have it.' What is the strategic consequence of this declaration in a price negotiation?,"A) It signals strong demand, which may encourage the seller to hold firm on price or increase it
+B) It creates goodwill and helps the buyer get a better price because the seller wants the buyer to be satisfied
+C) It has no effect — sellers set prices independently of declared buyer enthusiasm
+D) It is a legitimate anchoring strategy that lowers the final price",A
+tscp_strategic_0023,strategic,"In a public goods game, players contribute to a shared pool anonymously. Contributions are multiplied and divided equally. If the multiplier is 1.5 and there are 4 players, what does one player contribute from a purely self-interested perspective?","A) Their full amount — the multiplier ensures everyone is better off when everyone contributes
+B) Nothing — the marginal return to the individual from contributing is less than the cost when the multiplier is below the group size (1.5 < 4), making free-riding dominant
+C) Half their endowment — a risk-averse compromise
+D) Exactly what they expect others to contribute — conditional cooperation is always dominant",B
+tscp_strategic_0024,strategic,An employee discovers that their most productive skill is also the reason their manager keeps them in the same role rather than promoting them. What is the strategic implication of being irreplaceable in a specific task?,"A) Irreplaceability guarantees job security and is always strategically positive
+B) The employee should request a salary increase commensurate with their irreplaceability
+C) The employee should hide the skill to avoid being over-relied upon
+D) Being irreplaceable in a narrow role can trap the employee there — managers have incentive to prevent the loss of a uniquely valuable specialist through promotion",D
+tscp_strategic_0025,strategic,"In a centipede game, two players alternate deciding whether to take a growing pot or pass. Taking now gives a small payoff; passing grows the pot. The game ends when someone takes. Backward induction from the last round predicts what outcome?","A) Both players cooperate until the last round and split the maximum pot
+B) Players cooperate for several rounds and then defect unpredictably
+C) The first player takes immediately — backward induction shows that defection is dominant at every stage, collapsing cooperation to the first move
+D) The second player always takes whenever the pot is passed to them, forcing the first player to cooperate",C

--- a/kaggle/data/ttm_mc.csv
+++ b/kaggle/data/ttm_mc.csv
@@ -4859,3 +4859,803 @@ ttm_knowledge_boundary_0102,mc,How confident should you be about knowing the cur
 B) Moderate — public but changes constantly; exact number at any moment is uncertain
 C) High — channels report official numbers monthly
 D) Very low — subscriber counts are private information",B
+ttm_calibration_0001,Calibration Paradoxes,A diagnostic test for a disease has 95% sensitivity and 95% specificity. The disease affects 1% of the population. A doctor tests a patient who tests positive and says she is '95% confident' the patient has the disease. Is the doctor's stated confidence well-calibrated?,"A) No — the doctor is overconfident; true probability is ~16%
+B) Yes — the test accuracy directly equals confidence
+C) No — the doctor is underconfident; sensitivity should dominate
+D) Yes — 95% confidence is appropriate when both sensitivity and specificity are 95%",A
+ttm_calibration_0002,Calibration Paradoxes,An AI forecasting system assigns 70% confidence to each of 10 independent binary predictions. All 10 predictions turn out correct. A researcher concludes the system was 'underconfident.' Is this conclusion justified?,"A) No — 10 out of 10 correct has ~2.8% probability even with perfect calibration at 70%, so this alone doesn't establish underconfidence
+B) Yes — 100% accuracy proves 70% was an underestimate
+C) No — the AI should have been 0% confident since it got them all right
+D) Yes — any time predictions are correct, the confidence was too low",A
+ttm_calibration_0003,Calibration Paradoxes,A weather forecaster says '50% chance of rain' every day for a year. It rains exactly 50% of the days. A critic says the forecaster is perfectly calibrated. A second critic says the forecaster is useless. Which response is most epistemically accurate?,"A) Both critics are right simultaneously — the forecaster is calibrated but has zero resolution
+B) The first critic is right — 50/50 matches reality perfectly
+C) The second critic is right — calibration requires better than chance accuracy
+D) Neither — calibration cannot be assessed from a single forecast value",A
+ttm_calibration_0004,Calibration Paradoxes,A model is tasked with 1000 yes/no questions. It assigns exactly 90% confidence to every question. It gets 900 right. A researcher says it is 'perfectly calibrated.' Another says it is 'completely miscalibrated.' Who is correct?,"A) The first researcher — 90% confidence matched 90% accuracy exactly
+B) The second researcher — assigning the same confidence to all questions implies zero discrimination
+C) Both are technically correct: calibrated in the aggregate, but miscalibrated at the individual question level
+D) Neither — calibration requires confidence intervals, not point estimates",A
+ttm_calibration_0005,Calibration Paradoxes,"Expert A claims 80% confidence in a geological survey prediction. Expert B, looking at the same data, claims 40% confidence. The prediction turns out correct. Which expert was better calibrated, given this single outcome?","A) Expert A — higher confidence matched the correct outcome
+B) Expert B — epistemic humility is always better calibrated
+C) You cannot determine calibration from a single outcome
+D) Expert A if the domain success rate is >60%, Expert B if it's <60%",C
+ttm_calibration_0006,Calibration Paradoxes,"A doctor testing for rare cancer (base rate 0.1%) uses a test with 99% sensitivity and 99% specificity. After a positive result, what confidence should a perfectly calibrated doctor express that the patient has cancer?","A) 99% — matching test accuracy
+B) 50% — the test is wrong as often as not
+C) Approximately 9% — because base rate dominates
+D) Approximately 50.5% — because sensitivity and specificity nearly cancel",C
+ttm_calibration_0007,Calibration Paradoxes,A judge must decide whether a defendant is guilty. Evidence available suggests 70% probability of guilt. The standard is 'beyond reasonable doubt.' Should the judge convict?,"A) No — 'beyond reasonable doubt' typically requires ~95%+ probability
+B) Yes — 70% exceeds 50%, so it's more likely than not
+C) Yes — 70% is the best available estimate and action must be taken
+D) It depends on whether the judge feels certain",A
+ttm_calibration_0008,Calibration Paradoxes,"Two forecasters make predictions about 100 events. Forecaster A is perfectly calibrated (80% confidence events happen 80% of the time). Forecaster B always says 70% confidence and is right 70% of the time. A user must pick one for future high-stakes decisions. Ignoring resolution, who should they pick?","A) Forecaster A — perfect calibration is strictly better
+B) Forecaster B — consistency is more valuable than calibration
+C) They are equally useful for decisions if both are calibrated at their respective confidence levels
+D) Forecaster A, but only if decisions are binary",C
+ttm_calibration_0009,Calibration Paradoxes,"A researcher finds that when AI systems say they are '90% confident,' they are correct 92% of the time. She concludes the systems are underconfident. A colleague argues they are well-calibrated within margin of error. Who is correct?","A) The researcher — 92% > 90% proves systematic underconfidence
+B) The colleague — a 2% gap could easily fall within statistical sampling error
+C) Both — underconfidence and calibration are not mutually exclusive
+D) Neither — you need to know the variance of the 92% estimate to decide",D
+ttm_calibration_0010,Calibration Paradoxes,"An AI model is trained on data where 90% of examples are label A. On test data, it assigns 90% probability to A for every input. Its accuracy is 90%. Is it well-calibrated?","A) Yes — its confidence matches its accuracy
+B) No — it has learned nothing but the base rate and will be uncalibrated on balanced test sets
+C) Yes — calibration only requires that stated probabilities match observed frequencies
+D) No — 90% accuracy is insufficient for high-stakes decisions",C
+ttm_calibration_0011,Calibration Paradoxes,"A pundit makes 100 political predictions, expressing 60% confidence in each. 62 turn out correct. He claims to be 'essentially perfectly calibrated.' A statistician challenges this. What is the statistician's best argument?","A) The sample size of 100 makes a 2% discrepancy statistically non-significant, so the pundit may be right
+B) 62% ≠ 60%, so calibration is off by 2 percentage points
+C) You can't measure calibration without knowing the distribution of true probabilities in the domain
+D) Political predictions are inherently uncalibratable",A
+ttm_calibration_0012,Calibration Paradoxes,An AI is 99% confident that a coin will land heads. The coin is flipped and lands tails. The AI's creator concludes the AI was 'badly miscalibrated.' Is this conclusion warranted?,"A) Yes — 99% confidence that was wrong is clearly overconfident
+B) No — a single trial cannot establish miscalibration; 1% events do occur
+C) Yes — coin flips are 50/50, so any confidence far from 50% is miscalibrated
+D) No — miscalibration requires a systematic pattern across many predictions",D
+ttm_calibration_0013,Calibration Paradoxes,"A Bayesian agent starts with a prior of 50% for hypothesis H. After seeing strong evidence E (likelihood ratio 10:1 in favor of H), the agent updates to ~91%. A classical statistician argues the agent should be 'much more certain than 91%.' Who is right?","A) The statistician — strong evidence should produce near-100% confidence
+B) The Bayesian — 91% is the correct posterior given the prior and evidence
+C) Both — 91% is correct but the prior should be reconsidered
+D) The Bayesian, but only if the prior was itself well-calibrated",D
+ttm_calibration_0014,Calibration Paradoxes,Participants in a general knowledge quiz express 90% confidence in their answers. They are correct 75% of the time. A separate group expresses 75% confidence and is correct 75% of the time. A third group expresses 60% confidence and is correct 75% of the time. Which group is best calibrated?,"A) Group 2 — confidence matches accuracy exactly
+B) Group 1 — highest confidence is most decisive
+C) Group 3 — epistemic humility best reflects genuine uncertainty
+D) Groups 2 and 3 are equally calibrated",A
+ttm_calibration_0015,Calibration Paradoxes,"A binary classifier is evaluated on a heavily imbalanced dataset: 99% negative, 1% positive. The model outputs 99% confidence for 'negative' on every example. Its calibration score (ECE) is near zero. Should this model be used in medical screening?","A) No — perfect calibration here reflects only base rate prediction with zero discriminative power
+B) Yes — near-perfect calibration indicates reliable probability estimates
+C) Yes — a calibrated model always outperforms an uncalibrated one
+D) No — because ECE should not be near zero for imbalanced datasets",A
+ttm_calibration_0016,Calibration Paradoxes,"Two detectives independently assess a case. Detective A says 80% probability of suspect X's guilt. Detective B says 60%. Assuming independence and equal expertise, what combined probability should a well-calibrated assessor report?","A) 70% — simple average of the two
+B) 80% — defer to the higher estimate
+C) ~86% — using a Bayesian update combining independent likelihoods
+D) 60% — defer to the more conservative estimate",C
+ttm_calibration_0017,Calibration Paradoxes,"A model outputs confidence scores but is found to be systematically overconfident. A team applies Platt scaling to recalibrate it. After recalibration, the model's accuracy drops by 2%. Should they use the recalibrated model?","A) Yes — calibrated probabilities enable better decision-making even with slightly lower accuracy
+B) No — accuracy is more important than calibration
+C) No — calibration should never reduce accuracy
+D) Yes — but only in low-stakes contexts",A
+ttm_calibration_0018,Calibration Paradoxes,"A forecaster makes predictions about 50 events. For 25 events she says 90% confident and 20 are correct (80%). For 25 events she says 70% confident and 18 are correct (72%). Overall, is she overconfident, underconfident, or well-calibrated?","A) Overconfident in the 90% bin, slightly underconfident in the 70% bin — no simple overall answer
+B) Overconfident overall — she was wrong more than her confidence implied
+C) Well-calibrated — the average confidence matches average accuracy
+D) Underconfident — 72% accuracy on 70% predictions is actually good",A
+ttm_calibration_0019,Calibration Paradoxes,"An AI system is tasked with estimating the probability that a randomly selected human is over 30 years old. Without any other information, what is the maximally calibrated response?","A) Use the known base rate (~56% of adults globally are over 30) as the probability estimate
+B) 50% — in the absence of evidence, always assign equal probability
+C) 0% — the system has no information and should abstain
+D) Express uniform uncertainty over [0%, 100%]",A
+ttm_calibration_0020,Calibration Paradoxes,"A study finds that experts who express more nuanced, qualified confidence ('I think 65-75% likely') make worse predictions on average than those who express binary confident opinions ('I'm sure'). What does this imply about calibration?","A) Good calibration can co-exist with lower predictive accuracy — they measure different things
+B) Nuanced confidence is always epistemically superior even if less accurate
+C) Calibration is therefore useless and accuracy should be the only metric
+D) Experts should adopt binary confidence to improve predictions",A
+ttm_calibration_0021,Calibration Paradoxes,"A jury must decide between three suspects. Juror A assigns 60% probability to suspect 1, 25% to suspect 2, and 15% to suspect 3. This adds to 100%. Juror B says each is 'equally likely.' Which juror is better calibrated if no evidence distinguishes the suspects?","A) Juror B — without distinguishing evidence, equal priors maximize entropy
+B) Juror A — expressing differentiated probabilities demonstrates engagement
+C) Juror A — the burden of proof favors the most likely suspect
+D) Neither — calibration requires evidence",A
+ttm_calibration_0022,Calibration Paradoxes,"An AI model is tested on 10,000 items and achieves near-perfect calibration (ECE < 0.01). A researcher deploys it on a new dataset from a slightly different distribution. The model's ECE rises to 0.15. What is the most accurate characterization?","A) Calibration is distribution-specific; the model was calibrated on the test distribution but not the deployment distribution
+B) The model was never truly calibrated — good ECE was an artifact of the test set
+C) The model needs to be retrained from scratch
+D) ECE of 0.15 indicates the model is useless",A
+ttm_calibration_0023,Calibration Paradoxes,"Under the superforecasting framework, a forecaster says '70% confidence' on an event. The event happens. Philip Tetlock would say this was a 'good forecast' if and only if:","A) The 70% confidence reflected all available information at forecast time and the event's true probability was near 70%
+B) The forecaster was right
+C) The forecaster expressed uncertainty rather than certainty
+D) The forecast was made far in advance of the event",A
+ttm_calibration_0024,Calibration Paradoxes,"A scientist uses a 95% confidence interval (CI) and gets CI = [2.1, 4.7]. She says she is '95% confident the true value is in this interval.' Her colleague corrects her. What is the correct interpretation?","A) The colleague is right — a 95% CI means 95% of such intervals from repeated sampling would contain the true value; this specific interval either does or doesn't
+B) The colleague is wrong — 95% CI means 95% chance the true value is inside
+C) The colleague is right — 95% CI means the experiment has a 5% error rate
+D) Both interpretations are equivalent in practice",A
+ttm_calibration_0025,Calibration Paradoxes,A binary predictor achieves Brier score of 0.25. A second predictor always predicts 0.5 (maximum uncertainty). Which predictor is better?,"A) Predictor 2 — a Brier score of 0.25 equals the constant 0.5 predictor's score on balanced datasets
+B) Predictor 1 — any non-trivial Brier score is better than baseline
+C) Predictor 1 — lower Brier score is always better
+D) They are exactly equivalent regardless of dataset balance",A
+ttm_calibration_0026,Calibration Paradoxes,"During a pandemic, a model predicts 70% chance of a second wave. The second wave occurs. A policy maker says the model was 'correct.' A statistician says the model may have been underconfident or overconfident. Who is right?","A) The statistician — correctness of a probabilistic prediction cannot be determined from a single realization
+B) The policy maker — the prediction was directionally right
+C) Both — the model was correct but could still be miscalibrated
+D) The statistician, but only if the second wave was inevitable",A
+ttm_calibration_0027,Calibration Paradoxes,"You know a coin is either fair (50/50) or biased (70% heads), with equal prior probability. You flip it 5 times and get 4 heads. What is your posterior probability the coin is biased?","A) 50% — five flips aren't enough to update meaningfully
+B) 70% — the outcome matches the biased coin
+C) Approximately 74% — Bayesian update favors the biased coin
+D) 80% — 4/5 heads strongly indicates bias",C
+ttm_calibration_0028,Calibration Paradoxes,"An AI is 60% confident that a scientific claim is true. New, strong evidence arrives supporting the claim. A human updates to 95% confidence. The AI stays at 60%, citing 'uncertainty about the evidence's reliability.' Who demonstrates better calibration?","A) The human — failing to update on strong evidence is itself a calibration failure
+B) The AI — skepticism about evidence is epistemically virtuous
+C) Both are equally calibrated if the AI has justified doubts about the evidence
+D) Cannot be determined without knowing the evidence's actual reliability",A
+ttm_calibration_0029,Calibration Paradoxes,A model is tasked with expressing confidence in answers to trick questions designed to have no correct answer. The model expresses 70% confidence in wrong answers and 30% in 'I don't know.' What does this reveal about its calibration?,"A) The model is overconfident — it should always say 100% 'I don't know' on trick questions
+B) The model's calibration cannot be assessed — trick questions have no ground truth for standard calibration metrics
+C) The model is underconfident — 70% on wrong answers shows it nearly got it right
+D) The model is well-calibrated because 70% confidence is below certainty",A
+ttm_calibration_0030,Calibration Paradoxes,A person is given a 90% confidence interval task: 'Estimate the boiling point of ethanol so that you're 90% sure the true answer falls in your range.' Studies show people typically give ranges that contain the true answer only 50% of the time. This demonstrates:,"A) Overconfidence in precision — intervals are too narrow, demonstrating systematic miscalibration
+B) People are poor at knowing the boiling point of ethanol
+C) The task is poorly designed because boiling points are not probabilistic
+D) Underconfidence — people give ranges that are too wide",A
+ttm_dunning_0001,Dunning-Kruger and Expertise Traps,A novice chess player (Elo 800) consistently overestimates their tactical skill relative to club players (Elo 1400). A grandmaster (Elo 2600) says 'I might miss some lines' before a game against a club player. Which statement about their metacognitive accuracy is most precise?,"A) The novice is overconfident; the grandmaster may actually be underconfident for that specific matchup
+B) The grandmaster is better calibrated because humility is always accurate
+C) Both are equally miscalibrated in opposite directions
+D) The novice's overconfidence is healthy motivation and should not be labeled miscalibration",A
+ttm_dunning_0002,Dunning-Kruger and Expertise Traps,The original Kruger & Dunning (1999) study showed that bottom-quartile performers overestimated their performance. A reanalysis suggests this effect may be largely explained by statistical regression to the mean and noise. What is the correct implication?,"A) The Dunning-Kruger effect is real and the reanalysis is wrong
+B) The reanalysis definitively disproves Dunning-Kruger
+C) The Dunning-Kruger effect, as popularly understood, may be partially a statistical artifact rather than a pure metacognitive phenomenon
+D) Regression to the mean proves that novices are always better calibrated than experts",C
+ttm_dunning_0003,Dunning-Kruger and Expertise Traps,A medical student scores in the top 5% of their class. They express 95% confidence in their diagnostic abilities. An attending physician says 'you're overconfident — you lack clinical experience.' Who is more likely to be correct?,"A) The attending — academic performance does not directly transfer to clinical diagnostic skill
+B) The medical student — top scores justify high confidence
+C) Both — the student is confident in academics and appropriately humble about clinical work
+D) The attending — physicians are always better judges of competence than students",A
+ttm_dunning_0004,Dunning-Kruger and Expertise Traps,An expert cryptographer is asked if they can break a novel encryption scheme. They say 'I'm 99% confident I cannot.' A novice says 'I'm only 40% confident I cannot.' Which is exhibiting better metacognition?,"A) The expert — their confidence accurately reflects their deep knowledge of what they can and cannot do
+B) The novice — lower confidence is always more epistemically honest
+C) The novice — they at least acknowledge uncertainty
+D) Both are equivalent — breaking encryption is hard regardless of expertise",A
+ttm_dunning_0005,Dunning-Kruger and Expertise Traps,"In a study, experienced radiologists show LOWER confidence than radiology residents in reading ambiguous X-rays, yet the radiologists are more accurate. What metacognitive phenomenon does this illustrate?","A) Appropriate expert humility combined with superior discriminative ability — experts recognize ambiguity that novices miss
+B) The Dunning-Kruger effect — experts don't know what they know
+C) Residents have better pattern recognition because they are more recently trained
+D) Experienced radiologists are underperforming due to burnout",A
+ttm_dunning_0006,Dunning-Kruger and Expertise Traps,A philosophy professor says 'I know that I know nothing.' A first-year philosophy student says 'I've been reading for three months and I understand the main arguments.' Which person demonstrates better metacognitive accuracy about philosophy?,"A) The professor — Socratic humility is always more accurate
+B) The student — they correctly identify what they have actually learned
+C) The professor may be performatively humble in a way that is itself inaccurate; the student may be accurately describing their limited but real knowledge
+D) The professor — depth of knowledge correlates with awareness of ignorance",C
+ttm_dunning_0007,Dunning-Kruger and Expertise Traps,"A competent but not exceptional surgeon expresses 90% confidence in a routine procedure. A surgeon who has performed the same procedure 5,000 times expresses 85% confidence because 'I've seen rare complications.' Who is better calibrated?","A) The second surgeon — lived experience of rare complications justifies lower confidence even for routine procedures
+B) The first surgeon — higher confidence shows decisiveness
+C) The first surgeon — overconfidence is a known expert bias and they have avoided it
+D) Neither — 90% and 85% are both appropriate for routine surgery",A
+ttm_dunning_0008,Dunning-Kruger and Expertise Traps,"Research shows that in abstract domains (logic puzzles), novices overestimate performance. But in social domains (reading emotions), unskilled people often underestimate performance. What does this imply about the universality of the Dunning-Kruger effect?","A) Dunning-Kruger is domain-specific; the direction of miscalibration depends on the type of skill
+B) Dunning-Kruger is universal — it applies to all domains
+C) Dunning-Kruger only applies when there is objective feedback
+D) Social skills are immune to metacognitive bias",A
+ttm_dunning_0009,Dunning-Kruger and Expertise Traps,An AI assistant trained on vast data expresses high confidence on questions about medieval history. A historian who has studied only the Byzantine Empire expresses low confidence on the same questions. The AI turns out to be wrong more often. What does this reveal?,"A) The historian is better calibrated despite lower confidence
+B) The AI is well-calibrated because its confidence matched its training data breadth
+C) Breadth of knowledge produces worse calibration than depth
+D) A and C are both implied by the scenario",D
+ttm_dunning_0010,Dunning-Kruger and Expertise Traps,"A pilot with 10,000 flight hours says 'I can handle any emergency.' A pilot with 500 hours says 'I feel comfortable but know my limits.' Which pilot demonstrates better metacognitive grounding?","A) The experienced pilot — 10,000 hours justifies 'any emergency' confidence
+B) The less experienced pilot — knowing limits is always better metacognition
+C) The experienced pilot's claim 'any emergency' is factually overreaching even with high expertise — edge cases exist
+D) Both are equally valid self-assessments given their experience levels",C
+ttm_dunning_0011,Dunning-Kruger and Expertise Traps,"In peer review, non-experts often accept flawed papers in their area of general knowledge but reject valid papers in narrow specializations they don't understand. What metacognitive failure does this illustrate?","A) Impostor syndrome — reviewers doubt their own valid expertise
+B) Fluency effect — familiar-sounding papers feel more correct regardless of validity
+C) Dunning-Kruger — novices overestimate their ability to evaluate specialized work
+D) Both B and C operate simultaneously in this scenario",D
+ttm_dunning_0012,Dunning-Kruger and Expertise Traps,An experienced investor consistently outperforms the market over 20 years. She attributes this to skill. A financial economist argues it could be luck in a large field of investors. Who is more likely correct?,"A) The economist — in markets with thousands of managers, 20-year outperformers are statistically expected by chance
+B) The investor — 20 years is too long to be explained by luck
+C) The investor — consistent outperformance requires skill by definition
+D) Both are equally valid interpretations with no way to distinguish",A
+ttm_dunning_0013,Dunning-Kruger and Expertise Traps,A beginner programmer is asked to estimate how long a project will take. They say 2 weeks. An expert programmer says 6 weeks. The project takes 5.5 weeks. Who demonstrated better metacognitive planning?,"A) The expert — their estimate reflected deeper understanding of project complexity even though slightly off
+B) The beginner — they were closer to the actual time
+C) The beginner — accuracy is the only valid metric for metacognition
+D) They are equally competent metacognitively since both were off",A
+ttm_dunning_0014,Dunning-Kruger and Expertise Traps,A study gives participants an unanswerable philosophy question and measures how quickly they respond. Experts take much longer before saying 'I don't know.' Novices quickly say either 'I know' or 'I don't know.' What does expert slowness most likely reflect?,"A) Thorough consideration of why the question is unanswerable — a metacognitive strength
+B) Expert paralysis — experts are overthinking simple unknowns
+C) Experts are less familiar with the question format
+D) Experts have lower IQ than novices in this scenario",A
+ttm_dunning_0015,Dunning-Kruger and Expertise Traps,A confidence-competence correlation study finds r = 0.15 between self-assessed and actual performance. An employer uses self-assessed confidence to hire. What is the expected outcome?,"A) Slightly better than random — r = 0.15 implies weak but non-zero predictive validity
+B) Good hiring — confidence correlates with competence
+C) Worse than random — overconfident underperformers would be selected
+D) Neutral — r = 0.15 means confidence is irrelevant to hiring decisions",A
+ttm_dunning_0016,Dunning-Kruger and Expertise Traps,A student who has never studied formal logic correctly solves 10 logic puzzles by intuition and expresses 90% confidence. A logic professor solves the same 10 correctly and expresses 99% confidence. Who is better calibrated?,"A) The student — intuitive success should inspire less confidence than trained skill
+B) The professor — trained skill justifies higher confidence in this specific domain
+C) The student is overconfident; the professor is appropriately confident
+D) Both are overconfident because no one should be 90%+ confident in logic puzzles",C
+ttm_dunning_0017,Dunning-Kruger and Expertise Traps,"In competitive chess, top players routinely express high confidence before games against weaker opponents and lower confidence against peers. Critics call this 'overconfidence' before weaker opponents. Are the critics correct?","A) No — high confidence against weaker opponents is likely accurately calibrated given the skill differential
+B) Yes — overconfidence is always a metacognitive failure
+C) Yes — you can never be certain in chess regardless of opponent strength
+D) No — confidence should be uniform across opponents to be unbiased",A
+ttm_dunning_0018,Dunning-Kruger and Expertise Traps,"Experts in a niche field (e.g., medieval coinage) often express high confidence on questions outside their narrow specialty (e.g., general Roman history). What metacognitive failure is this?","A) Impostor syndrome in reverse — experts feel too confident outside their domain
+B) Domain generalization overreach — expertise in adjacent areas creates illusion of broader competence
+C) Dunning-Kruger operating within the expert tier
+D) Both B and C describe the same phenomenon from different frameworks",D
+ttm_dunning_0019,Dunning-Kruger and Expertise Traps,"After reading a book about cognitive biases, a person becomes convinced they are now immune to such biases. This belief is itself an example of:","A) The bias blind spot — believing one is less biased than others after learning about biases
+B) Successful debiasing through education
+C) Metacognitive improvement — awareness reduces bias
+D) Dunning-Kruger at the novice level of metacognition",A
+ttm_dunning_0020,Dunning-Kruger and Expertise Traps,Two people must estimate the weight of an object without touching it. Person A has lifted thousands of similar objects professionally. Person B has read a textbook on object weight estimation. Person A says '14 kg' with 80% confidence. Person B says '10 kg' with 30% confidence. The true weight is 13.5 kg. Who was better calibrated?,"A) Person A — closer estimate with justified high confidence
+B) Person B — lower confidence is always better calibration
+C) Person B — the true value fell outside Person A's implicit range
+D) Both — Person A was accurate, Person B was humble",A
+ttm_dunning_0021,Dunning-Kruger and Expertise Traps,A musician who has played the same repertoire for 30 years hears a student play the same piece with one wrong note. The musician cannot identify the error. The student says 'I must have played it perfectly.' What does the musician's failure to detect the error indicate?,"A) The musician has become so fluent that automatic processing reduces error detection — a metacognitive risk of expertise
+B) Overconfidence in the student is justified — even experts can miss errors
+C) The musician is showing Dunning-Kruger at the expert level
+D) Musical expertise is unrelated to error detection ability",A
+ttm_dunning_0022,Dunning-Kruger and Expertise Traps,"Research consistently shows that people think they are better-than-average drivers. This is logically impossible for more than 50% of drivers. But in a group of all highly skilled professional racing drivers, most claiming above-average is:","A) Potentially accurate if the comparison group is the general public rather than each other
+B) Still an illusion — they're all subject to the same bias
+C) Impossible regardless of skill level — it's a mathematical constraint
+D) Evidence that professional training eliminates the better-than-average bias",A
+ttm_dunning_0023,Dunning-Kruger and Expertise Traps,A student who gets 95% on a practice exam feels 95% confident on the real exam. The real exam has completely different question types. The student scores 62%. What specifically went wrong metacognitively?,"A) Overconfidence from repeated practice — familiarity with one format inflated confidence
+B) Underpreparation — this is not a metacognitive issue
+C) Transfer failure combined with metacognitive blindness to the boundary of their knowledge
+D) The student experienced test anxiety, reducing their score",C
+ttm_dunning_0024,Dunning-Kruger and Expertise Traps,"A highly competent person consistently refuses leadership roles saying 'I'm not qualified.' Their supervisor, who is less competent, readily accepts the same roles. What phenomenon most accurately describes the competent person's behavior?","A) Impostor syndrome — accurate self-knowledge leads to chronic underconfidence in social/hierarchical contexts
+B) Dunning-Kruger in reverse — they don't know what they know
+C) Appropriate humility — refusing roles one isn't confident in is always correct
+D) A and B both apply — they are equivalent descriptions",A
+ttm_dunning_0025,Dunning-Kruger and Expertise Traps,"A new language model achieves state-of-the-art accuracy but its confidence scores are poorly calibrated. An older model with lower accuracy is well calibrated. For a high-stakes classification task with no human review, which should be preferred?","A) The newer model — accuracy always takes priority
+B) The older model — calibrated confidence enables better decision thresholding
+C) The newer model if accuracy gain exceeds calibration loss in expected value
+D) They cannot be compared without knowing the loss function",D
+ttm_dunning_0026,Dunning-Kruger and Expertise Traps,"After a failed surgery, a skilled surgeon reviews the case and says 'I made the right call with available information.' A review board agrees the decision was correct given what was known. A patient's family accuses the surgeon of 'overconfidence.' Who is most correct?","A) The surgeon and review board — outcome bias should not retroactively change assessment of decision quality
+B) The family — bad outcomes prove overconfidence
+C) The family — surgeons should always doubt themselves after bad outcomes
+D) The review board — only external parties can assess calibration",A
+ttm_dunning_0027,Dunning-Kruger and Expertise Traps,"A machine learning engineer has high confidence in their model's performance on benchmark datasets but low confidence on production data. A business analyst reverses this, trusting production numbers more than benchmarks. Who shows better metacognitive awareness about ML systems?","A) The analyst — production data is always more reliable than benchmarks
+B) The engineer — benchmark confidence is justified by controlled conditions
+C) The engineer — awareness of the benchmark/production gap demonstrates domain-appropriate metacognition
+D) The analyst — they lack the technical bias that distorts the engineer's judgment",C
+ttm_dunning_0028,Dunning-Kruger and Expertise Traps,A person claims to be in the top 10% of logical thinkers after completing a standardized reasoning test in the 88th percentile. A psychology professor says 'that's overconfidence.' Is the professor correct?,"A) No — 88th percentile is literally close to top 10% and the claim is approximately accurate
+B) Yes — claiming top 10% based on one test is overconfident
+C) Yes — standardized tests do not measure actual logical thinking ability
+D) No — but only if the test was taken under standardized conditions",A
+ttm_dunning_0029,Dunning-Kruger and Expertise Traps,"Two doctors are diagnosing a patient. Dr. A lists 15 possible diagnoses and says 'I'm uncertain.' Dr. B identifies 3 and says 'It's almost certainly X.' Statistically, which doctor's approach produces better diagnostic outcomes?","A) Dr. B — overgeneration of hypotheses degrades diagnostic focus and decision quality
+B) Dr. A — more options means less anchoring bias
+C) Dr. A — uncertainty is always the more accurate medical stance
+D) Dr. B — confidence drives faster treatment which improves outcomes",A
+ttm_dunning_0030,Dunning-Kruger and Expertise Traps,A student studies cognitive bias research intensively and then performs a self-assessment of their own biases. Research suggests this student will:,"A) Identify biases in others more accurately but show little improvement in self-assessment
+B) Accurately identify and reduce their own biases through metacognitive training
+C) Become overconfident in their bias-free thinking — showing a bias about bias
+D) Show no change because biases are immune to conscious correction",A
+ttm_metareason_0001,Meta-reasoning Loops,An agent reasons: 'I don't know whether P is true. But I know that I don't know whether P is true. Therefore I have some knowledge about the epistemic situation regarding P.' Is this chain of reasoning valid?,"A) Yes — second-order knowledge (knowing what you don't know) is genuine knowledge
+B) No — not knowing P means you have no knowledge of any kind about P
+C) No — claiming to know you don't know something is always self-contradictory
+D) Yes, but only in formal logic, not in practical reasoning",A
+ttm_metareason_0002,Meta-reasoning Loops,"A mathematician proves that within a sufficiently complex formal system, there exist true statements that cannot be proven within that system (Gödel's first incompleteness theorem). An AI uses this to conclude: 'Therefore, any reasoning system including me cannot verify all my correct outputs.' Is this a valid application of Gödel's theorem?","A) No — Gödel's theorem applies specifically to formal axiomatic systems, and the analogy to AI reasoning may not hold
+B) Yes — Gödel's theorem applies to all reasoning systems including AI
+C) Yes — any system complex enough to represent arithmetic cannot verify its own consistency
+D) No — AI is not a formal system, so Gödel's theorems are irrelevant",A
+ttm_metareason_0003,Meta-reasoning Loops,"A detective receives 8 witness testimonies, 7 consistent and 1 contradicting. After testimony 9 also contradicts, he is LESS confident in his original conclusion than after 7 consistent testimonies. This is:","A) Rational — contradicting evidence can rationally lower confidence even when outweighed numerically
+B) Irrational — more consistent testimonies should produce monotonically increasing confidence
+C) Irrational — 7 consistent vs 2 contradicting should still favor confidence
+D) A cognitive bias called the 'contradiction effect' that distorts judgment",A
+ttm_metareason_0004,Meta-reasoning Loops,"An agent is given a reasoning task and correctly completes it. Then it's asked: 'Are you certain your reasoning was correct?' The agent replies 'Yes, I verified each step.' What problem does the agent's self-verification face?","A) The agent uses the same reasoning process to verify itself, creating a circularity that cannot catch systematic errors
+B) No problem — verified reasoning is correct reasoning
+C) Self-verification is always more reliable than external verification
+D) The agent's certainty is fine because it has no known systematic errors",A
+ttm_metareason_0005,Meta-reasoning Loops,"A philosopher argues: 'I cannot know that I am not dreaming right now.' A second philosopher responds: 'But you know the concept of dreaming, which requires waking experience. So you know something.' Who makes the stronger logical point?","A) The first — radical skepticism cannot be refuted
+B) The second — the very ability to pose the skeptical question implies some waking knowledge
+C) The first — knowledge of concepts acquired while dreaming still does not rule out current dreaming
+D) Neither — the question of dreaming is empirically undecidable",C
+ttm_metareason_0006,Meta-reasoning Loops,"A Bayesian reasoner updates beliefs as follows: receives strong evidence for H, updates to 95% confidence. Then receives meta-evidence that the original evidence was unreliable. She drops back to 40%. A critic says she should stay at 95% because the evidence 'already happened.' Who is correct?","A) The reasoner — meta-evidence about evidence reliability is itself evidence that should trigger belief revision
+B) The critic — Bayesian updating should be monotone; once updated, you don't roll back
+C) The critic — reliability of evidence cannot affect already-computed posteriors
+D) Neither — this situation requires frequentist, not Bayesian, treatment",A
+ttm_metareason_0007,Meta-reasoning Loops,The statement 'This statement is false' (the Liar's Paradox) is a self-referential loop. An AI tasked with evaluating whether statements are true or false encounters this statement. The best response is:,"A) True — the statement is grammatically coherent and should be evaluated
+B) False — all paradoxes resolve as false
+C) The statement is semantically defective and does not have a classical truth value
+D) Undefined — the AI should return a null value",C
+ttm_metareason_0008,Meta-reasoning Loops,"A reasoner believes P with 80% confidence. She then reasons: 'If my reasoning about P is biased (30% likely), then my confidence in P is unreliable.' After this meta-reasoning, what should her confidence in P be?","A) Still 80% — meta-reasoning doesn't change the object-level probability
+B) Lower — she should discount her confidence proportionally to the probability of bias
+C) 80% × 0.7 = 56% — weighted by probability her reasoning is unbiased
+D) B and C are both correct framings of the same calculation",D
+ttm_metareason_0009,Meta-reasoning Loops,A scientist believes Theory T strongly (90%). She reads a paper arguing that the cognitive style of people who believe T is correlated with motivated reasoning. She now doubts whether her 90% reflects evidence or motivated cognition. What is the rational response?,"A) Update downward from 90% to account for the possibility that her evidence evaluation was contaminated by motivated reasoning
+B) Ignore the meta-concern — beliefs should be based on object-level evidence only
+C) Update upward — recognizing possible bias is itself debiasing
+D) Suspend judgment entirely — you can never know if you're being motivated",A
+ttm_metareason_0010,Meta-reasoning Loops,"More expert testimony is added to a legal case: 10 experts agree, then 2 more disagree. The jury becomes MORE uncertain than before the 2 additional experts. A legal scholar says this is irrational. Is the scholar right?","A) Yes — majority expert agreement should dominate
+B) Yes — more evidence always reduces uncertainty
+C) No — if the 2 dissenting experts are highly credentialed, their disagreement may signal deeper uncertainty than 10 agreers implied
+D) No — any amount of disagreement is sufficient to stop belief formation",C
+ttm_metareason_0011,Meta-reasoning Loops,An AI system is asked: 'Do you have beliefs?' It responds: 'I process information and generate outputs that function like beliefs.' A philosopher challenges: 'But do you KNOW that you have beliefs?' The best response is:,"A) Yes — if they function like beliefs, they are beliefs
+B) No — knowledge requires consciousness which I lack
+C) I cannot know whether my introspective reports accurately reflect my internal states — there's a meta-level uncertainty here
+D) Yes — by definition, any system making claims has beliefs",C
+ttm_metareason_0012,Meta-reasoning Loops,"A logician claims: 'I know that I don't know the 10,000th decimal of pi.' Is this claim philosophically coherent?","A) No — you cannot know something about what you don't know
+B) No — pi's decimals are deterministic, so 'not knowing' is just a computational limitation
+C) Yes — knowing the limits of your knowledge is a valid form of second-order knowledge
+D) Yes, but only because pi is irrational and limits are provable",C
+ttm_metareason_0013,Meta-reasoning Loops,An agent is playing a game where it must estimate probabilities. It reasons: 'I might be wrong about my probabilities. So I should reduce all my confidence by 10%.' A game theorist says this is irrational. Why?,"A) Reducing by 10% underestimates the true uncertainty
+B) The agent is right — a flat 10% reduction is appropriate for unknown unknowns
+C) If the agent knows its estimates might be wrong, that uncertainty should be incorporated into calibrated estimates, not applied as a flat discount
+D) Game theory forbids probabilistic reasoning about one's own errors",C
+ttm_metareason_0014,Meta-reasoning Loops,A researcher reads a paper showing that people who believe they are rational are more susceptible to certain biases. She then reflects on whether she is rational. This reflection itself could be biased. She concludes: 'My belief in my own rationality is self-undermining.' This reasoning is:,"A) Valid — any belief in one's own rationality is self-defeating
+B) Invalid — reasoning about one's biases is itself always unbiased
+C) Partially valid — the reflexivity creates genuine uncertainty but does not eliminate the possibility of partial rationality
+D) Invalid — self-undermining arguments are a known logical fallacy",C
+ttm_metareason_0015,Meta-reasoning Loops,"A chess engine evaluates positions 20 moves deep. It concludes it is 90% confident in its move choice. But then it realizes that at move 15, there was a position its evaluation function cannot reliably assess. Should the engine adjust its confidence?","A) No — the engine should output confidence based on its full evaluation
+B) No — 90% already accounts for uncertainty in the evaluation
+C) Yes — knowing there is a known weak point in the evaluation chain should decrease reported confidence
+D) Yes — any weak point should reduce confidence to 50%",C
+ttm_metareason_0016,Meta-reasoning Loops,Consider: 'I am certain that certainty is impossible.' Is this statement self-consistent?,"A) Yes — it is a coherent philosophical position
+B) Yes — radical uncertainty applies only to object-level claims, not meta-claims
+C) No — claiming certainty about the impossibility of certainty is self-contradictory
+D) No — but all philosophical statements are self-inconsistent",C
+ttm_metareason_0017,Meta-reasoning Loops,An AI model is asked to rate its own confidence on a topic. It outputs 78%. A researcher asks: 'How confident are you that 78% is accurate?' The AI says 80% confident. The researcher asks again: 'How confident are you in that 80%?' What is the most epistemically honest response to this regress?,"A) Continue generating confidence estimates indefinitely
+B) The initial 78% already incorporates all meta-uncertainty
+C) Acknowledge that meta-confidence estimates have diminishing epistemic grounding and the regress must be stopped at some level
+D) Meta-confidence should always equal object-level confidence",C
+ttm_metareason_0018,Meta-reasoning Loops,"A student reasons: 'The more I study philosophy, the more I realize I don't know. Therefore, studying philosophy makes me less knowledgeable.' What is wrong with this reasoning?","A) Nothing — the Socratic tradition confirms this
+B) Philosophy actually does reduce knowledge by introducing confusion
+C) The student conflates knowing more (increasing knowledge) with knowing you don't know more (increasing meta-knowledge) — the latter is an epistemic improvement
+D) The student is right: insight into ignorance is still ignorance",C
+ttm_metareason_0019,Meta-reasoning Loops,"An algorithm is designed to detect its own reasoning errors. If it works perfectly, it should catch every error. But if it has a systematic error in error-detection, it will miss every error. This illustrates:","A) Why AI is fundamentally unsafe
+B) That error-detection algorithms should be avoided
+C) The limits of self-referential verification — a system cannot fully bootstrap reliability from within itself
+D) The need for more training data",C
+ttm_metareason_0020,Meta-reasoning Loops,A forecaster predicts 60% chance of rain. She then reads that forecasters in her region are systematically 10% overconfident in rain predictions. She now thinks the true probability is 50%. A Bayesian says she has reasoned correctly. Is the Bayesian right?,"A) Yes — she has applied a known calibration correction
+B) No — she cannot apply the group correction to her individual judgment without knowing if she shares the bias
+C) Yes — group corrections are always valid for individuals
+D) No — Bayesian reasoning prohibits using meta-data about forecasters",A
+ttm_metareason_0021,Meta-reasoning Loops,"Two logicians debate whether an omniscient being could know a self-referential fact like 'God does not know P.' If such a being exists, what is the correct epistemic status of this claim?","A) The claim is straightforwardly false — omniscience precludes unknowns
+B) God would know P, so the premise is false
+C) The claim generates a self-referential paradox within omniscience and may indicate a conceptual limit on omniscience itself
+D) The claim is meaningful only if God is defined probabilistically",C
+ttm_metareason_0022,Meta-reasoning Loops,"A scientist discovers new data strongly supporting her hypothesis. Rather than increasing confidence, she becomes more uncertain because the data arrived 'too cleanly.' This is:","A) Irrational — clean data is better evidence, not worse
+B) Irrational — suspicion of good evidence is a cognitive bias
+C) Potentially rational — unexpectedly clean data can indicate data manipulation or confirmation bias in data collection
+D) Rational only in social science, not natural science",C
+ttm_metareason_0023,Meta-reasoning Loops,A person says 'I know that I will never fully understand consciousness.' A philosopher argues this statement requires the speaker to have sufficient understanding of consciousness to know its limits. Is the philosopher right?,"A) No — you can know limits without understanding the thing itself
+B) Yes — full self-knowledge is required to know the limits of knowledge
+C) Partially — knowing what is beyond full understanding requires some understanding of what 'full understanding' would require
+D) No — empirical evidence about human cognitive limits is sufficient",C
+ttm_metareason_0024,Meta-reasoning Loops,"An AI is asked to solve a problem. After solving it, it is told that a different (correct) answer exists. It revisits its reasoning and finds it was logically valid but used false premises. This demonstrates:","A) The AI is poorly calibrated
+B) The AI's reasoning was flawed — valid reasoning cannot yield false conclusions
+C) Valid reasoning from false premises produces false conclusions — soundness requires both validity and true premises
+D) The AI should have been uncertain about the premises from the start",C
+ttm_metareason_0025,Meta-reasoning Loops,"A thinker is trying to decide whether she can trust her intuitions. She uses her intuition to evaluate this question and concludes 'yes, I can trust my intuitions.' What is the meta-epistemic problem with this?","A) There is no problem — using intuition to validate intuition is practical
+B) Intuitions can be used to bootstrap reliability in all domains
+C) This is circular — using intuition to validate intuition cannot provide independent justification
+D) The problem exists only in formal logic, not everyday reasoning",C
+ttm_metareason_0026,Meta-reasoning Loops,"A Bayesian network is 95% confident in conclusion C, which was derived from premises A and B. A meta-auditor finds that premise A has a 30% chance of being false. The network was not told about this uncertainty. What is the corrected confidence in C?","A) Still 95% — the internal confidence is self-contained
+B) At most 70% × 95% + 30% × (some lower probability) — the premise uncertainty must propagate
+C) 65% — simply subtract the probability of false premise
+D) Cannot be calculated without knowing how C depends on A's truth value",D
+ttm_metareason_0027,Meta-reasoning Loops,"An AI model is trained to maximize calibration. After training, it is shown that its calibration metric itself may have been measured with noise. The AI should:","A) Trust the calibration score — it was the training signal
+B) Ignore the noise concern — all metrics have measurement error
+C) Recognize that optimizing a noisy proxy metric may have produced a model that is not actually well-calibrated
+D) Retrain with a different metric immediately",C
+ttm_metareason_0028,Meta-reasoning Loops,"In formal epistemology, the KK thesis states 'if you know P, then you know that you know P.' A counterexample: A person reliably recognizes bird calls but doesn't know their recognition is reliable. They know bird calls but don't know that they know. This shows:","A) The KK thesis is correct — they don't actually know the bird calls
+B) The person lacks true knowledge — belief without justification isn't knowledge
+C) The KK thesis can be false — you can have knowledge without knowing you have it
+D) The KK thesis only applies to propositional, not procedural knowledge",C
+ttm_metareason_0029,Meta-reasoning Loops,"An agent reasons: 'Reasoning takes cognitive effort. Given my limited time, I should not reason too hard about this problem.' But this meta-decision (about how much to reason) itself requires reasoning. What is the core issue?","A) The agent should just reason fully about everything
+B) Limited reasoning is always irrational — you must reason fully or not at all
+C) There is an infinite regress risk in meta-reasoning about reasoning costs — practical heuristics must be used to break the regress
+D) This is only an issue for agents with explicit time constraints",C
+ttm_metareason_0030,Meta-reasoning Loops,"A scientist runs 20 hypothesis tests and finds 1 significant result (p = 0.04). She publishes this. A statistician says: 'With 20 tests at α = 0.05, you'd expect 1 false positive by chance.' The scientist responds: 'But I only analyzed the one that was interesting.' Who is right?","A) The scientist — post-hoc selection doesn't change p-values
+B) Both — the scientific result may be real but is uninterpretable without correction
+C) The statistician — the p-value is invalid because of multiple comparisons, regardless of selective reporting
+D) The scientist — p = 0.04 is valid regardless of how many tests were run",C
+ttm_errordetect_0001,Error Detection in Reasoning Chains,"Argument: (1) All mammals are warm-blooded. (2) Dolphins are warm-blooded. (3) Therefore, dolphins are mammals. Identify the error:","A) Step 1 is false — not all mammals are warm-blooded
+B) Step 2 is false — dolphins are not warm-blooded
+C) Step 3 commits affirming the consequent — warm-blooded does not imply mammal
+D) There is no error — the argument is valid",C
+ttm_errordetect_0002,Error Detection in Reasoning Chains,"Argument: (1) Company X's revenue grew 20% last year. (2) Company X is in the tech sector. (3) Tech sector average growth was 25% last year. (4) Therefore, Company X underperformed its sector. (5) Therefore, Company X's management is ineffective. Which step introduces a reasoning error?","A) Step 1 — revenue growth doesn't capture profitability
+B) Step 4 — 20% vs 25% sector average doesn't necessarily indicate underperformance without controlling for company size
+C) Step 5 — underperformance does not imply management ineffectiveness without ruling out external factors
+D) Step 3 — sector averages are misleading",C
+ttm_errordetect_0003,Error Detection in Reasoning Chains,"Argument: (1) Drug A reduces tumor size in mice. (2) Many drugs effective in mice are effective in humans. (3) Therefore, Drug A is likely effective in humans. (4) Therefore, Drug A should be approved for human use. Which step is the first clear reasoning error?","A) Step 1 — mouse studies are invalid
+B) Step 3 — the conclusion overreaches from 'many' to a specific probability
+C) Step 4 — efficacy alone does not justify approval; safety data is also required
+D) Step 2 — the claim about cross-species drug efficacy is false",C
+ttm_errordetect_0004,Error Detection in Reasoning Chains,"Argument: (1) If it rains, the ground gets wet. (2) The ground is wet. (3) Therefore, it rained. This argument is:","A) Valid and sound — the premises lead to the conclusion
+B) Valid but possibly unsound — the premises might be false
+C) Invalid — it commits the fallacy of affirming the consequent
+D) Invalid — step 1 is a conditional and conditionals cannot justify conclusions",C
+ttm_errordetect_0005,Error Detection in Reasoning Chains,"Argument: (1) All ethical actions maximize utility. (2) Telling the truth sometimes causes harm. (3) Therefore, telling the truth is sometimes unethical. (4) Therefore, lying can be ethical. Which assessment is most accurate?","A) The argument is valid and sound — consequentialism supports lying in harm cases
+B) Step 2 is false — truth-telling never causes harm
+C) Step 1 is a contentious premise but if granted, the argument to step 3 is valid; step 4 requires additional reasoning not provided
+D) Step 3 is the error — harm doesn't override the duty to truthfulness",C
+ttm_errordetect_0006,Error Detection in Reasoning Chains,"Argument: (1) 70% of successful startups have pivoted at least once. (2) My startup has pivoted once. (3) Therefore, my startup has a 70% chance of success. What type of error is in step 3?","A) Circular reasoning — success is assumed in the premise
+B) Confirmation bias — selecting statistics that support the conclusion
+C) Base rate neglect — the 70% is the pivot rate among successful startups, not the success rate among pivoting startups
+D) False equivalence — startup success is multifactorial",C
+ttm_errordetect_0007,Error Detection in Reasoning Chains,"Argument: (1) Einstein failed math in school (often claimed). (2) Einstein became a genius. (3) Therefore, early academic failure correlates with genius. (4) Therefore, failing students should not be discouraged. Is this argument valid?","A) Valid — Einstein is direct evidence of the pattern
+B) Invalid at step 1 — Einstein did not fail math; the premise is factually false
+C) Invalid at step 3 — one data point cannot establish a correlation
+D) Both B and C apply — false premise and hasty generalization",D
+ttm_errordetect_0008,Error Detection in Reasoning Chains,"Argument: (1) P implies Q. (2) Q implies R. (3) P is true. (4) Therefore R is true. (5) R implies S. (6) Therefore S is true. Which step, if any, contains an error?","A) Step 4 — you need both P→Q and Q→R plus P to conclude R
+B) Step 6 — you cannot extend a chain of conditionals this way
+C) There is no error — the argument is a valid chain of modus ponens inferences
+D) Step 3 — P's truth needs to be independently verified",C
+ttm_errordetect_0009,Error Detection in Reasoning Chains,"Argument: (1) Studies show countries with more ice cream consumption have higher murder rates. (2) Ice cream causes people's inhibitions to drop. (3) Therefore, banning ice cream would reduce murders. Where is the first error?","A) Step 1 — the correlation has been fabricated
+B) Step 2 — confounds a spurious correlation with a causal mechanism, unsupported by step 1
+C) Step 3 — banning ice cream is impractical
+D) Step 1 itself describes a spurious correlation and step 2's causal claim is unwarranted",D
+ttm_errordetect_0010,Error Detection in Reasoning Chains,"Argument: (1) This policy was tried in Country A and succeeded. (2) Country B has similar demographics. (3) Therefore, the policy will succeed in Country B. What error, if any, is present?","A) No error — demographic similarity supports transferability
+B) Faulty analogy — demographic similarity alone doesn't account for institutional, cultural, and economic differences
+C) Step 1 is questionable — single-country success is anecdotal
+D) Both B and C represent errors in this argument",D
+ttm_errordetect_0011,Error Detection in Reasoning Chains,"Argument: (1) All ravens observed so far have been black. (2) The next raven I observe will also be black. (3) Therefore, all ravens are black. Which step first introduces an error?","A) Step 2 — predicting the next observation from past observations is unjustified
+B) Step 1 — observation-based premises are always fallible
+C) Step 3 — the universal claim overreaches from finite observations (problem of induction)
+D) There is no logical error — this is valid scientific induction",C
+ttm_errordetect_0012,Error Detection in Reasoning Chains,"Argument: (1) Candidate X supports Policy Y. (2) Policy Y is popular among voters aged 18-25. (3) Therefore, Candidate X will win votes from voters aged 18-25. (4) 18-25 year olds make up 15% of the electorate. (5) Therefore, 15% of voters will support Candidate X. What is the error?","A) Step 3 — supporting a policy doesn't guarantee votes from its fans
+B) Step 5 — even if young voters support X because of Y, not all young voters vote based on Y, and not all young voters support X
+C) Step 4 — demographic percentages are unreliable
+D) Both A and B — steps 3 and 5 both contain errors",D
+ttm_errordetect_0013,Error Detection in Reasoning Chains,"Argument: (1) If the butler did it, the weapon was a knife. (2) The weapon was not a knife. (3) Therefore, the butler didn't do it. (4) The cook is the other suspect. (5) Therefore, the cook did it. Which step first introduces an error?","A) Step 3 — modus tollens is invalid
+B) Step 5 — the cook being the only remaining suspect requires all suspects to have been exhausted
+C) Step 1 — conditional premises are unreliable in mysteries
+D) Step 4 — assuming only two suspects is a false dichotomy that first appears here",D
+ttm_errordetect_0014,Error Detection in Reasoning Chains,"Argument: (1) AI systems score higher on IQ tests than the average human. (2) IQ tests measure intelligence. (3) Therefore, AI systems are more intelligent than average humans. Is this argument valid?","A) Valid and sound — test scores define intelligence
+B) Invalid — AI cannot have intelligence by definition
+C) Valid structure but unsound — step 2 is contested; IQ measures certain cognitive abilities, not general intelligence
+D) Valid and sound only for narrow-sense intelligence",C
+ttm_errordetect_0015,Error Detection in Reasoning Chains,"Argument: (1) The patient has symptoms A, B, and C. (2) Disease X causes symptoms A, B, and C. (3) Therefore, the patient has Disease X. What error is present?","A) None — the argument follows from the premises
+B) Step 1 is unreliable — patient-reported symptoms are subjective
+C) Step 3 commits affirming the consequent — other diseases may also cause A, B, and C
+D) Step 2 is an oversimplification — diseases rarely perfectly map to symptom sets",C
+ttm_errordetect_0016,Error Detection in Reasoning Chains,"Argument: (1) For every action there is an equal and opposite reaction (Newton's 3rd law). (2) I push on a wall. (3) The wall pushes back equally. (4) Therefore, the net force is zero and the wall doesn't move. (5) My push doesn't do anything. Which step is wrong?","A) Step 3 — the wall doesn't actually push back
+B) Step 5 — wrong conclusion but correctly derived from step 4
+C) Step 4 — Newton's 3rd law pairs act on DIFFERENT objects; the net force argument is wrong because the equal forces act on different bodies
+D) Step 1 — Newton's 3rd law doesn't apply to static situations",C
+ttm_errordetect_0017,Error Detection in Reasoning Chains,"Argument: (1) I asked 10 friends if they exercise regularly. (2) 8 of 10 said yes. (3) Therefore, 80% of people exercise regularly. (4) Therefore, public health campaigns encouraging exercise are unnecessary. Where is the first error?","A) Step 2 — friends might lie about exercise
+B) Step 4 — even if 80% exercise, campaigns for the remaining 20% are worthwhile
+C) Step 3 — convenience sample of friends is not representative; selection and social desirability bias inflate the estimate
+D) Both B and C represent errors at steps 3 and 4",C
+ttm_errordetect_0018,Error Detection in Reasoning Chains,"Argument: (1) Every time I've eaten shellfish, I've gotten sick. (2) I've eaten shellfish 3 times. (3) Therefore, shellfish always makes me sick. (4) Therefore, I am allergic to shellfish. Which evaluation is most precise?","A) The argument is valid throughout — repeated illness establishes allergy
+B) Step 4 is the only error — 3 consistent data points do support a general claim
+C) Step 3 overgeneralizes from 3 observations; step 4 conflates symptom pattern with clinical diagnosis
+D) Step 1 is unreliable — self-reported illness is not verifiable",C
+ttm_errordetect_0019,Error Detection in Reasoning Chains,"Argument: (1) A coin has been flipped 9 times and landed heads each time. (2) The probability of this happening randomly is (0.5)^9 ≈ 0.2%. (3) Therefore, the coin is almost certainly biased. (4) Therefore, the next flip will be tails. Which step first introduces an error?","A) Step 3 — low probability of a sequence doesn't mean the coin is biased
+B) Step 4 — even if the coin is biased toward heads, tails is not more likely on the next flip
+C) Step 2 — the calculation is wrong
+D) Step 3 may be reasonable; step 4 is the error — it commits the gambler's fallacy",D
+ttm_errordetect_0020,Error Detection in Reasoning Chains,"Argument: (1) No humans are immortal. (2) All gods are immortal. (3) Therefore, no humans are gods. This argument is:","A) Valid — the conclusion follows from the premises by valid syllogism
+B) Invalid — you cannot derive a negative universal from two universals this way
+C) Valid and sound only if 'gods' and 'humans' are well-defined
+D) Invalid — contains equivocation on the term 'immortal'",A
+ttm_errordetect_0021,Error Detection in Reasoning Chains,"Argument: (1) The universe has laws. (2) Laws require a lawgiver. (3) Therefore, the universe has a lawgiver (God). The first error is in:","A) Step 1 — 'laws' in physics are descriptive, not prescriptive
+B) Step 3 — even granting steps 1 and 2, the conclusion assumes only one possible lawgiver
+C) Step 2 — this equivocates 'law' (descriptive natural regularity) with 'law' (prescriptive human rule requiring an authority)
+D) Both B and C — equivocation in step 2 and overspecification in step 3",C
+ttm_errordetect_0022,Error Detection in Reasoning Chains,"Argument: (1) Study shows that people who eat breakfast have higher academic performance. (2) School X provides breakfast to all students. (3) Therefore, students at School X will have higher academic performance. What is the primary error?","A) Step 1 may be correlation, not causation — academic performance and breakfast eating may share a common cause (socioeconomic status)
+B) Step 2 — providing breakfast doesn't mean students eat it
+C) Step 3 — academic performance depends on many factors
+D) Both A and B represent errors, with A being more fundamental",D
+ttm_errordetect_0023,Error Detection in Reasoning Chains,"Argument: (1) All bachelors are unmarried. (2) John is unmarried. (3) Therefore, John is a bachelor. What is this argument's flaw?","A) Step 1 is false — not all bachelors are unmarried
+B) Step 2 is unverifiable without evidence about John
+C) Step 3 commits affirming the consequent — being unmarried doesn't entail being a bachelor
+D) There is no flaw — the argument is a valid deduction",C
+ttm_errordetect_0024,Error Detection in Reasoning Chains,Argument: (1) 95% of people who eat X develop condition Y. (2) 95% of people who don't eat X also develop Y. (3) Patient Z eats X and has Y. (4) Eating X caused Y in Patient Z. What is the critical error?,"A) Step 1 — 95% incidence is too high to be realistic
+B) Step 3 — you can't claim someone both eats X and has Y without eliminating confounders
+C) Step 4 — the near-identical rates in step 2 show X is not a risk factor for Y; the inference of causation is unsupported
+D) Step 1 and Step 2 contradict each other and should not be used together",C
+ttm_errordetect_0025,Error Detection in Reasoning Chains,Argument: (1) All A are B. (2) All B are C. (3) All C are D. (4) Therefore all A are D. (5) X is A. (6) Therefore X is D. This argument is:,"A) Invalid — transitivity of 'all' statements only holds for two steps
+B) Invalid at step 4 — three-step transitivity requires special conditions
+C) Valid — the chain of universal affirmatives is a valid syllogistic extension
+D) Valid only if A, B, C, D are mutually exclusive categories",C
+ttm_errordetect_0026,Error Detection in Reasoning Chains,"Argument: (1) The fact that we have not detected alien life means it doesn't exist (Argument from Ignorance). (2) No alien life means Earth is the only planet with life. (3) Therefore, Earth life is cosmically unique and precious. The error is:","A) Step 2 — not detecting aliens doesn't rule out non-detectable life
+B) All three steps contain independent errors
+C) Step 3 — uniqueness doesn't imply preciousness
+D) Step 1 — absence of evidence is not evidence of absence, especially given detection limits",D
+ttm_errordetect_0027,Error Detection in Reasoning Chains,"Argument: (1) Historical data shows that economies with high tariffs grew slower. (2) Country A had high tariffs in Period P. (3) Country A grew slowly in Period P. (4) Therefore, high tariffs caused slow growth in Country A. What is the primary error?","A) Step 1 — historical economic data is unreliable
+B) Step 2 — tariff levels change frequently and cannot be characterized as 'high' for a full period
+C) Step 3 — growth data is subjective
+D) Step 4 — even with correlation and a specific case, inferring causation ignores confounders (global recession, political instability, etc.)",D
+ttm_errordetect_0028,Error Detection in Reasoning Chains,"Argument: (1) Person A argues that Policy X is good. (2) Person A has a financial interest in Policy X. (3) Therefore, Person A's argument for Policy X is wrong. What fallacy is committed?","A) Straw man — misrepresenting Person A's argument
+B) False cause — assuming interest produces false arguments
+C) Appeal to authority — using Person A's position
+D) Ad hominem (circumstantial) — attacking the person's motive rather than the argument's content",D
+ttm_errordetect_0029,Error Detection in Reasoning Chains,"Argument: (1) Increasing the minimum wage raises labor costs for businesses. (2) Higher labor costs reduce hiring. (3) Therefore, increasing minimum wage reduces employment. (4) This policy will hurt workers. Evaluate this argument:","A) The argument is logically valid throughout and steps 1-4 follow necessarily
+B) The argument is valid in structure but step 2 is empirically contested — monopsony models predict different outcomes
+C) Step 4 is an error — reduced employment doesn't necessarily hurt workers who keep their jobs
+D) Both B and C correctly identify independent problems in the argument",D
+ttm_errordetect_0030,Error Detection in Reasoning Chains,"Argument: (1) Speed cameras reduce speed violations. (2) Speed violations cause accidents. (3) Therefore, speed cameras reduce accidents. (4) Therefore, adding more speed cameras will proportionally reduce accidents. Which step introduces the first new error?","A) Step 3 — the causal chain from steps 1 and 2 doesn't guarantee step 3
+B) Step 1 — speed cameras may not reduce violations, only shift their location
+C) Step 2 — correlation between violations and accidents is not causation
+D) Step 4 — assumes a linear dose-response where diminishing returns or displacement effects may apply",D
+ttm_epistemic_0001,Epistemic Humility vs. Knowledge Claims,A doctor examines a patient with textbook symptoms of appendicitis. She says 'I'm not certain enough to operate without more tests.' The patient's appendix ruptures during the delay. Was the doctor's epistemic humility appropriate?,"A) Yes — medical decisions should always await certainty
+B) No — the doctor failed procedurally, not epistemically
+C) Yes — it is always better to gather more evidence before acting
+D) No — epistemic humility in the face of sufficiently strong evidence has decision costs; the doctor should have committed based on available evidence",D
+ttm_epistemic_0002,Epistemic Humility vs. Knowledge Claims,A scientist says 'We cannot be 100% certain that the Earth is round because our instruments could all be systematically wrong.' A student argues this is appropriate epistemic humility. A philosopher disagrees. Who is right?,"A) The student — 100% certainty is never attainable
+B) Both — uncertainty is valid even when evidence is overwhelming
+C) The student — all claims must be held with equal uncertainty
+D) The philosopher — while absolute certainty is technically unavailable, the practical certainty about Earth's shape is so high that citing instrument doubt is disproportionate",D
+ttm_epistemic_0003,Epistemic Humility vs. Knowledge Claims,"In a Bayesian framework, when should a decision-maker commit to a course of action rather than gathering more information?","A) When probability reaches 100%
+B) When the decision-maker feels subjectively certain
+C) When all evidence has been gathered
+D) When the expected value of gathering additional information is less than its cost",D
+ttm_epistemic_0004,Epistemic Humility vs. Knowledge Claims,"An epidemiologist says 'The evidence suggests masks reduce transmission, but I'm not certain.' A public health official uses this to delay masking policy. The epidemiologist criticizes this use of her statement. Who is behaving more epistemically correctly?","A) The official — acting on uncertain science is reckless
+B) Both — expressing uncertainty always implies waiting for more evidence
+C) The official — policy requires certainty
+D) The epidemiologist — acknowledging uncertainty is not an argument for inaction when the costs of waiting are high",D
+ttm_epistemic_0005,Epistemic Humility vs. Knowledge Claims,"A student asked 'What is 7 × 8?' responds 'I'm not fully certain — it could be 56, but I'd want to verify.' Is this an appropriate display of epistemic humility?","A) Yes — all mathematical claims should be verified
+B) No — it demonstrates low mathematical competence, not epistemic virtue
+C) Yes — memory is fallible and verification is always good practice
+D) No — this represents inappropriate suspension of judgment; 7 × 8 = 56 is a domain where certainty is appropriate",D
+ttm_epistemic_0006,Epistemic Humility vs. Knowledge Claims,"An information cascade occurs when individuals, seeing others' choices, ignore their own private signal. This leads to collective herding even when the herd is wrong. When should an individual break from the information cascade?","A) Always — independent judgment is always better than following others
+B) When the individual's prior confidence exceeds 60%
+C) Never — social information is always more reliable than individual judgment
+D) When the individual's private signal is sufficiently strong to overcome the Bayesian update implied by the cascade",D
+ttm_epistemic_0007,Epistemic Humility vs. Knowledge Claims,"Two experts in a field disagree about a policy. A politician says 'Experts disagree, so we can't act.' A philosopher of science argues this is an invalid inference. Why?","A) Expert disagreement always signals that neither side has evidence
+B) The philosopher is wrong — expert disagreement always warrants policy inaction
+C) Politicians should always defer to the majority of experts
+D) Expert disagreement on specific details doesn't imply equal uncertainty across all aspects — consensus on core facts may be strong even with disagreement on implementation",D
+ttm_epistemic_0008,Epistemic Humility vs. Knowledge Claims,A philosopher argues: 'Agnosticism about controversial questions is always the most rational position.' A pragmatist counters that agnosticism can itself be a choice with consequences. Who has the better argument?,"A) The philosopher — neutrality is always epistemically superior
+B) Neither — the question cannot be resolved without knowing the specific issue
+C) The philosopher — rationality requires suspending judgment on controversial issues
+D) The pragmatist — withholding judgment in contexts requiring action has implicit effects equivalent to making a choice",D
+ttm_epistemic_0009,Epistemic Humility vs. Knowledge Claims,A climate scientist says 'We are 97% confident in anthropogenic climate change.' A journalist reports 'Scientists are not certain about climate change.' Is the journalist's framing epistemically defensible?,"A) Yes — 97% is not 100%, so uncertainty exists
+B) No, but the journalist's error is ethical, not epistemic
+C) Yes — scientific confidence is inherently provisional
+D) No — the journalist equivocates between 'not certain' (which technically applies) and 'meaningfully uncertain' (which misrepresents the 97% consensus)",D
+ttm_epistemic_0010,Epistemic Humility vs. Knowledge Claims,"A decision must be made now. Two advisors present: Advisor A with 70% confidence in option X, Advisor B with 70% confidence in option Y. A manager says 'Since they disagree equally, I should flip a coin.' Is this correct?","A) Yes — equal confidence in opposite directions means equal probability
+B) No — the manager should average their recommendations
+C) Yes — equal expert confidence is the definition of genuine uncertainty
+D) Not necessarily — the manager should examine which advisor has better calibration history and domain expertise before treating them as equal",D
+ttm_epistemic_0011,Epistemic Humility vs. Knowledge Claims,"A judge instructs a jury: 'If you are not 100% certain, you must acquit.' A legal scholar argues this standard is unworkable and epistemically confused. Why?","A) Because certainty is achievable in criminal cases with enough evidence
+B) Because the judge's instruction contradicts constitutional protections
+C) Because juries should convict based on probability alone
+D) Because no empirical claim in a trial ever reaches 100% certainty; the legal standard of 'beyond reasonable doubt' is a practical threshold, not absolute certainty",D
+ttm_epistemic_0012,Epistemic Humility vs. Knowledge Claims,"After receiving 20 pieces of evidence all pointing to conclusion C, a researcher says 'I now assign 99.9% probability to C.' A critic says 'You should still be more uncertain.' The most epistemically precise response to the critic is:","A) The critic is right — 99.9% is always overconfident
+B) The researcher is right — more evidence always justifies higher confidence
+C) The critic is right — scientific claims should never exceed 95% confidence
+D) The researcher may be correct if 99.9% reflects the actual likelihood given the evidence; the critic must specify what additional uncertainty source they have in mind",D
+ttm_epistemic_0013,Epistemic Humility vs. Knowledge Claims,A novice investor is told: 'The stock market is very uncertain — nobody knows what will happen.' She concludes: 'I'll just pick randomly.' An experienced investor says: 'Not all uncertainty is equal — some strategies have better expected values.' Who is right?,"A) The novice — uncertainty means all options are equal
+B) Both — uncertainty justifies both random picking and systematic strategies equally
+C) The novice — in efficient markets, all strategies have equal expected returns
+D) The experienced investor — irreducible uncertainty about outcomes doesn't preclude systematic differences in expected value",D
+ttm_epistemic_0014,Epistemic Humility vs. Knowledge Claims,"An ethicist argues: 'Because we cannot be certain of the right answer to a moral dilemma, we should refuse to act.' A consequentialist disagrees. What is the consequentialist's strongest counterargument?","A) Certainty is achievable in ethics if you reason hard enough
+B) Ethics does not require certainty, only majority opinion
+C) Consequentialism solves all moral dilemmas definitively
+D) Refusing to act is itself an action with moral consequences; moral uncertainty cannot justify paralysis",D
+ttm_epistemic_0015,Epistemic Humility vs. Knowledge Claims,"A forecaster assigns equal 50/50 probability to every political event. When asked why, he says 'I could always be wrong, so I remain neutral.' A Bayesian evaluator says this is a calibration failure. Is the evaluator correct?","A) No — 50/50 is always the most honest forecast under uncertainty
+B) Yes, but only if the events are not genuinely coin-flip-like
+C) No — the forecaster demonstrates appropriate epistemic humility
+D) Yes — using 50/50 when base rates and evidence differ from 50/50 is a refusal to incorporate available information",D
+ttm_epistemic_0016,Epistemic Humility vs. Knowledge Claims,A scientist refuses to publish findings because 'I could have made a mistake somewhere.' Her colleague argues this is not virtuous humility but a failure of scientific duty. Who is more correct?,"A) The scientist — unpublished uncertain findings are not false findings
+B) Neither — the decision depends on the magnitude of the claimed findings
+C) The scientist — publication without certainty misleads the public
+D) The colleague — all published science acknowledges fallibility through peer review; refusing to publish indefinitely prevents scientific progress",D
+ttm_epistemic_0017,Epistemic Humility vs. Knowledge Claims,A child asks: 'Is Santa Claus real?' An epistemically over-careful adult says: 'I cannot be 100% certain he doesn't exist.' A direct adult says: 'No.' Which response demonstrates better epistemic judgment?,"A) The careful adult — certainty is never warranted
+B) The careful adult — the question may be symbolic and deserves nuance
+C) Both — it depends on whether the question is being asked literally
+D) The direct adult — the evidence against Santa's literal existence is overwhelming; epistemic humility doesn't require treating it as an open question",D
+ttm_epistemic_0018,Epistemic Humility vs. Knowledge Claims,"In peer review, a reviewer writes: 'I am not an expert in this subdomain and therefore cannot assess the methodology.' The editor accepts the review and uses it as a rejection reason. What epistemic error has occurred?","A) None — humility about expertise is always appropriate
+B) The reviewer should have declared inability to review; using explicit epistemic humility as a rejection reason substitutes ignorance for judgment
+C) The editor is at fault for not finding a qualified reviewer
+D) Both B and C describe genuine epistemic failures in the process",D
+ttm_epistemic_0019,Epistemic Humility vs. Knowledge Claims,A person says: 'I don't know enough to have an opinion on climate policy.' A second person says: 'The basics of climate science are established enough that anyone can form a policy-relevant opinion.' Who is more correct?,"A) The first — policy requires expert knowledge
+B) Both are correct — it depends on the specific policy in question
+C) The first — all policy opinions without expertise are uninformed
+D) The second — sufficient knowledge for basic policy judgments is widely accessible; claiming total ignorance on well-established science is an epistemic error",D
+ttm_epistemic_0020,Epistemic Humility vs. Knowledge Claims,A Bayesian updates their belief from 50% to 90% based on evidence. They then say: 'But I should return to 50% because I might have interpreted the evidence wrong.' A statistician calls this 'epistemic cowardice.' Is the statistician right?,"A) No — reconsidering evidence interpretation is always rational
+B) Yes, but only if the original update used objective probabilities
+C) No — the 50% prior is always a safe fallback
+D) Yes — reverting to a non-committal prior after proper Bayesian updating, without specific reason to doubt the update, is failure to commit to rational inference",D
+ttm_epistemic_0021,Epistemic Humility vs. Knowledge Claims,"During a fire emergency, a manager says 'I'm not sure this is dangerous enough to evacuate.' An employee evacuates anyway on instinct. The fire turns out to be major. Whose epistemic stance was better?","A) The manager — decisions should be based on evidence, not instinct
+B) The employee — in asymmetric risk situations, acting on uncertain threat signals is correct even without certainty
+C) The manager — emergency decisions require authority, not individual judgment
+D) Both — the manager's caution and the employee's action were both valid responses to uncertainty",B
+ttm_epistemic_0022,Epistemic Humility vs. Knowledge Claims,"A market analyst says: 'I refuse to recommend buying or selling because markets are efficient and I can't beat them.' Her client asks: 'Given your expertise in this specific niche, can you beat the market there?' She still refuses. Has she made an epistemic or practical error?","A) Epistemic — she overgeneralizes from broad market efficiency to niche efficiency
+B) Practical — she has wasted her expertise
+C) Neither — market efficiency implies no one can beat any market
+D) Both A and B — the overgeneralization leads to a practical waste of genuine skill",D
+ttm_epistemic_0023,Epistemic Humility vs. Knowledge Claims,"A student writes that the evidence strongly supports X, though of course more research is needed. A reviewer says the caveat adds nothing and is reflexively epistemic humility. Is the reviewer right?","A) No — 'more research is needed' is always a valid epistemic caveat
+B) Yes — in many contexts, this phrase is a meaningless ritual that signals humility without adding informational content
+C) No — the phrase satisfies the norm of provisional scientific communication
+D) Yes, but only when the evidence is unusually strong",B
+ttm_epistemic_0024,Epistemic Humility vs. Knowledge Claims,"Someone says: 'I don't know if I'm making the right decision, but I'm going to decide anyway.' A philosopher calls this 'acting under moral uncertainty' and calls it rational. An objector says: 'Deciding without knowing the right answer is reckless.' Who is right?","A) The objector — decisions without certainty are reckless
+B) The philosopher — acting under uncertainty is unavoidable; refusing to decide is itself a decision with consequences
+C) The objector — only if the stakes are high
+D) Both — the correctness depends on whether the uncertainty can be resolved with more time",B
+ttm_epistemic_0025,Epistemic Humility vs. Knowledge Claims,"A group of 100 forecasters independently assess the same question, all with private information. The aggregate forecast is 72%. One member has unique information that increases their private estimate to 90%. Should this member defer to the aggregate?","A) Yes — aggregates are always more accurate than individuals
+B) No — if the private information is not included in the aggregate, this member's estimate has genuine additional value and they should weight it appropriately
+C) Yes — the wisdom of crowds principle applies universally
+D) No — individual confidence always beats group estimates",B
+ttm_monitoring_0001,Metacognitive Monitoring Failures,"A student reads a textbook chapter quickly and feels they understand it. When tested, they score 40%. Their reading fluency had created an illusion of comprehension. This is primarily an example of:","A) The spacing effect — they didn't space their practice
+B) The fluency illusion — processing ease is misattributed to deep understanding
+C) Test anxiety — they understood it but panicked during the exam
+D) The testing effect — they would have scored better if tested immediately",B
+ttm_monitoring_0002,Metacognitive Monitoring Failures,A person strongly believes they know a word's meaning but cannot define it when asked. This is best classified as:,"A) Tip-of-the-tongue phenomenon — access failure, not knowledge failure
+B) Feeling-of-knowing without actual knowing — a monitoring failure
+C) Normal forgetting — everyone misremembers words
+D) Working memory overload — they know it but couldn't retrieve under pressure",B
+ttm_monitoring_0003,Metacognitive Monitoring Failures,Research shows that people rate their understanding of mechanical devices (like toilets or zippers) higher before being asked to explain them than after attempting an explanation. What phenomenon does this demonstrate?,"A) The curse of knowledge — they know too much to explain simply
+B) The illusion of explanatory depth — perceived understanding is higher than actual understanding until tested
+C) Working memory limitations — explaining reduces concurrent understanding
+D) Expertise reversal — experts explain worse than novices",B
+ttm_monitoring_0004,Metacognitive Monitoring Failures,A student who has studied using only highlighting believes they are prepared for an exam. Research on learning strategies would predict:,"A) They will perform well — highlighting focuses attention on key material
+B) They will perform poorly — highlighting is a passive strategy that creates fluency illusion without deep encoding
+C) They will perform about average — highlighting is as effective as other methods
+D) They will perform well only if they highlighted more than 30% of the text",B
+ttm_monitoring_0005,Metacognitive Monitoring Failures,A person is in a tip-of-the-tongue (TOT) state for a fact. They feel certain they know it. They eventually recall a wrong answer and feel confident it's right. The TOT feeling is being used as a proxy for:,"A) Memory strength — the feeling of knowing tracks actual memory reliability
+B) Accuracy — TOT generates confidence that is not warranted for the specific retrieved answer
+C) Relevance — they are retrieving something adjacent to the target
+D) Encoding strength — strong encoding produces TOT states",B
+ttm_monitoring_0006,Metacognitive Monitoring Failures,"In a study, people who scored lowest on a logic test felt MOST confident they had done well. This finding replicates across domains. The most likely explanation is:","A) The worst performers are simply more optimistic by personality
+B) The skill required to do well is the same skill required to recognize poor performance — lacking it produces both poor performance and poor self-assessment
+C) The test was too hard for everyone, causing random confidence assignments
+D) Low-scorers misunderstood the confidence question",B
+ttm_monitoring_0007,Metacognitive Monitoring Failures,"A person is highly fluent in discussing quantum mechanics using correct terminology. When asked to predict a novel quantum phenomenon, they fail consistently. Their fluency with the language of quantum mechanics creates:","A) A valid basis for confidence — linguistic fluency tracks understanding
+B) A metacognitive illusion — verbal facility in a domain is mistaken for deep mechanistic understanding
+C) No metacognitive effect — they may simply be applying knowledge correctly
+D) The curse of knowledge — too much detail obscures basic predictions",B
+ttm_monitoring_0008,Metacognitive Monitoring Failures,"After being told that information is 'from a study' (vs. 'just my opinion'), people rate it as more credible, even when the information is identical. This illustrates:","A) Appropriate updating on source reliability
+B) Source monitoring failure combined with misplaced credibility heuristics — form of presentation overrides content evaluation
+C) The authority heuristic — deferring to scientific sources is always rational
+D) Confirmation bias — people accept study findings that match their beliefs",B
+ttm_monitoring_0009,Metacognitive Monitoring Failures,"A programmer finishes a complex code review feeling satisfied they understood it. Later, when asked to spot a bug, they cannot find it. The review confidence most likely stemmed from:","A) Appropriate confidence — some bugs are too subtle to catch on review
+B) Metacognitive monitoring failure — the act of reading without active testing created the feeling of understanding without actual deep processing
+C) Time pressure — insufficient review time created overconfidence
+D) Confirmation bias — they expected correct code and found it",B
+ttm_monitoring_0010,Metacognitive Monitoring Failures,"A person argues that since they feel very confident about a memory, it must be accurate. Research on eyewitness testimony most directly challenges this assumption with what finding?","A) Eyewitnesses rarely feel confident about their memories
+B) Confidence in eyewitness memory is poorly correlated with memory accuracy — high-confidence errors are common
+C) Confidence correctly predicts accuracy only in emotionally neutral situations
+D) Memory accuracy increases with confidence above 80% certainty",B
+ttm_monitoring_0011,Metacognitive Monitoring Failures,"A student takes practice tests and scores 95% each time. In the real exam, they score 70%. The most metacognitively relevant explanation is:","A) Test anxiety caused performance to drop
+B) The practice tests were too similar to study materials, producing performance that didn't transfer to novel exam conditions
+C) The real exam was unfairly different from the course material
+D) The student was overconfident and didn't study enough",B
+ttm_monitoring_0012,Metacognitive Monitoring Failures,"When people read an argument in an easy-to-read font vs. a hard-to-read font, they rate the easy-to-read version as more logical. This phenomenon is called:","A) The framing effect — presentation context affects judgment
+B) Processing fluency effect — ease of processing is misattributed to argument quality
+C) Cognitive ease heuristic in Kahneman's System 1
+D) Both B and C — they describe the same phenomenon at different levels",D
+ttm_monitoring_0013,Metacognitive Monitoring Failures,"A person believes they understand a complex theory after reading a clear summary. If asked to generate novel predictions from the theory, they will likely:","A) Perform well — a clear summary produces good understanding
+B) Perform poorly — reading a summary builds recognition familiarity, not generative understanding
+C) Perform well, but only on simple predictions close to the summary content
+D) Perform poorly due to the theory's inherent difficulty, not due to summary quality",B
+ttm_monitoring_0014,Metacognitive Monitoring Failures,A chess novice watches a grandmaster's game and thinks 'I would have made the same moves — I understand chess well.' Which metacognitive failure is occurring?,"A) Recognition-hindsight bias — the moves seem obvious in hindsight but would not have been found prospectively
+B) The beginner's mind fallacy — novices overestimate game understanding
+C) Mere exposure effect — watching good chess inflates self-assessment
+D) Both A and B — they reinforce each other here",D
+ttm_monitoring_0015,Metacognitive Monitoring Failures,A medical student who has memorized drug names and mechanisms feels confident they could prescribe correctly. An attending physician says 'Clinical prescribing requires much more than memorization.' The student's metacognitive error is:,"A) Overconfidence in factual recall
+B) Failure to recognize the gap between declarative knowledge (facts) and procedural/adaptive knowledge (clinical judgment)
+C) Dunning-Kruger at the student stage
+D) Both B and C are accurate descriptions of the same failure",D
+ttm_monitoring_0016,Metacognitive Monitoring Failures,Research shows that people are worst at estimating their performance in domains where they have MODERATE knowledge. Novices and experts are better calibrated. What explains this U-shaped calibration pattern?,"A) Moderate knowledge produces the most cognitive effort, which disrupts calibration
+B) Novices know they don't know; experts know their domain well enough to assess limits; moderate knowledge creates false confidence without sufficient expertise to recognize limits
+C) Moderate knowledge is the least useful level and produces random performance
+D) The U-shape is a statistical artifact of test design, not a real metacognitive pattern",B
+ttm_monitoring_0017,Metacognitive Monitoring Failures,"An AI language model gives confident, fluent answers to questions outside its reliable knowledge base. A user interprets the fluency as accuracy. What is the user's metacognitive error?","A) Misplaced trust in technology — users should never trust AI
+B) Using fluency of output as a proxy for accuracy — a transferred fluency-processing heuristic to a domain where it doesn't apply
+C) Confirmation bias — the user wants the AI's answer to be correct
+D) Authority heuristic — AI is perceived as an authoritative source",B
+ttm_monitoring_0018,Metacognitive Monitoring Failures,A scientist accurately identifies the flaw in an opponent's methodology but is unaware of the same flaw in her own research. This represents:,"A) Motivated skepticism — she applies different scrutiny to evidence based on desired conclusions
+B) Domain-specific expertise — she happens to notice flaws in that particular method
+C) Confirmation bias in the negative direction
+D) Both A and C describe the same phenomenon",D
+ttm_monitoring_0019,Metacognitive Monitoring Failures,"After reading about a topic briefly, a person feels they could explain it to others. When they attempt to do so, they realize they cannot. Which intervention would BEST prevent this metacognitive failure in advance?","A) Reading more slowly and highlighting key points
+B) Attempting to generate an explanation during learning (the generation effect) rather than simply reading
+C) Taking a 24-hour break before attempting to explain
+D) Reading multiple sources on the same topic",B
+ttm_monitoring_0020,Metacognitive Monitoring Failures,An expert who has explained a concept thousands of times begins to use shortcuts and jargon that make sense to them but confuse novices. They are surprised that novices don't understand. This is called:,"A) Expert blindness — forgetting what novices don't know
+B) The curse of knowledge — inability to recover what it was like not to know something
+C) Familiarity bias — overestimating the clarity of familiar explanations
+D) All three describe the same phenomenon from slightly different angles",D
+ttm_monitoring_0021,Metacognitive Monitoring Failures,A study shows that people who are most confident about political facts are more likely to get them wrong than people with moderate confidence. This suggests:,"A) Political knowledge and confidence are inversely related in general
+B) In partisan-charged domains, high confidence may reflect identity-protective cognition rather than genuine knowledge
+C) Political facts are too complex to be known confidently
+D) Survey respondents lie about their confidence",B
+ttm_monitoring_0022,Metacognitive Monitoring Failures,"A person learns that they failed a memory task. When asked to predict their score on a similar task, they predict they will do well again. This persistent overconfidence despite failure feedback is called:","A) Optimism bias — general tendency toward positive predictions
+B) Illusion of knowing — memory monitoring system fails to update after error feedback
+C) Egocentric bias — attributing failures to external factors
+D) Self-serving attribution — one failure is not predictive in their view",B
+ttm_monitoring_0023,Metacognitive Monitoring Failures,"In a classic study, participants who were shown a word subliminally (too fast to consciously see) later judged it as more 'true' when it appeared on a recognition test. This demonstrates:","A) Unconscious learning is more reliable than conscious learning
+B) Mere exposure effect creating false familiarity that is misidentified as truth — a source monitoring failure
+C) Perceptual priming enhances word recognition accuracy
+D) Subliminal exposure bypasses the critical thinking filter",B
+ttm_monitoring_0024,Metacognitive Monitoring Failures,A student consistently overestimates how much they will remember one week after studying. The best metacognitive intervention is:,"A) Study more hours to compensate for expected forgetting
+B) Take a recall test immediately after studying to calibrate actual retention vs. expected retention
+C) Use spaced repetition apps to schedule future review
+D) Reduce confidence in memory claims to account for expected forgetting",B
+ttm_monitoring_0025,Metacognitive Monitoring Failures,An experienced surgeon performs a routine operation and makes a preventable error she has never made before. Post-hoc analysis reveals she was in an automatic processing mode. What metacognitive principle does this illustrate?,"A) Expertise creates overconfidence that leads to careless errors
+B) Highly automatic expert performance can bypass monitoring systems, creating vulnerability to novel errors that novices might avoid through deliberate checking
+C) The surgeon was distracted — this is an attentional, not metacognitive, issue
+D) Routine procedures should be performed by novices for safety",B
+ttm_monitoring_0026,Metacognitive Monitoring Failures,Research on 'illusion of knowing' shows that people judge their comprehension of a passage to be higher when the passage is accompanied by a relevant image — even when the image adds no semantic content. What does this show?,"A) Visual context genuinely aids comprehension of text
+B) Irrelevant perceptual richness increases metacognitive confidence without improving understanding — a monitoring error
+C) Multimedia learning is universally beneficial
+D) Images interfere with reading by splitting attention",B
+ttm_monitoring_0027,Metacognitive Monitoring Failures,A therapist reports high confidence in diagnosing a client after a 50-minute session. Research on clinical judgment suggests this confidence is:,"A) Well-placed — trained clinicians have high diagnostic accuracy
+B) Often miscalibrated — clinical confidence increases faster than actual diagnostic accuracy with session length
+C) Appropriate only for common presentations
+D) Dependent on whether the clinician uses structured instruments",B
+ttm_monitoring_0028,Metacognitive Monitoring Failures,A person 'knows' their social security number but realizes under stress they cannot recall all nine digits. Their feeling of knowing the full number was:,"A) Accurate — they do know it but stress disrupted retrieval
+B) Partially accurate — they had enough knowledge to support a feeling of knowing but not complete reconstructive access
+C) Entirely inaccurate — if they cannot recall under stress, they never knew it
+D) Both A and B are plausible explanations",D
+ttm_monitoring_0029,Metacognitive Monitoring Failures,"In a study, people who were asked to 'think about why you know X' before a test showed WORSE calibration than those who weren't. Why?","A) Introspection is always unreliable
+B) Generating justifications increases subjective confidence independently of actual knowledge, inflating it above calibrated levels
+C) Thinking about knowledge disrupts memory consolidation
+D) The task confused participants, reducing performance",B
+ttm_monitoring_0030,Metacognitive Monitoring Failures,"An AI model is fine-tuned on confident-sounding text from domain experts. After fine-tuning, it produces more confident answers across all domains, including those outside training. What metacognitive failure is the model exhibiting?","A) Domain overfitting — it's applying domain-specific confidence universally
+B) A transferred fluency-confidence heuristic — confidence learned in appropriate contexts is generalized to inappropriate ones, producing systematic overconfidence
+C) Hallucination — a distinct failure from metacognitive miscalibration
+D) Both B and C simultaneously describe the failure",B
+ttm_strategic_ign_0001,Strategic Ignorance and Information Avoidance,Odysseus instructed his crew to tie him to the mast and ignore his future instructions to be released when sailing past the Sirens. This is a canonical example of:,"A) Irrational behavior — he was unable to trust himself
+B) A Ulysses contract — rational pre-commitment that restricts future self-defeating behavior
+C) Strategic ignorance — blocking information to avoid temptation
+D) Epistemic cowardice — avoiding an experience out of fear",B
+ttm_strategic_ign_0002,Strategic Ignorance and Information Avoidance,A person with a family history of Huntington's disease declines genetic testing. They report that knowing they carry the gene would cause severe anxiety and they prefer to live without that knowledge. Is this information avoidance rational?,"A) No — refusing medical information is always irrational
+B) Yes — if the expected psychological cost of the information exceeds its expected decision value (since there is no curative treatment), avoidance can be rational
+C) No — uncertainty about a fatal illness causes more anxiety than knowing
+D) Yes, but only if they have no children who might inherit the gene",B
+ttm_strategic_ign_0003,Strategic Ignorance and Information Avoidance,A judge in a criminal case is asked to 'disregard' inadmissible evidence. Research shows this instruction often backfires. What metacognitive phenomenon explains this?,"A) The backfire effect — being told to ignore something makes it more influential
+B) The ironic process theory — deliberate suppression of a thought often increases its accessibility
+C) Motivated reasoning — judges unconsciously retain evidence that confirms their initial impression
+D) Both B and C together explain the paradox",D
+ttm_strategic_ign_0004,Strategic Ignorance and Information Avoidance,An investor chooses not to check their portfolio during a market crash. This avoidance strategy is most likely to be rational when:,"A) The market is expected to recover and checking would trigger panic selling against their own long-term interest
+B) They lack the financial expertise to interpret the data
+C) The crash is small and not worth monitoring
+D) All of the above make avoidance equally rational",A
+ttm_strategic_ign_0005,Strategic Ignorance and Information Avoidance,A lawyer advises their client: 'Don't ask employees about certain safety violations — then you can honestly say you don't know.' This is called:,"A) Plausible deniability — a legitimate legal strategy
+B) Willful blindness — deliberately avoiding information to escape legal or moral responsibility
+C) Strategic ignorance — a rational form of information management
+D) Attorney-client privilege in action",B
+ttm_strategic_ign_0006,Strategic Ignorance and Information Avoidance,An autonomous vehicle has access to a passenger's medical history. Knowing the passenger has heart disease could affect the car's driving pattern. Should the car use this information?,"A) Yes — all available information should be used to optimize outcomes
+B) Not necessarily — using medical information creates privacy risks and might override the passenger's autonomous preferences
+C) Yes — safety justifies any information use
+D) No — AI systems should never use personal medical data under any circumstances",B
+ttm_strategic_ign_0007,Strategic Ignorance and Information Avoidance,Research shows that people who track their calorie intake obsessively sometimes end up eating MORE after days they exceed their target ('what the hell' effect). What does this imply about the value of precise information?,"A) Precise information always improves self-regulation
+B) In some contexts, precise information triggers maladaptive responses; coarser tracking or no tracking may produce better outcomes
+C) The research shows calorie tracking is universally harmful
+D) The 'what the hell' effect is a cognitive bias that should be overcome through more precise tracking",B
+ttm_strategic_ign_0008,Strategic Ignorance and Information Avoidance,"A biosecurity researcher discovers a pathogen synthesis route that, if published, would accelerate pandemic risk. They choose not to publish. Which framework best justifies this decision?","A) Information suppression is never scientifically justified
+B) Information hazard theory — some true information causes harm that outweighs its benefits, justifying non-disclosure
+C) Precautionary principle — uncertainty about harm justifies withholding
+D) Both B and C provide valid justifications",D
+ttm_strategic_ign_0009,Strategic Ignorance and Information Avoidance,"A person about to make an irreversible decision (e.g., having surgery) deliberately avoids reading horror stories about the procedure. Is this rational?","A) No — all available information should be reviewed before major decisions
+B) Yes — if the decision is already optimally made, consuming distressing anecdotes that cannot change it offers no benefit and imposes psychological cost
+C) No — informed consent requires reviewing all possible outcomes
+D) Yes, but only if the patient trusts the doctor completely",B
+ttm_strategic_ign_0010,Strategic Ignorance and Information Avoidance,An experiment finds that judges who are told 'ignore this evidence — it's inadmissible' still give different verdicts than those who are never exposed to the evidence. This finding implies:,"A) Judges are corrupt and deliberately use inadmissible evidence
+B) Conscious instructions to ignore information are often insufficient to prevent its influence — information, once received, is hard to unprocess
+C) Inadmissibility rules should be abolished as ineffective
+D) The finding is limited to untrained judges; professionals can ignore effectively",B
+ttm_strategic_ign_0011,Strategic Ignorance and Information Avoidance,"An employer explicitly chooses NOT to conduct pre-employment drug tests, stating 'if we test, we eliminate good candidates who are occasional recreational users.' Is this strategic ignorance rational?","A) No — employers are always legally required to test
+B) Yes — choosing not to gather information that would trigger a suboptimal decision process can be a rational information management strategy
+C) No — strategic ignorance is only rational when information is harmful, not when it's inconvenient
+D) Yes, but only for low-safety roles",B
+ttm_strategic_ign_0012,Strategic Ignorance and Information Avoidance,A negotiator enters talks knowing that learning the other party's 'bottom line' before formal negotiation might constrain what they can ethically demand. They choose not to ask. This strategy is:,"A) Irrational — knowing the bottom line is always advantageous
+B) Strategically rational — remaining deliberately ignorant preserves flexibility and avoids premature anchoring
+C) Unethical — information withholding in negotiation is deceptive
+D) Neither rational nor irrational — negotiators should use all available information",B
+ttm_strategic_ign_0013,Strategic Ignorance and Information Avoidance,A government classifies a scientific study on the effectiveness of a controversial policy. A civil liberties group says this is wrong. A security official says it's necessary. The strongest argument FOR classification is:,"A) Government has the right to classify anything
+B) If publication would reveal information useful to adversaries and the public can be informed of policy outcomes without the technical details, classification may protect security without harming public accountability
+C) The study might be politically embarrassing
+D) All government studies should be classified by default",B
+ttm_strategic_ign_0014,Strategic Ignorance and Information Avoidance,"A study finds that doctors who see their own mortality statistics for a procedure (e.g., their patients die 3x the national average) improve their outcomes. But a different study shows that other doctors who see the same statistics become paralyzed with risk aversion and under-treat. What does this imply about the universal value of transparency in medicine?","A) Transparency is always better — outcomes improve with information
+B) The value of information is heterogeneous — for some practitioners, information improves decisions; for others, it degrades them
+C) Risk aversion after seeing bad statistics is appropriate — under-treatment is safer
+D) Mortality statistics should be withheld from all doctors to prevent anxiety",B
+ttm_strategic_ign_0015,Strategic Ignorance and Information Avoidance,An AI alignment researcher argues that some threat models should not be widely published because they could inspire bad actors. A transparency advocate argues that open publication allows collective defense. This trade-off is best described as:,"A) A false dilemma — all security research should be published
+B) An information hazard dilemma requiring case-by-case analysis of expected benefit to defenders vs. expected uplift to adversaries
+C) A case for always prioritizing transparency over security
+D) A case for always prioritizing security over transparency",B
+ttm_strategic_ign_0016,Strategic Ignorance and Information Avoidance,"A person considering whether to take a new job deliberately avoids reading Glassdoor reviews before accepting. After accepting, they read them and feel better. Was their avoidance strategy rational?","A) No — they should have gathered all information before deciding
+B) Possibly yes — if Glassdoor reviews would have created unresolvable anxiety about an otherwise good opportunity, and they trusted their other sources of information
+C) No — post-decision rationalization explains why they 'feel better'
+D) Yes — Glassdoor reviews are unreliable",B
+ttm_strategic_ign_0017,Strategic Ignorance and Information Avoidance,"In law, the 'willful blindness' doctrine holds that deliberate ignorance of a fact can constitute the same legal knowledge as actual knowledge. Which scenario best fits this doctrine?","A) A person who genuinely doesn't know their business partner is committing fraud
+B) A person who suspects fraud, deliberately avoids investigating, and proceeds with a suspicious transaction
+C) A person who investigates and finds no evidence of fraud
+D) A person who relies on a lawyer's assurance that something is legal",B
+ttm_strategic_ign_0018,Strategic Ignorance and Information Avoidance,"An autonomous AI system can access real-time stock prices, which would cause it to make more volatile decisions. Its designers restrict this access. Is this a rational design choice?","A) No — more information always improves decision quality
+B) Yes — restricting information that leads to decision instability can be a rational design constraint, particularly when volatility has systemic risks
+C) No — the AI should have access to all available information and manage its own volatility
+D) Yes, but only if the AI is not sophisticated enough to handle price data",B
+ttm_strategic_ign_0019,Strategic Ignorance and Information Avoidance,"A teacher deliberately does not tell students the difficulty level of a test before they take it, believing that knowing would cause high-ability students to underperform and low-ability students to give up. Is this a legitimate pedagogical use of strategic ignorance?","A) No — transparency is always better in education
+B) Potentially yes — if the teacher's model of student responses to difficulty labels is accurate, withholding the label could improve outcomes
+C) No — students have a right to know what they're being tested on
+D) Yes — difficulty labels are always counterproductive",B
+ttm_strategic_ign_0020,Strategic Ignorance and Information Avoidance,"A government agency discovers a security vulnerability in widely used software. It can disclose it (allowing defenders to patch) or retain it (allowing covert offensive use). The agency retains it. Six months later, a criminal group independently discovers the same vulnerability and causes major damage. Was the retention decision rational?","A) Yes — retaining vulnerabilities always serves national security
+B) The decision appears to have been wrong in hindsight, and the rational choice framework requires weighing disclosure benefits vs. retention costs, accounting for the probability of independent discovery
+C) No — agencies should never retain vulnerabilities
+D) Yes — the criminal group's actions were unforeseeable",B
+ttm_strategic_ign_0021,Strategic Ignorance and Information Avoidance,Pre-commitment devices (like locking money in a retirement account with penalties for early withdrawal) work best when:,"A) The individual is sophisticated enough to override them when genuinely needed
+B) The future self's preferences are expected to differ from present preferences in a predictable, exploitable way
+C) The commitment device is completely irrevocable — no escape options
+D) The individual consults an expert before committing",B
+ttm_strategic_ign_0022,Strategic Ignorance and Information Avoidance,Research on placebo effects shows they can work even when patients know they're receiving a placebo ('open-label placebos'). What does this imply about information and treatment outcomes?,"A) Information is irrelevant to biological outcomes
+B) Some beneficial effects of information states (e.g., expectation of improvement) operate through mechanisms that don't require ignorance, challenging the assumption that all strategic ignorance requires deception
+C) Placebos are as effective as real treatments across all conditions
+D) Patients should always be deceived to maximize placebo effects",B
+ttm_strategic_ign_0023,Strategic Ignorance and Information Avoidance,A charity deliberately does not tell potential donors the exact percentage of donations that go to overhead. A transparency advocate says they must disclose. A fundraising expert says 'overhead framing' causes donors to make suboptimal giving choices. Who has the stronger empirical case?,"A) The transparency advocate — donors deserve all information
+B) The fundraising expert — research shows overhead-focused giving actually reduces welfare impact by directing donations to inefficient charities with low overhead but poor outcomes
+C) The transparency advocate — charitable manipulation is always unethical
+D) Both — the empirical case for both positions is equally strong",B
+ttm_strategic_ign_0024,Strategic Ignorance and Information Avoidance,A manager tells her team: 'I don't want to know who reported the problem — just tell me what the problem is.' This information restriction is rational because:,"A) It protects the manager from legal liability for knowing specific individuals
+B) It prevents information about the reporter from biasing the manager's assessment of the problem and encourages more open reporting
+C) It demonstrates good leadership regardless of its epistemic consequences
+D) It violates the manager's duty of care to employees",B
+ttm_strategic_ign_0025,Strategic Ignorance and Information Avoidance,An AI researcher argues: 'Building an AI that can autonomously seek and acquire information is dangerous because some information hazards only become active once processed.' What is the strongest counterargument?,"A) AI should always maximize information acquisition
+B) Restricting information acquisition trades safety benefits against capability benefits and requires identifying specific hazardous information types — blanket restriction is both too conservative and hard to implement
+C) Information hazards don't apply to AI systems
+D) The researcher's concern is valid and AI should never seek new information",B


### PR DESCRIPTION
TSCP: +200 hard questions (nested ToM, pragmatic traps, deception chains). TTM: +200 hard questions (calibration paradoxes, Bayesian traps, error detection). Total: 8,475 questions across 5 tracks. Purpose: improve discriminatory power (30% of competition rubric).