### PR TITLE
ci(ring-033): Enforce ISSUE-GATE to block PRs without linked issues

### DIFF
--- a/.github/workflows/issue-gate.yml
+++ b/.github/workflows/issue-gate.yml
@@ -32,8 +32,9 @@ jobs:
             }' --jq '.data.repository.pullRequest.closingIssuesReferences.nodes[].number' 2>/dev/null)
 
           if [ -z "$ISSUES" ]; then
-            echo "::warning::No linked issues found. Consider adding 'Closes #N' to PR description."
-            echo "✅ Continuing without linked issue (allowed for documentation/fixup PRs)"
+            echo "::error::TOXIC: PR must reference an issue with 'Closes #N', 'Fixes #N', or 'Resolves #N' (L1 TRACEABILITY)"
+            echo "::error::See issue #128 for ISSUE-GATE requirements"
+            exit 1
           else
             echo "✅ Linked issues: $ISSUES"
           fi

--- a/docs/ISSUE-GATE-001.md
+++ b/docs/ISSUE-GATE-001.md
@@ -1,0 +1,74 @@
+# ISSUE-GATE-001: L1 TRACEABILITY Enforcement
+
+**Version:** 1.0
+**Status:** ENFORCED
+**Date:** 2026-04-06
+**Related:** L1 TRACEABILITY (T27-CONSTITUTION.md), Issue #128
+
+---
+
+## Purpose
+
+Enforces **Law 1 (L1) TRACEABILITY**: Every commit must reference a GitHub Issue via `Closes #N`. This ensures all code changes are traceable to tracked work units.
+
+## Enforcement Mechanism
+
+The `issue-gate.yml` workflow runs on every pull request to `master` and **blocks merge** if no linked issue is found.
+
+### Workflow
+
+File: `.github/workflows/issue-gate.yml`
+
+```yaml
+check-linked-issue:
+  runs-on: ubuntu-latest
+  steps:
+    - name: Check for linked issues via GraphQL
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        ISSUES=$(gh api graphql ... --jq ...)
+
+        if [ -z "$ISSUES" ]; then
+          echo "::error::TOXIC: PR must reference an issue with 'Closes #N'"
+          exit 1
+        fi
+```
+
+## Acceptable Keywords
+
+The following keywords in PR body or title link an issue:
+
+| Keyword | Effect |
+|---------|--------|
+| `Closes #N` | Closes issue on merge |
+| `Fixes #N` | Closes issue on merge |
+| `Resolves #N` | Closes issue on merge |
+
+## Blocking Behavior
+
+- **With linked issue:** ✅ CI passes, PR can merge
+- **Without linked issue:** ❌ CI fails, PR **cannot** merge
+
+**Error message:**
+```
+TOXIC: PR must reference an issue with 'Closes #N', 'Fixes #N', or 'Resolves #N' (L1 TRACEABILITY)
+See issue #128 for ISSUE-GATE requirements
+```
+
+## Exceptions
+
+**None.** All code changes must be traceable. If you need to make a fix without an issue, create one first using the issue template.
+
+## Related Laws
+
+| Law | Name | Relation |
+|-----|------|----------|
+| L1 | TRACEABILITY | This gate enforces L1 directly |
+| L4 | TESTABILITY | Issues should contain acceptance criteria |
+
+## See Also
+
+- [T27-CONSTITUTION.md](T27-CONSTITUTION.md) — L1–L7 laws
+- [NOW.md](docs/NOW.md) — Current rings and issues
+- Issue [#128](https://github.com/gHashTag/t27/issues/128) — Ring 033: ISSUE-GATE CI enforcement

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -5,7 +5,7 @@
 
 # NOW — Rolling integration snapshot
 
-**Last updated:** 2026-04-06 — Monday, 06 April 2026 (UTC) · Ring 032 canonical iteration schema · RFC3339 2026-04-06T21:30:00Z
+**Last updated:** 2026-04-07 — Tuesday, 07 April 2026 (UTC+07) · Ring 033 issue-gate enforcement · RFC3339 2026-04-06T22:00:00Z
 
 **Document class:** Operational focus document
 **Revision:** **Rings 46+47+49+51+040+045+048 → Phase 3 Complete** — E2E CI loop (#150), K3 truth table (#143), Sacred physics (#145), Jones polynomial (#175), Agent Alphabet (#135), ISA registers (#140), VSA algebra (#144) — all CLOSED. Seal cleanup: JonesPolynomial ring 12→51, SacredPhysics conformance hash fixed. L7 UNITY: NO-PYTHON migration (coq-kernel CI) in progress (#156). 79/79 specs PASS, all seals verified.


### PR DESCRIPTION
Ring 033 — ISSUE-GATE CI Enforcement

- Change issue-gate.yml from warning to error/exit 1 (blocks merge)
- Create docs/ISSUE-GATE-001.md with enforcement specification
- Update NOW.md Last updated date
- Enforces L1 TRACEABILITY: all PRs must have Closes #N

Closes #128