### PR TITLE
fix(l7-unity): phi-loop-ci.yml use t27c lint-docs

### DIFF
--- a/.github/workflows/phi-loop-ci.yml
+++ b/.github/workflows/phi-loop-ci.yml
@@ -60,4 +60,4 @@ jobs:
           echo "phi^2 + 1/phi^2 = 3 | TRINITY"
 
       - name: First-party docs must be English (Cyrillic check)
-        run: bash scripts/check-first-party-doc-language.sh
+        run: ./bootstrap/target/release/t27c lint-docs  # L7 UNITY: no .sh on critical path


### PR DESCRIPTION
Replace `bash scripts/check-first-party-doc-language.sh` with `./bootstrap/target/release/t27c lint-docs` (Rust implementation in `tooling.rs`).

**Compliance:** SOUL.md Article VIII — NO-NEW-SHELL invariant.

**Implementation:** `tooling::run_lint_docs()` checks for Cyrillic characters in first-party Markdown.

Closes #181 (partial) — remaining: migrate `scripts/ci/now-sync-gate-diff.sh`