### PR TITLE
Phase 18: Add integration tests for trinity-core Store

### DIFF
--- a/backend/trinity-core/src/store.rs
+++ b/backend/trinity-core/src/store.rs
@@ -210,3 +210,150 @@ pub struct MessageUpdate {
     pub tokens: Option<crate::models::MessageTokens>,
     pub error: Option<crate::models::MessageError>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{
+        AssistantMessage, ContentBlock, SessionState, UserMessage,
+    };
+
+    fn make_session(dir: &str) -> Session {
+        Session::new(dir.to_string())
+    }
+
+    fn make_user_msg(session_id: &str, parent_id: &str) -> Message {
+        Message::User(UserMessage::new(
+            session_id.to_string(),
+            parent_id.to_string(),
+            vec![ContentBlock::text("b1".to_string(), "hello".to_string())],
+        ))
+    }
+
+    fn make_assistant_msg(session_id: &str, parent_id: &str) -> Message {
+        Message::Assistant(AssistantMessage::new(
+            session_id.to_string(),
+            parent_id.to_string(),
+            "claude-sonnet-4-5".to_string(),
+            "anthropic".to_string(),
+        ))
+    }
+
+    #[test]
+    fn session_crud() {
+        let store = Store::new();
+        let s = make_session("/tmp/test");
+        let id = s.id.clone();
+
+        let created = store.create_session(s);
+        assert_eq!(created.id, id);
+
+        let got = store.get_session(&id).unwrap();
+        assert_eq!(got.id, id);
+        assert_eq!(got.directory, "/tmp/test");
+
+        let upd = SessionUpdate {
+            status: Some(SessionState::Busy),
+            title: Some("updated".to_string()),
+            ..Default::default()
+        };
+        let updated = store.update_session(&id, upd).unwrap();
+        assert_eq!(updated.state, SessionState::Busy);
+        assert_eq!(updated.title.unwrap(), "updated");
+
+        assert!(store.delete_session(&id));
+        assert!(store.get_session(&id).is_none());
+    }
+
+    #[test]
+    fn list_sessions_by_directory() {
+        let store = Store::new();
+        let s1 = make_session("/a");
+        let s2 = make_session("/b");
+        store.create_session(s1);
+        store.create_session(s2);
+
+        assert_eq!(store.list_sessions(None).len(), 2);
+        assert_eq!(store.list_sessions(Some("/a")).len(), 1);
+        assert_eq!(store.list_sessions(Some("/c")).len(), 0);
+    }
+
+    #[test]
+    fn message_crud() {
+        let store = Store::new();
+        let s = make_session("/tmp/m");
+        let sid = s.id.clone();
+        store.create_session(s);
+
+        let msg = make_user_msg(&sid, "root");
+        let mid = msg.id().to_string();
+        let created = store.create_message(&sid, msg).unwrap();
+        assert_eq!(created.id(), mid);
+
+        let got = store.get_message(&sid, &mid).unwrap();
+        assert_eq!(got.id(), mid);
+
+        let msgs = store.list_messages(&sid);
+        assert_eq!(msgs.len(), 1);
+
+        assert!(store.delete_message(&sid, &mid));
+        assert!(store.get_message(&sid, &mid).is_none());
+    }
+
+    #[test]
+    fn update_assistant_message() {
+        let store = Store::new();
+        let s = make_session("/tmp/um");
+        let sid = s.id.clone();
+        store.create_session(s);
+
+        let msg = make_assistant_msg(&sid, "root");
+        let mid = msg.id().to_string();
+        store.create_message(&sid, msg);
+
+        let upd = MessageUpdate {
+            completed: Some(true),
+            cost: Some(0.05),
+            ..Default::default()
+        };
+        let updated = store.update_message(&sid, &mid, upd).unwrap();
+        assert_eq!(updated.id(), mid);
+    }
+
+    #[test]
+    fn parts_crud() {
+        let store = Store::new();
+        let part = Part::Text {
+            id: "p1".to_string(),
+            message_id: "m1".to_string(),
+            text: "hello".to_string(),
+            time: None,
+        };
+
+        let added = store.add_part("m1", part).unwrap();
+        assert_eq!(added.id(), "p1");
+
+        let parts = store.list_parts("m1");
+        assert_eq!(parts.len(), 1);
+
+        let got = store.get_part("m1", "p1").unwrap();
+        assert_eq!(got.id(), "p1");
+
+        assert!(store.get_part("m1", "p999").is_none());
+    }
+
+    #[test]
+    fn delete_session_cascades() {
+        let store = Store::new();
+        let s = make_session("/tmp/dc");
+        let sid = s.id.clone();
+        store.create_session(s);
+
+        let msg = make_user_msg(&sid, "root");
+        let mid = msg.id().to_string();
+        store.create_message(&sid, msg);
+
+        assert!(store.delete_session(&sid));
+        assert!(store.list_messages(&sid).is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- Add 6 integration tests for trinity-core Store (session, message, part CRUD)
- Tests verify: create/get/list/update/delete sessions, messages, parts
- Cascading delete test (session -> messages cleanup)
- All 6 tests pass

## Constitutional Laws
- Law #4: .t27 specs are source of truth
- Law #5: No new Rust business logic