### PR TITLE
docs(research): Conjecture H1 + roadmap (post #277 merge)

### DIFF
--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -5,10 +5,10 @@
 
 # NOW — Rolling integration snapshot
 
-**Last updated:** 2026-04-07 — Tuesday, 07 April 2026 (UTC+07) · Fixing property-test template syntax · RFC3339 2026-04-07T17:00:00Z
+**Last updated:** 2026-04-07 — Tuesday, 07 April 2026 (UTC+07) · Trinity-Pellis research docs handoff (#283 / #285) · RFC3339 2026-04-07T18:00:00Z
 
 **Document class:** Operational focus document
-**Revision:** **Phase 4 Crown extended** — Rings 051-059 (#197, #199, #201, #203, #205, #207, #209, #216) — VERDICT_SCHEMA, brain seals, property-test template, META_DASHBOARD, EXPERIENCE_SCHEMA, schema-validation CI, conflict resolution, experience aggregation for Queen brain seals. **Issue [#277](https://github.com/gHashTag/t27/issues/277):** `tri math compare` (Pellis / hybrid / sensitivity) + `specs/physics/pellis-formulas.t27` + `research/trinity-pellis-paper/` scaffold.
+**Revision:** **Phase 4 Crown extended** — Rings 051-059 (#197, #199, #201, #203, #205, #207, #209, #216) — VERDICT_SCHEMA, brain seals, property-test template, META_DASHBOARD, EXPERIENCE_SCHEMA, schema-validation CI, conflict resolution, experience aggregation for Queen brain seals. **Issue [#277](https://github.com/gHashTag/t27/issues/277):** `tri math compare` (Pellis / hybrid / sensitivity) + `specs/physics/pellis-formulas.t27` + `research/trinity-pellis-paper/` scaffold. **PR [#283](https://github.com/gHashTag/t27/pull/283) / [#285](https://github.com/gHashTag/t27/issues/285):** formal Conjecture H1, `ROADMAP.md`, `FORMULA_TABLE.md` SSOT notes under `research/trinity-pellis-paper/`.
 
 **Status:** ACTIVE — replace body on every ring boundary  
 **Queen health:** GREEN / 1.0 (all 17 domains; sealed 2026-04-05T12:00Z) — *verify* `.trinity/state/queen-health.json`  

--- a/research/trinity-pellis-paper/FORMULA_TABLE.md
+++ b/research/trinity-pellis-paper/FORMULA_TABLE.md
@@ -23,6 +23,21 @@ The table is intentionally sparse at scaffold time; fill rows as each identity i
 
 ## Next steps
 
-1. Import row metadata from the sacred formula JSON when it lands in-repo.
+1. **SSOT for 152 rows (this repo):** derive rows from `specs/physics/sacred_verification.t27` and linked conformance/docs — there is **no** `src/particle_physics/formulas.zig` in t27. When a single JSON catalog for all 152 IDs exists, generate or sync table rows from that file under `tri` (no Python on the verification critical path per AGENTS).
 2. Mirror each **EXACT** row with a `test` / `invariant` in the owning `.t27` file.
-3. Use `tri math compare --sensitivity` to track numeric stability of the hybrid proxy under phi perturbations.
+3. Add columns **Pellis equivalent** (if known) and **delta_ppm** vs experiment once definitions are frozen.
+4. Use `tri math compare --sensitivity` to track numeric stability of the hybrid proxy under phi perturbations.
+
+## Outreach snippet (Pellis / collaborators)
+
+After merge to `master`:
+
+```text
+PR #280 is merged (#277 closed). Repro on a clean checkout:
+
+  ./scripts/tri math compare --pellis --hybrid --sensitivity
+
+P1..P5 = {1,2,5,12,29} are in specs/physics/pellis-formulas.t27.
+Current hybrid inner product (diagnostic v1) ~ 0.5638 — first joint numeric handle;
+see research/trinity-pellis-paper/hybrid-conjecture.md for Conjecture H1 and limits.
+```

--- a/research/trinity-pellis-paper/README.md
+++ b/research/trinity-pellis-paper/README.md
@@ -24,6 +24,7 @@ Each run appends one JSON line to `.trinity/experience/math_compare.jsonl` (proo
 |------|---------|
 | [`FORMULA_TABLE.md`](FORMULA_TABLE.md) | Placeholder catalog toward 152 formulas (IDs + category + status). |
 | [`hybrid-conjecture.md`](hybrid-conjecture.md) | Formal sketch of the hybrid hypothesis, falsifiers, sensitivity scope, open work. |
+| [`ROADMAP.md`](ROADMAP.md) | Post-merge priorities (formula table, outreach, preprint). |
 | `README.md` | Hypothesis, scope, and CLI pointers. |
 
 ## Project impact (summary)

--- a/research/trinity-pellis-paper/ROADMAP.md
+++ b/research/trinity-pellis-paper/ROADMAP.md
@@ -1,0 +1,15 @@
+# Trinity x Pellis — roadmap (one glance)
+
+PR [#280](https://github.com/gHashTag/t27/pull/280) merged; [issue #277](https://github.com/gHashTag/t27/issues/277) closed via L1.
+
+```text
+Done          Merge PR #280 → master
+  │
+  ├── ~1 d    Issue: expand FORMULA_TABLE 13 → 152 (SSOT: sacred_verification.t27 + future JSON; see FORMULA_TABLE.md)
+  ├── ~2 d    Outreach: Pellis runs `tri math compare --pellis --hybrid --sensitivity` (repro joint observable)
+  ├── ~3 d    hybrid-conjecture.md: Conjecture H1 + test/falsify protocol (this file + hybrid-conjecture.md)
+  ├── ~1 w    Outreach: Olsen — concrete ask (historical section outline for preprint)
+  └── ~2 w    Zenodo preprint bump (v0.2+) once PDF + author list ready
+```
+
+**Central empirical question:** under a *defined* extension of constants and a *fixed* hybrid map, does the hybrid score **stabilize** or **drift**? Answer drives the paper; the current CLI score (~0.564) is **version 1** of the map — renormalization may change the target value (see `hybrid-conjecture.md`).

--- a/research/trinity-pellis-paper/hybrid-conjecture.md
+++ b/research/trinity-pellis-paper/hybrid-conjecture.md
@@ -8,7 +8,28 @@ English-first research note. Implementation lives in `specs/physics/pellis-formu
 - **Pell ladder (integer, \(\sqrt{2}\) structure):** \(P_1..P_5 = 1,2,5,12,29\) as explicit constants in the spec; CLI uses the same recurrence for the hybrid map.
 - **Hybrid score:** dot product of the two normalized vectors above (dimensionless scalar). **Not** a physical observable until mapped to measured quantities.
 
-## Conjecture (falsifiable, weak form)
+## Conjecture H1 (structural projection, research — not proven in code)
+
+**H1 (projection):** A Trinity monomial of the form
+
+\[
+M = 2^{a}\,3^{b}\,\varphi^{p}\,\pi^{m}\,e^{q}
+\]
+
+(with integer exponents \((a,b,p,m,q)\) in a stated finite range) is the **image** of a truncated Pellis-type expansion
+
+\[
+\sum_{k=0}^{N} c_k\,\varphi^{-k}
+\quad\text{with}\quad N \leq 3
+\]
+
+under a fixed linear or renormalization map \(T\) (to be specified: coefficients \(c_k\) from Pell data, truncation rule, and normalization).
+
+**Testable corollary (paper-grade, requires map \(T\) fixed):** if H1 holds for the chosen \(T\) and the constant catalog is extended in a documented way, a **renormalized hybrid statistic** \(H\) (derived from the same geometry as today’s CLI inner product, but possibly rescaled) should **converge** to a stable value (one natural target is \(H \to 1\) under a chosen normalization). If, under repeated controlled extensions, \(H\) fails to stabilize, that is **falsification of H1** for that \(T\).
+
+**Relation to current CLI:** `tri math compare --hybrid` implements a **concrete diagnostic** inner product (~0.564 on IEEE `f64`); it is **not** yet the general \(T\) in H1. Porting H1 into code means defining \(T\), truncation \(N\), and the renormalized \(H\) explicitly, then locking them in `.t27` + seals.
+
+## Conjecture (falsifiable, weak form — operational)
 
 If a renormalization-style map links Pell-weighted thin-structure data to an effective \(\phi\)-scaling law, then **extensions of the constant set** (neutrino sector, CKM, electroweak masses) should move the hybrid score **predictably** under a *stated* embedding rule — or the conjecture fails for that rule.
 


### PR DESCRIPTION
## Summary
Docs-only follow-up after **#280 merged** / **#277 closed**.

## Changes (4 files + NOW handoff)
- `hybrid-conjecture.md`: **Conjecture H1** + testable corollary (hybrid statistic convergence; current CLI ~0.56 is diagnostic v1)
- `ROADMAP.md`: post-merge priorities
- `FORMULA_TABLE.md`: SSOT note — **no** `src/particle_physics/formulas.zig` in t27; outreach snippet for Pellis
- `README.md`: link ROADMAP
- `docs/NOW.md`: coordination line for this PR + **#285** (NOW sync gate)

No bootstrap/spec/seal changes.

Closes #285