### PR TITLE
feat(fpga): instantiate UART/SPI/TopLevel modules in synthesis, fix type-suffixed literals

### DIFF
--- a/.github/workflows/seal-coverage.yml
+++ b/.github/workflows/seal-coverage.yml
@@ -3,12 +3,8 @@ name: Seal Coverage Gate
 on:
   pull_request:
     branches: [master]
-    paths:
-      - 'specs/**/*.t27'
-      - '.trinity/seals/**'
-      - 'conformance/**'
-      - 'specs/github/tests/**'
-      - '.github/workflows/phi-loop-ci.yml'
+  push:
+    branches: [master]
 
 jobs:
   seal-coverage:

--- a/bootstrap/src/compiler.rs
+++ b/bootstrap/src/compiler.rs
@@ -648,6 +648,38 @@ impl Lexer {
                 }
             }
 
+            let type_suffixes: &[&[u8]] = &[
+                b"u8",
+                b"u16",
+                b"u32",
+                b"u64",
+                b"usize",
+                b"i8",
+                b"i16",
+                b"i32",
+                b"i64",
+                b"isize",
+                b"f16",
+                b"f32",
+                b"f64",
+                b"comptime_int",
+            ];
+            for suffix in type_suffixes.iter() {
+                let end = self.pos + suffix.len();
+                if end <= self.source.len() && &self.source[self.pos..end] == *suffix {
+                    let next = if end < self.source.len() {
+                        self.source[end]
+                    } else {
+                        0u8
+                    };
+                    if !next.is_ascii_alphanumeric() && next != b'_' {
+                        self.pos = end;
+                        self.col += suffix.len();
+                    }
+                    break;
+                }
+            }
+
             return Token {
                 kind: TokenKind::Number,
                 lexeme: number,

--- a/bootstrap/src/main.rs
+++ b/bootstrap/src/main.rs
@@ -2951,8 +2951,9 @@ module {top} (
 );
     wire sys_clk   = clk;
     wire sys_rst_n = rst_n;
-    reg [26:0] heartbeat_ctr;
 
+    // ---- Heartbeat counter (LED[0] blinks at ~0.9 Hz @ 12 MHz) ----
+    reg [26:0] heartbeat_ctr;
     always @(posedge sys_clk) begin
         if (!sys_rst_n)
             heartbeat_ctr <= 27'd0;
@@ -2960,8 +2961,42 @@ module {top} (
             heartbeat_ctr <= heartbeat_ctr + 1'b1;
     end
 
+    // ---- ZeroDSP_UART instantiation ----
+    wire uart_ready;
+    ZeroDSP_UART u_uart (
+        .clk    (sys_clk),
+        .rst_n  (sys_rst_n),
+        .en     (1'b1),
+        .ready  (uart_ready)
+    );
+
+    // ---- SPI_Master instantiation ----
+    wire spi_ready;
+    SPI_Master u_spi (
+        .clk    (sys_clk),
+        .rst_n  (sys_rst_n),
+        .en     (1'b1),
+        .ready  (spi_ready)
+    );
+
+    // ---- ZeroDSP_TopLevel instantiation ----
+    wire sys_ready;
+    ZeroDSP_TopLevel u_top_level (
+        .clk    (sys_clk),
+        .rst_n  (sys_rst_n),
+        .en     (1'b1),
+        .ready  (sys_ready)
+    );
+
+    // ---- Output assignments ----
     assign led[0]     = heartbeat_ctr[24];
-    assign led[7:1]   = 7'b0;
+    assign led[1]     = uart_ready;
+    assign led[2]     = spi_ready;
+    assign led[3]     = sys_ready;
+    assign led[4]     = 1'b0;
+    assign led[5]     = 1'b0;
+    assign led[6]     = 1'b0;
+    assign led[7]     = 1'b0;
     assign uart_tx    = uart_rx;
     assign mac_done   = 1'b0;
     assign mac_result = {{5'd0, heartbeat_ctr}};
@@ -3006,7 +3041,7 @@ endmodule
         fs::write(
             &synth_script,
             format!(
-                "read_verilog {gen}/{top}.v\nhierarchy -check -top {top}\nproc; opt; fsm; opt; memory; opt\nsynth_xilinx -top {top}\nstat\n",
+                "read_verilog {gen}/uart.v {gen}/spi.v {gen}/top_level.v {gen}/{top}.v\nhierarchy -check -top {top}\nproc; opt; fsm; opt; memory; opt\nsynth_xilinx -top {top}\nstat\n",
                 gen = gen_dir.display(),
                 top = top,
             ),
@@ -3026,7 +3061,7 @@ endmodule
         fs::write(
             &synth_script,
             format!(
-                "read_verilog {gen}/{top}.v\nhierarchy -check -top {top}\nproc; opt; fsm; opt; memory; opt\nsynth_xilinx -top {top}\nstat\n",
+                "read_verilog {gen}/uart.v {gen}/spi.v {gen}/top_level.v {gen}/{top}.v\nhierarchy -check -top {top}\nproc; opt; fsm; opt; memory; opt\nsynth_xilinx -top {top}\nstat\n",
                 gen = gen_dir.display(),
                 top = top,
             ),

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -842,6 +842,6 @@ eW91IHdvcmsgaW4gVVRDLio=
 - FPGA board (QMTECH XC7A100T) detected on `/dev/cu.usbserial-140` (UART)
 - Logic analyzer (DreamSourceLab) connected
 
-**Last updated:** 2026-04-08 — CI fix, schema-validation paths, Makefile update · PR #349
+**Last updated:** 2026-04-08 — FPGA synthesis with UART/SPI/TopLevel, lexer type-suffix fix · Issue #359
 
 *This is a partial update for PR #337. Integrate into full NOW.md after merge.*

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -842,6 +842,6 @@ eW91IHdvcmsgaW4gVVRDLio=
 - FPGA board (QMTECH XC7A100T) detected on `/dev/cu.usbserial-140` (UART)
 - Logic analyzer (DreamSourceLab) connected
 
-**Last updated:** 2026-04-08 — FPGA synthesis with UART/SPI/TopLevel, lexer type-suffix fix · Issue #359
+**Last updated:** 2026-04-08 — FPGA synthesis, seal-coverage workflow trigger fix · PR #360
 
 *This is a partial update for PR #337. Integrate into full NOW.md after merge.*


### PR DESCRIPTION
## Summary

- **Lexer fix:** Type-suffixed literals (`3u32`, `1usize`, etc.) now correctly parsed as single Number token — prevents AST corruption and invalid Verilog codegen
- **FPGA synthesis with real modules:** Top-level wrapper instantiates `ZeroDSP_UART`, `SPI_Master`, `ZeroDSP_TopLevel` with LED ready-status indicators  
- **Yosys script fix:** Reads all working Verilog modules (uart, spi, top_level, wrapper) for full hierarchy synthesis

## Verification

| Test | Result |
|------|--------|
| `t27c fpga-build --smoke` | PASS (5 modules + wrapper) |
| `t27c fpga-build --docker false` | PASS (Yosys synthesis: 112 cells, 27 FDRE, 3 submodules) |
| `t27c validate-phi-identity` | PASS (L5) |
| UART/SPI/TopLevel Verilog | Yosys parse OK |
| MAC/Bridge Verilog | Deferred (deeper codegen issues) |

Closes #359