### PR TITLE
docs(pellis): finalize WORK_REPORT (EN §1, PR #328 row)

### DIFF
--- a/research/trinity-pellis-paper/WORK_REPORT_PELLIS_2026-04.md
+++ b/research/trinity-pellis-paper/WORK_REPORT_PELLIS_2026-04.md
@@ -6,7 +6,7 @@
 
 ## Executive Summary
 
-The Pellis programme has moved from “beautiful coincidences” to a **verifiable catalogue**: every claimed φ-formula in the repository either has a path to an executable check (`tri math compare`, `.t27` specs) or carries an explicit **CONJECTURAL** label with a numerical value, experimental reference, and deviation. **Three numerical errors** were found and corrected during audit (two CKM table entries + one NuFIT σ mishandling), making the picture simultaneously more honest and more defensible for peer review.
+The Pellis program has moved from “beautiful coincidences” to a **verifiable catalog**: every claimed φ-formula in the repository either has a path to an executable check (`tri math compare`, `.t27` specs) or carries an explicit **CONJECTURAL** label with a numerical value, experimental reference, and deviation. **Three numerical errors** were found and corrected during audit (two CKM table entries + one NuFIT σ mishandling), making the picture simultaneously more honest and more defensible for peer review.
 
 ---
 
@@ -21,41 +21,28 @@ The document audit found and corrected **three numerical errors** that were dist
 
 After corrections the picture is **honest**: some ansätze look better, some harder than before the audit.
 
-**New Conjecture H2** (**sin θ₁₃ = φ⁻⁴**): \(\varphi^{-4} \approx 0.145898\) → \(\arcsin(\varphi^{-4}) \approx 8.39^\circ\). Compared to a reactor-style centre ~8.54° with ±0.15° uncertainty this is ~1σ — **provided** the parametrisation and error source are stated explicitly. The table must not conflate **sin θ₁₃** and **sin²2θ₁₃**.
+**New Conjecture H2** (**sin θ₁₃ = φ⁻⁴**): \(\varphi^{-4} \approx 0.145898\) → \(\arcsin(\varphi^{-4}) \approx 8.39^\circ\). Compared to a reactor-style central value ~8.54° with ±0.15° uncertainty this is ~1σ — **provided** the parametrization and error source are stated explicitly. The table must not conflate **sin θ₁₃** and **sin²2θ₁₃**.
 
 ---
 
-## 1. GitHub Integration Timeline
+## 1. GitHub integration timeline
 
-| Artefact | Status | Content (brief) |
-|----------|--------|-----------------|
-| [**PR #294**](https://github.com/gHashTag/t27/pull/294) | Merged | Large bundle: seals (`.trinity`), specs (ternary, Pellis precision, GF competitive), language benchmarks, `math_compare` + trinity-pellis docs, merge with `master`, conflict resolution |
-| [**PR #299**](https://github.com/gHashTag/t27/pull/299) | **Merged** | P0 Core Rewrite Sprint 1: Zig → `.t27` specs (`PackedTrit`, `SacredConstants`, `HybridArithmetic`); see §3 |
-| [**PR #325**](https://github.com/gHashTag/t27/pull/325) | **Merged** | April work report + `FORMULA_TABLE` rows 31–32 (H2) + `TECHNOLOGY_MAP.md` + §13 index update |
-| [**PR #297**](https://github.com/gHashTag/t27/pull/297) | Open (not mergeable from bot) | [`docs/WHITEPAPER/gf_paper_v3_imrad_draft.md`](../../docs/WHITEPAPER/gf_paper_v3_imrad_draft.md) + extended [`benchmarks/language_tests/`](../../benchmarks/language_tests/) — **merge blocked:** conflicts + failing `check-linked-issue` gate (verify in GitHub UI) |
-| [**PR #321**](https://github.com/gHashTag/t27/pull/321) | Merged | Removed nested `trinity/.git`; added [`trinity/README.md`](../../trinity/README.md) |
-| [**Issue #295**](https://github.com/gHashTag/t27/issues/295) | Open | Canonical Weinberg CLI work: `tri math compare --weinberg` — template [`GH_ISSUE_WEINBERG_CLI_BODY.md`](GH_ISSUE_WEINBERG_CLI_BODY.md) |
-| [**Issue #296**](https://github.com/gHashTag/t27/issues/296) | Open | Canonical hybrid v2 work — template [`GH_ISSUE_HYBRID_V2_BODY.md`](GH_ISSUE_HYBRID_V2_BODY.md) |
+| Artifact | Status | Summary |
+|----------|--------|---------|
+| [**PR #294**](https://github.com/gHashTag/t27/pull/294) | **Merged** | `.trinity` seals; specs (ternary, Pellis precision, GF competitive); [`benchmarks/language_tests/`](../../benchmarks/language_tests/); [`bootstrap/src/math_compare.rs`](../../bootstrap/src/math_compare.rs) + [`research/trinity-pellis-paper/`](./); merge to `master` with conflicts resolved. |
+| [**PR #299**](https://github.com/gHashTag/t27/pull/299) | **Merged** | P0 Sprint 1: Zig → `.t27` — [`PackedTrit`](../../specs/ternary/packed_trit.t27), [`SacredConstants`](../../specs/sacred/constants.t27), [`HybridArithmetic`](../../specs/ternary/hybrid_arithmetic.t27); see §3. |
+| [**PR #321**](https://github.com/gHashTag/t27/pull/321) | **Merged** | Removed nested `trinity/.git`; [`trinity/README.md`](../../trinity/README.md) tracked as normal files. |
+| [**PR #325**](https://github.com/gHashTag/t27/pull/325) | **Merged** | This report, [`FORMULA_TABLE.md`](./FORMULA_TABLE.md) rows **31–32**, [`TECHNOLOGY_MAP.md`](./TECHNOLOGY_MAP.md), [`TRINITY_VS_SM_FORMULAS.md`](./TRINITY_VS_SM_FORMULAS.md) §13. |
+| [**PR #328**](https://github.com/gHashTag/t27/pull/328) | **Merged** | Revert-merge **[#327](https://github.com/gHashTag/t27/pull/327)** (wrong files), re-apply **only** this report + `TECHNOLOGY_MAP.md`. |
+| [**PR #297**](https://github.com/gHashTag/t27/pull/297) | **Open** | Whitepaper + benchmarks — **blocked:** merge conflicts + **`check-linked-issue`** until PR links a qualifying issue (GitHub **Checks** tab). |
+| [**Issue #295**](https://github.com/gHashTag/t27/issues/295) | **Open** | `tri math compare --weinberg` — [`GH_ISSUE_WEINBERG_CLI_BODY.md`](./GH_ISSUE_WEINBERG_CLI_BODY.md). |
+| [**Issue #296**](https://github.com/gHashTag/t27/issues/296) | **Open** | Hybrid v2 + golden **N = 5, 10, 15, 20, 50, 152** — [`GH_ISSUE_HYBRID_V2_BODY.md`](./GH_ISSUE_HYBRID_V2_BODY.md). |
 
-*PR **#302** / **#303** were closed as duplicates of **#295** / **#296** (April 2026 tracker cleanup).*
+*[**#302**](https://github.com/gHashTag/t27/issues/302) / [**#303**](https://github.com/gHashTag/t27/issues/303) **closed** as duplicates of **#295** / **#296**.*
 
-*PR/issue numbers: confirm in the [GitHub UI](https://github.com/gHashTag/t27) before citing in external letters.*
+*Confirm numbers in [GitHub](https://github.com/gHashTag/t27) before external citations.*
 
-**Merge policy note (April 2026):** **PR #299** and **#325** are on `master`. **PR #297** still needs manual conflict resolution + issue-gate compliance. Do **not** bulk-merge unrelated Ring PRs without review; treat merges as scoped releases.
-
-### 1.1 Хронология интеграции (RU) — «чистая» сводка
-
-| Артефакт | Статус | Содержание (кратко) |
-|----------|--------|----------------------|
-| [PR #294](https://github.com/gHashTag/t27/pull/294) | Объединено | Большой пакет: сертификаты (`.trinity`), спецификации (тройная архитектура, точность Pellis, конкурентоспособность GF), языковые тесты, `math_compare` + документация Trinity–Pellis, слияние с `master`, разрешение конфликтов |
-| [PR #299](https://github.com/gHashTag/t27/pull/299) | Объединено | P0 Core Rewrite Sprint 1: Zig → `.t27` specs (`PackedTrit`, `SacredConstants`, `HybridArithmetic`); см. §3 |
-| [PR #325](https://github.com/gHashTag/t27/pull/325) | Объединено | Отчёт апреля + строки 31–32 в `FORMULA_TABLE` (H2) + `TECHNOLOGY_MAP.md` + индекс §13 |
-| [PR #297](https://github.com/gHashTag/t27/pull/297) | Открыто (не подлежит автослиянию) | `docs/WHITEPAPER/gf_paper_v3_imrad_draft.md` + расширение `benchmarks/language_tests/` — слияние заблокировано: **конфликты** + сбой проверки **`check-linked-issue`** (см. UI GitHub) |
-| [PR #321](https://github.com/gHashTag/t27/pull/321) | Объединено | Удалён вложенный `trinity/.git`; добавлен `trinity/README.md` |
-| [Issue #295](https://github.com/gHashTag/t27/issues/295) | Открыто | Канон: `tri math compare --weinberg` — тело шаблона `GH_ISSUE_WEINBERG_CLI_BODY.md` |
-| [Issue #296](https://github.com/gHashTag/t27/issues/296) | Открыто | Канон: hybrid v2 + golden N — тело шаблона `GH_ISSUE_HYBRID_V2_BODY.md` |
-
-*Ранее открытые **#302** / **#303** закрыты как дубликаты **#295** / **#296**.*
+**Merge policy:** **#294**, **#299**, **#321**, **#325**, **#328** are on `master`. **#297** needs manual fix. No bulk-merge of unrelated Ring PRs.
 
 ---
 
@@ -82,7 +69,7 @@ After corrections the picture is **honest**: some ansätze look better, some har
 
 \[\arcsin(\varphi^{-4}) \approx 8.39^\circ\]
 
-Compared to reactor centre ~8.54° with ±0.15° → **~1σ** (conjecture registered in catalogue; main long-horizon check: next-generation reactor / JUNO-era fits).
+Compared to reactor central value ~8.54° with ±0.15° → **~1σ** (conjecture in the catalog; main long-horizon check: next-generation reactor / JUNO-era fits).
 
 ---
 
@@ -109,7 +96,7 @@ The relation \(\varphi^2 + \varphi^{-2} = 3\) is enforced as a **machine-checkab
 
 ---
 
-## 4. Formula catalogue ([`FORMULA_TABLE.md`](FORMULA_TABLE.md))
+## 4. Formula catalog ([`FORMULA_TABLE.md`](FORMULA_TABLE.md))
 
 **On `master` (this report commit):**
 


### PR DESCRIPTION
Single-file update: complete English GitHub timeline (L30–39 + §1), PR **#328** row, **#302/#303** closed note, removed RU subsection, US spelling.

Made with [Cursor](https://cursor.com)