### PR TITLE
feat(l7-unity): Replace Python validate_phi with t27c in coq-kernel CI

### DIFF
--- a/.github/workflows/coq-kernel.yml
+++ b/.github/workflows/coq-kernel.yml
@@ -36,8 +36,13 @@ jobs:
           cd coq
           coqchk -silent -R . T27 T27.Kernel.PhiFloat
 
-      - name: Validate phi f64 parameters (Python)
-        run: python3 scripts/validate_phi_f64.py
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build t27c and validate phi f64 parameters
+        run: |
+          cd bootstrap && cargo build --release
+          ./target/release/t27c validate-phi
 
       - name: Verify Kernel PHI layer has no Admitted
         run: |

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -8,7 +8,7 @@
 **Last updated:** 2026-04-06 — Tuesday, 06 April 2026 (UTC) · Phase 3 Ring 051 (Jones Polynomial) — V(L,t) from input structure with variable t · RFC3339 2026-04-06T19:30:00Z
 
 **Document class:** Operational focus document
-**Revision:** **Rings 46+47+49+51 → Phase 3 Complete** — E2E CI loop (#150), K3 truth table (#143), Sacred physics (#145), Jones polynomial (#175) — all CLOSED. Seal cleanup: JonesPolynomial ring 12→51, SacredPhysics conformance hash fixed. 79/79 specs PASS, all seals verified.
+**Revision:** **Rings 46+47+49+51 → Phase 3 Complete** — E2E CI loop (#150), K3 truth table (#143), Sacred physics (#145), Jones polynomial (#175) — all CLOSED. Seal cleanup: JonesPolynomial ring 12→51, SacredPhysics conformance hash fixed. L7 UNITY: NO-PYTHON migration (coq-kernel CI) in progress (#156). 79/79 specs PASS, all seals verified.
 
 **Status:** ACTIVE — replace body on every ring boundary  
 **Queen health:** GREEN / 1.0 (all 17 domains; sealed 2026-04-05T12:00Z) — *verify* `.trinity/state/queen-health.json`  


### PR DESCRIPTION
NO-PYTHON / NO-SHELL migration (#156):

Replace `python3 scripts/validate_phi_f64.py` with native `t27c validate-phi` in coq-kernel.yml CI workflow.

**Changes:**
- Install Rust via dtolnay/rust-toolchain@stable
- Build t27c in CI
- Run `t27c validate-phi` instead of Python script

**Rationale:**
- L7 UNITY: No new shell scripts on critical path
- t27c has native `validate-phi` command (since Ring 050)
- Removes Python dependency from coq-kernel CI

Closes #156