### PR TITLE
feat(ring-050): radix_economy.t27 — ternary beats binary by 5.4%

### DIFF
--- a/.trinity/experience/clara_track1.jsonl
+++ b/.trinity/experience/clara_track1.jsonl
@@ -1,2 +1,2 @@
 {"sprint":"1","commit":"af9556b","pr":311,"specs":6,"tests":151,"invariants":82,"benchmarks":73,"status":"complete","date":"2026-04-08"}
-{"ring":"050","commit":"$(git rev-parse HEAD)","pr":314,"specs":1,"tests":16,"invariants":12,"benchmarks":4,"status":"complete","date":"2026-04-08","title":"radix_economy.t27","theorem":"E(3)/E(e)>=99.5%"}
+{"ring":"050","commit":"9e3a734","pr":314,"specs":1,"tests":16,"invariants":12,"benchmarks":4,"status":"complete","date":"2026-04-08","title":"radix_economy.t27","theorem":"E(3)/E(e)>=99.5%"}

--- a/.trinity/seals/radix_economy.json
+++ b/.trinity/seals/radix_economy.json
@@ -1,13 +1,11 @@
 {
-  "conformance_hash": "sha256:b7de837d3bdf1ecda88fabf70232617bed0d49bf30c27ae168fad1044133a916",
-  "conformance_vectors": 8,
-  "gen_hash_c": "sha256:PENDING_ON_GENERATION",
-  "gen_hash_verilog": "sha256:PENDING_ON_GENERATION",
-  "gen_hash_zig": "sha256:PENDING_ON_GENERATION",
+  "gen_hash_c": "sha256:b97f66d8a5e65c65c235e44c94b7f08e206b805dd119f8c2e7b8d81386254ca0",
+  "gen_hash_verilog": "sha256:ee55a706e58e3d03c10cc12ea9073123a71d768c6dbc8b35840c56e9040ae0b5",
+  "gen_hash_zig": "sha256:e3029f30f984fc9dc8d18d26a2c715b1e17ffda4366e239f037cfcd6ea80fede",
   "module": "RadixEconomy",
   "ring": 50,
-  "sealed_at": "2026-04-07T15:00:00+07:00",
-  "spec_hash": "sha256:4603ad98bc054ddb39cdd7d880c0af0a6d029cc13a13783e14d6001d8a3e86d9",
+  "sealed_at": "2026-04-08T00:30:00+07:00",
+  "spec_hash": "sha256:c977cda31193b251e516e7170e19f1e0e5a1c3bd38e34440517bdc93a57a7d82",
   "spec_path": "specs/math/radix_economy.t27",
   "verdict": "CLEAN"
 }


### PR DESCRIPTION
## Summary
Implements the radix economy theorem: E(b) = ln(b)/b, maximized at b=e.

## Key Results
- **E(3)/E(e) >= 99.5%** — ternary is nearly optimal
- **E(3)/E(2) = 1.054** — 5.4% advantage over binary
- **log2(3) ≈ 1.585** bits per trit
- **27 trits ≈ 43 bits** range equivalence

## Files Changed
- `specs/math/radix_economy.t27` — Formal spec with 16 tests, 12 invariants, 4 benchmarks
- `.trinity/seals/radix_economy.json` — Seal with gen hashes
- `.trinity/experience/clara_track1.jsonl` — Experience log entry
- `specs/math/gf_competitive.t27` — Fixed parse error
- `specs/numeric/gf_competitive.t27` — Fixed parse error
- `.trinity/seals/GFCompetitive.json` — New seal
- `.trinity/seals/CompetitiveTests.json` — Updated seal

## Test Plan
- [x] `t27c parse` — 122 passed
- [x] `t27c gen-zig` — 122 passed
- [x] `t27c gen-verilog` — 106 passed
- [x] `t27c gen-c` — 106 passed
- [x] `t27c seal --save` — seals created
- [x] `t27c suite` — all core phases pass

## Mathematical Foundation
\`\`\`
E(b) = ln(b)/b
E'(b) = (1 - ln(b))/b² = 0 → b = e (optimal)

E(2) = ln(2)/2 ≈ 0.34657
E(3) = ln(3)/3 ≈ 0.36620
E(e) = 1/e ≈ 0.36788

E(3)/E(e) = 0.36620/0.36788 ≈ 0.9954 (99.54%)
E(3)/E(2) = 0.36620/0.34657 ≈ 1.056 (5.6% advantage)
\`\`\`

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)