### PR TITLE
docs(ci): seal discipline + conformance workflow path — Closes #131

### DIFF
--- a/.github/workflows/seal-coverage.yml
+++ b/.github/workflows/seal-coverage.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'specs/**/*.t27'
       - '.trinity/seals/**'
+      - 'conformance/**'
 
 jobs:
   seal-coverage:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,15 +7,15 @@ Thank you for helping improve T27. This repository is **spec-first**: behavior l
 1. Read **[`SOUL.md`](SOUL.md)** at repo root — **canonical** constitutional law. Use **[`docs/nona-03-manifest/SOUL.md`](docs/nona-03-manifest/SOUL.md)** only as **expanded** reference (especially Law #1 detail); if they disagree, **root `SOUL.md` wins**.
 2. Check **`OWNERS.md`** in the directory you touch (and the repo root **[`OWNERS.md`](OWNERS.md)**) for the **primary** Trinity agent / domain owner.
 3. Open or reference a **GitHub Issue**; pull requests should satisfy the project **Issue Gate** where applicable (`Closes #N`).
-4. Multi-agent coordination: **[`TASK.md`](TASK.md)** and **[`docs/coordination/TASK_PROTOCOL.md`](docs/coordination/TASK_PROTOCOL.md)**.
+4. Multi-agent coordination: root **[`NOW.md`](NOW.md)** (rolling snapshot) and **[`docs/coordination/TASK_PROTOCOL.md`](docs/coordination/TASK_PROTOCOL.md)**. **CI** also requires every PR/push to touch **[`docs/NOW.md`](docs/NOW.md)** (mirror / coordination copy; see [#141](https://github.com/gHashTag/t27/issues/141)).
 
 ## NOW.md sync gates (Ring 033)
 
-Keep **`docs/NOW.md`** current: it is the rolling snapshot for humans and agents (see [#141](https://github.com/gHashTag/t27/issues/141)).
+Keep **both** **`NOW.md` (repo root)** and **`docs/NOW.md`** aligned for handoffs: root is what **`t27c check-now`** reads; **`docs/NOW.md`** must appear in every PR diff for **`now-sync-gate.yml`**.
 
-1. **Local pre-commit:** run once after clone: **`bash scripts/setup-git-hooks.sh`** (sets `core.hooksPath` to **`.githooks/`**). Every commit is blocked unless `docs/NOW.md` **Last updated** line includes **today’s calendar date `YYYY-MM-DD`** (checked against your **local** date when `tri check-now` runs). Prefer **human-readable local wall time** in that line, not UTC `Z`, unless you work in UTC (see **`docs/NOW.md`** header template).
+1. **Local pre-commit:** run once after clone: **`bash scripts/setup-git-hooks.sh`** (sets `core.hooksPath` to **`.githooks/`**). Every commit is blocked unless **root `NOW.md`** **Last updated** line includes **today’s calendar date `YYYY-MM-DD`** (checked against your **local** date when `tri check-now` runs). Prefer **human-readable local wall time** in that line, not UTC `Z`, unless you work in UTC.
 2. **CI:** **`.github/workflows/now-sync-gate.yml`** requires **`docs/NOW.md`** in each PR/push to `master` and checks the date (UTC today or yesterday). **`.github/workflows/phi-loop-ci.yml`** builds **`t27c`**, then runs the same gates through **`./scripts/tri`** (`check-now`, `test`, `validate-conformance`, `validate-gen-headers`). Calendar date for **`tri check-now`** must match the runner’s local “today” (typically UTC on GitHub Actions).
-3. **`tri`:** **`./scripts/tri check-now`** forwards to **`t27c check-now`**; **`gen*`** and **`compile*`** run that gate automatically before invoking codegen.
+3. **`tri`:** **`./scripts/tri check-now`** forwards to **`t27c check-now`** (root **`NOW.md`**); **`gen*`** and **`compile*`** run that gate automatically before invoking codegen.
 
 ## PHI Loop CI — why assistants do not “see” red builds
 
@@ -37,6 +37,16 @@ Install the **GitHub Actions** extension in the editor if you want in-UI log lin
 ```
 
 If **`gen_hash_*` mismatches** appear for many specs, the compiler output changed; refresh seals intentionally (same `--save` per spec or batch policy from maintainers) and commit **`.trinity/seals/*.json`**.
+
+## Seal discipline
+
+1. **Every spec under `specs/`** that you add or materially change should have a matching entry under **`.trinity/seals/<module>.json`**. Generate or refresh with:
+   ```bash
+   ./scripts/tri seal specs/path/to/module.t27 --save
+   ```
+2. **Pull requests:** **[`.github/workflows/seal-coverage.yml`](.github/workflows/seal-coverage.yml)** runs when `specs/**/*.t27`, **`.trinity/seals/**`, or **`conformance/**`** change. It lists changed `specs/**/*.t27` files in the PR and runs **`t27c validate-seals --pr-files …`** so missing or stale seals fail CI.
+3. **Hardening (maintainers, optional):** mark the **Seal Coverage Gate** workflow as a **required status check** under branch protection; extend trigger paths further if new layouts appear.
+4. **Traceability:** seal-related fixes should reference the issue (e.g. [#131](https://github.com/gHashTag/t27/issues/131)) in the PR body when applicable.
 
 ## Specs and tests
 

--- a/NOW.md
+++ b/NOW.md
@@ -5,10 +5,10 @@
 
 # NOW — Rolling integration snapshot
 
-**Last updated:** 2026-04-06 — Monday, 06 April 2026 · 23:27 local time (+07) · RFC3339 2026-04-06T23:27:23+0700
+**Last updated:** 2026-04-06 — Monday, 06 April 2026 · 23:55 local time (+07) · RFC3339 2026-04-06T23:55:00+07:00
 
 **Document class:** Operational focus document
-**Revision:** 2026-04-07 — **NO-SHELL**: `scripts/tri` exec shim → `t27c`. **#129:** `t27c expand-gf16` → **50** rows in `gf16_vectors.json`; `t27c gen-nmse-benchmark` → `nmse_synthetic_roundtrip` in `gf_family_bench.json` (synthetic roundtrip NMSE; `half` crate).
+**Revision:** 2026-04-07 — **NO-SHELL** / **#129** GF16+NMSE (PR #162). **#131 seal CI:** documented in **`CONTRIBUTING.md`** (Seal discipline); **`seal-coverage.yml`** also triggers on **`conformance/**`**.
 **Status:** ACTIVE — replace body on every ring boundary  
 **Queen health:** GREEN / 1.0 (all 17 domains; sealed 2026-04-05T12:00Z) — *verify* `.trinity/state/queen-health.json`  
 **Canonical URL:** `https://github.com/gHashTag/t27/blob/master/NOW.md`
@@ -209,8 +209,10 @@ CROWN (Queen brain & automation)
 | 2.3  | [#131](https://github.com/gHashTag/t27/issues/131) | Seal coverage CI             | **✅ DONE** | `.github/workflows/seal-coverage.yml` (PR-scoped gate)                                                     |
 | 2.4  | —                                                  | GF16 vectors grow            | **✅ DONE** | **`t27c expand-gf16`** → **50** rows in `gf16_vectors.json` (≥33 target); v2 seal recomputed                     |
 | 2.5  | [#163](https://github.com/gHashTag/t27/issues/163) | L5 IDENTITY seal refresh     | **🔄 OPEN** | `FORMAT-SPEC-001.json` → v2 + phi_distance + seal (0.0486326415435630 from gf16_vectors) |
-| 2.6  | —                                                  | Numeric debt sprint          | —      | `[NUMERIC-GF16-DEBT-INVENTORY.md](docs/nona-02-organism/NUMERIC-GF16-DEBT-INVENTORY.md)` — math → nn/vsa → ar |
+| 2.6  | —                                                  | Numeric debt sprint          | **⏳ OPEN** | `[NUMERIC-GF16-DEBT-INVENTORY.md](docs/nona-02-organism/NUMERIC-GF16-DEBT-INVENTORY.md)` — math → nn/vsa → ar (Phase 2.5 bridge → Phase 3 L4) |
 
+
+**Phase 2 handoff:** Steps **2.0–2.4** are **✅** (schema v2, migrate, synthetic NMSE / GF16 expansion, seal coverage workflow). **[#131](https://github.com/gHashTag/t27/issues/131)** is **implemented** via **`seal-coverage.yml`** + **`t27c validate-seals`**. **Remaining:** **[#163](https://github.com/gHashTag/t27/issues/163)** (2.5 identity seal), **2.6** numeric debt sprint.
 
 **Numeric palette:** `[NUMERIC-STANDARD-001.md](docs/nona-02-organism/NUMERIC-STANDARD-001.md)` · `[NUMERIC-GF16-CANONICAL-PICTURE.md](docs/nona-02-organism/NUMERIC-GF16-CANONICAL-PICTURE.md)` · `[NUMERIC-WHY-NOT-GF16-EVERYWHERE.md](docs/nona-02-organism/NUMERIC-WHY-NOT-GF16-EVERYWHERE.md)` · `[NUMERIC-CORE-PALETTE-REGISTRY.md](docs/nona-02-organism/NUMERIC-CORE-PALETTE-REGISTRY.md)`
 

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -5,10 +5,10 @@
 
 # NOW — Rolling integration snapshot
 
-**Last updated:** 2026-04-06 — Monday, 06 April 2026 · 23:27 local time (+07) · RFC3339 2026-04-06T23:27:23+0700
+**Last updated:** 2026-04-06 — Monday, 06 April 2026 · 23:55 local time (+07) · RFC3339 2026-04-06T23:55:00+07:00
 
 **Document class:** Operational focus document
-**Revision:** 2026-04-07 — **NO-SHELL**: `scripts/tri` exec shim → `t27c`. **#129:** `t27c expand-gf16` → **50** rows in `gf16_vectors.json`; `t27c gen-nmse-benchmark` → `nmse_synthetic_roundtrip` in `gf_family_bench.json` (synthetic roundtrip NMSE; `half` crate).
+**Revision:** 2026-04-07 — **NO-SHELL** / **#129** GF16+NMSE (PR #162). **#131 seal CI:** documented in **`CONTRIBUTING.md`** (Seal discipline); **`seal-coverage.yml`** also triggers on **`conformance/**`**.
 **Status:** ACTIVE — replace body on every ring boundary  
 **Queen health:** GREEN / 1.0 (all 17 domains; sealed 2026-04-05T12:00Z) — *verify* `.trinity/state/queen-health.json`  
 **Canonical URL:** `https://github.com/gHashTag/t27/blob/master/NOW.md`
@@ -209,8 +209,10 @@ CROWN (Queen brain & automation)
 | 2.3  | [#131](https://github.com/gHashTag/t27/issues/131) | Seal coverage CI             | **✅ DONE** | `.github/workflows/seal-coverage.yml` (PR-scoped gate)                                                     |
 | 2.4  | —                                                  | GF16 vectors grow            | **✅ DONE** | **`t27c expand-gf16`** → **50** rows in `gf16_vectors.json` (≥33 target); v2 seal recomputed                     |
 | 2.5  | [#163](https://github.com/gHashTag/t27/issues/163) | L5 IDENTITY seal refresh     | **🔄 OPEN** | `FORMAT-SPEC-001.json` → v2 + phi_distance + seal (0.0486326415435630 from gf16_vectors) |
-| 2.6  | —                                                  | Numeric debt sprint          | —      | `[NUMERIC-GF16-DEBT-INVENTORY.md](docs/nona-02-organism/NUMERIC-GF16-DEBT-INVENTORY.md)` — math → nn/vsa → ar |
+| 2.6  | —                                                  | Numeric debt sprint          | **⏳ OPEN** | `[NUMERIC-GF16-DEBT-INVENTORY.md](docs/nona-02-organism/NUMERIC-GF16-DEBT-INVENTORY.md)` — math → nn/vsa → ar (Phase 2.5 bridge → Phase 3 L4) |
 
+
+**Phase 2 handoff:** Steps **2.0–2.4** are **✅** (schema v2, migrate, synthetic NMSE / GF16 expansion, seal coverage workflow). **[#131](https://github.com/gHashTag/t27/issues/131)** is **implemented** via **`seal-coverage.yml`** + **`t27c validate-seals`**. **Remaining:** **[#163](https://github.com/gHashTag/t27/issues/163)** (2.5 identity seal), **2.6** numeric debt sprint.
 
 **Numeric palette:** `[NUMERIC-STANDARD-001.md](docs/nona-02-organism/NUMERIC-STANDARD-001.md)` · `[NUMERIC-GF16-CANONICAL-PICTURE.md](docs/nona-02-organism/NUMERIC-GF16-CANONICAL-PICTURE.md)` · `[NUMERIC-WHY-NOT-GF16-EVERYWHERE.md](docs/nona-02-organism/NUMERIC-WHY-NOT-GF16-EVERYWHERE.md)` · `[NUMERIC-CORE-PALETTE-REGISTRY.md](docs/nona-02-organism/NUMERIC-CORE-PALETTE-REGISTRY.md)`
 


### PR DESCRIPTION
## Summary
- **CONTRIBUTING.md:** new **§ Seal discipline** (`validate-seals`, `seal --save`, link to workflow). **NOW gates:** root `NOW.md` vs `docs/NOW.md` clarified (fixes stale `TASK.md` mention).
- **seal-coverage.yml:** PR trigger also on `conformance/**` so conformance-only PRs run the gate (still no-op if no `specs/**/*.t27` changed).
- **NOW.md** / **docs/NOW.md:** **Phase 2 handoff** paragraph (\#131 implemented; remaining \#163 + 2.6); step **2.6** marked **OPEN**.

## Issue
\#131 closed with [comment](https://github.com/gHashTag/t27/issues/131#issuecomment-4193499282); this PR lands the doc + CI follow-up.

## Optional maintainer follow-up
- Branch protection: require **Seal Coverage Gate** check.

Made with [Cursor](https://cursor.com)