### PR TITLE
fix(compiler): const→reg in Verilog codegen, 5 FPGA specs parse in Yosys

### DIFF
--- a/bootstrap/src/compiler.rs
+++ b/bootstrap/src/compiler.rs
@@ -3900,11 +3900,7 @@ impl VerilogCodegen {
             }
             NodeKind::StmtLocal => {
                 self.write_indent();
-                let kw = if node.extra_mutable {
-                    "reg"
-                } else {
-                    "// const"
-                };
+                let kw = if node.extra_mutable { "reg" } else { "reg" };
                 let width = Self::type_to_width(&node.extra_type);
                 let signed = Self::type_is_signed(&node.extra_type);
                 let signed_str = if signed { "signed " } else { "" };

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -842,6 +842,6 @@ eW91IHdvcmsgaW4gVVRDLio=
 - FPGA board (QMTECH XC7A100T) detected on `/dev/cu.usbserial-140` (UART)
 - Logic analyzer (DreamSourceLab) connected
 
-**Last updated:** 2026-04-08 — FPGA synthesis, seal-coverage workflow trigger fix · PR #360
+**Last updated:** 2026-04-08 — FPGA const→reg codegen fix, 3 modules in synthesis · PR #361
 
 *This is a partial update for PR #337. Integrate into full NOW.md after merge.*


### PR DESCRIPTION
## Summary

- **const→reg fix:** Function-local `const` declarations now emit `reg` in Verilog instead of commented-out `// const`. This makes variables visible to Yosys and fixes cascading parse errors.

## Verification

| Module | Yosys Parse | Yosys synth_xilinx |
|--------|-------------|-------------------|
| uart.v | PASS | PASS |
| spi.v | PASS | PASS |
| top_level.v | PASS | PASS |
| mac.v | PASS | FAIL (parser-level `0 = ...` issue) |
| bridge.v | PASS | FAIL (parser-level `& &` issue) |
| zerodsp_top (wrapper) | PASS | PASS (3 submodules) |

Full synthesis with UART + SPI + TopLevel: **112 cells, 27 FDRE, 3 submodules**.

Closes #359