### PR TITLE
feat(fpga): MAC in synthesis (4/5 modules), &&/|| precedence, field access fix

### DIFF
--- a/.trinity/seals/FPGA_Bridge.json
+++ b/.trinity/seals/FPGA_Bridge.json
@@ -1,11 +1,11 @@
 {
-  "gen_hash_c": "sha256:45e673c300466c3e02f108e78c122bbe00a2608bdf4ad73e1657325e4e4699a5",
-  "gen_hash_rust": "sha256:bfc23eceeb8b3caf9a1a0f1fd014c5877174a70ad84ddd6c380cfff516892bf2",
-  "gen_hash_verilog": "sha256:2c4365b7de4b2895d2632df3f8e48a446ecceb7b86a8611c6b0eb50ad18ced39",
-  "gen_hash_zig": "sha256:0279ee77de74ccfe74d0c2b0596bcb387748c16e8e881af01e22a53cfae92ffc",
+  "gen_hash_c": "sha256:c0743209e2c55b27b89f173aed4b989fc80cdd3d90dcc37647a04dcf2999e1dd",
+  "gen_hash_rust": "sha256:40643d8e0d8841553bc5284d9278d1a05610c66b22f07d28cbaab8759550ee43",
+  "gen_hash_verilog": "sha256:ebd48c4bc053fb13fe6990b7de37362156d02c086f2fb3f9487c45c6c155a7ec",
+  "gen_hash_zig": "sha256:f5529bd9d83cd18d2e2a772be62a9c867d49ecdb7c5b167cfbae5363a839ec59",
   "module": "FPGA_Bridge",
   "ring": 12,
-  "sealed_at": "2026-04-08T08:09:16Z",
-  "spec_hash": "sha256:55eb424b792db0bb3c5efae81066cc2ecfe8dfc08bd6e0331d2a72fe7f632a80",
+  "sealed_at": "2026-04-08T11:11:18Z",
+  "spec_hash": "sha256:af21707151ff95a48ebadbfd7d6631a1907c8da8a376bc32994ac58f27892244",
   "spec_path": "specs/fpga/bridge.t27"
 }

--- a/bootstrap/src/compiler.rs
+++ b/bootstrap/src/compiler.rs
@@ -1983,7 +1983,7 @@ impl Parser {
     /// Parse bitwise or (|)
     fn parse_expr_bitor(&mut self) -> Result<Node, String> {
         let mut left = self.parse_expr_bitxor()?;
-        while self.current.kind == TokenKind::Pipe {
+        while self.current.kind == TokenKind::Pipe && self.current.lexeme == "|" {
             let op = self.current.lexeme.clone();
             self.advance();
             let right = self.parse_expr_bitxor()?;
@@ -2017,7 +2017,7 @@ impl Parser {
     /// Parse bitwise and (&)
     fn parse_expr_bitand(&mut self) -> Result<Node, String> {
         let mut left = self.parse_expr_shift()?;
-        while self.current.kind == TokenKind::Amp {
+        while self.current.kind == TokenKind::Amp && self.current.lexeme == "&" {
             let op = self.current.lexeme.clone();
             self.advance();
             let right = self.parse_expr_shift()?;
@@ -4205,14 +4205,27 @@ impl VerilogCodegen {
                 }
             }
             NodeKind::ExprFieldAccess => {
-                // Verilog doesn't have field access — flatten to name_field
                 if !node.children.is_empty() {
-                    self.gen_verilog_expr(&node.children[0]);
-                    self.write("_");
+                    let child = &node.children[0];
+                    if child.kind == NodeKind::ExprIndex && !child.children.is_empty() {
+                        let base_name = match child.children[0].kind {
+                            NodeKind::ExprIdentifier => child.children[0].name.clone(),
+                            _ => String::new(),
+                        };
+                        let flat_name = format!("{}{}", base_name, node.name);
+                        self.write(&flat_name);
+                    } else if child.kind == NodeKind::ExprIdentifier {
+                        self.write(&child.name);
+                        self.write("_");
+                        self.write(&node.name);
+                    } else {
+                        self.gen_verilog_expr(child);
+                        self.write("_");
+                        self.write(&node.name);
+                    }
                 } else {
-                    // Just the field name
+                    self.write(&node.name);
                 }
-                self.write(&node.name);
             }
             NodeKind::ExprIndex => {
                 if node.children.len() >= 2 {

--- a/bootstrap/src/main.rs
+++ b/bootstrap/src/main.rs
@@ -2961,6 +2961,15 @@ module {top} (
             heartbeat_ctr <= heartbeat_ctr + 1'b1;
     end
 
+    // ---- ZeroDSP_MAC instantiation ----
+    wire mac_ready;
+    ZeroDSP_MAC u_mac (
+        .clk    (sys_clk),
+        .rst_n  (sys_rst_n),
+        .en     (1'b1),
+        .ready  (mac_ready)
+    );
+
     // ---- ZeroDSP_UART instantiation ----
     wire uart_ready;
     ZeroDSP_UART u_uart (
@@ -2990,15 +2999,15 @@ module {top} (
 
     // ---- Output assignments ----
     assign led[0]     = heartbeat_ctr[24];
-    assign led[1]     = uart_ready;
-    assign led[2]     = spi_ready;
-    assign led[3]     = sys_ready;
-    assign led[4]     = 1'b0;
+    assign led[1]     = mac_ready;
+    assign led[2]     = uart_ready;
+    assign led[3]     = spi_ready;
+    assign led[4]     = sys_ready;
     assign led[5]     = 1'b0;
     assign led[6]     = 1'b0;
     assign led[7]     = 1'b0;
     assign uart_tx    = uart_rx;
-    assign mac_done   = 1'b0;
+    assign mac_done   = mac_ready;
     assign mac_result = {{5'd0, heartbeat_ctr}};
     assign spi_cs     = 1'b1;
     assign spi_sck    = 1'b0;
@@ -3041,7 +3050,7 @@ endmodule
         fs::write(
             &synth_script,
             format!(
-                "read_verilog {gen}/uart.v {gen}/spi.v {gen}/top_level.v {gen}/{top}.v\nhierarchy -check -top {top}\nproc; opt; fsm; opt; memory; opt\nsynth_xilinx -top {top}\nstat\n",
+                "read_verilog {gen}/mac.v {gen}/uart.v {gen}/spi.v {gen}/top_level.v {gen}/{top}.v\nhierarchy -check -top {top}\nproc; opt; fsm; opt; memory; opt\nsynth_xilinx -top {top}\nstat\n",
                 gen = gen_dir.display(),
                 top = top,
             ),
@@ -3061,7 +3070,7 @@ endmodule
         fs::write(
             &synth_script,
             format!(
-                "read_verilog {gen}/uart.v {gen}/spi.v {gen}/top_level.v {gen}/{top}.v\nhierarchy -check -top {top}\nproc; opt; fsm; opt; memory; opt\nsynth_xilinx -top {top}\nstat\n",
+                "read_verilog {gen}/mac.v {gen}/uart.v {gen}/spi.v {gen}/top_level.v {gen}/{top}.v\nhierarchy -check -top {top}\nproc; opt; fsm; opt; memory; opt\nsynth_xilinx -top {top}\nstat\n",
                 gen = gen_dir.display(),
                 top = top,
             ),

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -842,6 +842,6 @@ eW91IHdvcmsgaW4gVVRDLio=
 - FPGA board (QMTECH XC7A100T) detected on `/dev/cu.usbserial-140` (UART)
 - Logic analyzer (DreamSourceLab) connected
 
-**Last updated:** 2026-04-08 — FPGA optimizer const_propagate fix, &&/|| lexer · PR #364
+**Last updated:** 2026-04-08 — FPGA 4/5 modules in synthesis (MAC fixed!), &&/|| precedence · Issue #367
 
 *This is a partial update for PR #337. Integrate into full NOW.md after merge.*

--- a/specs/fpga/bridge.t27
+++ b/specs/fpga/bridge.t27
@@ -77,12 +77,12 @@ module FPGA_Bridge;
 
     // buffer_write(buf: []u8, size: usize, head: usize, data: u8) → bool
     // Write byte to circular buffer
-    fn buffer_write(buf: []u8, size: usize, head: usize, data: u8) -> bool {
+    fn buffer_write(buf_in: []u8, size: usize, head: usize, data: u8) -> bool {
         const new_head = (head + 1) % size;
         if (new_head == 0 && head == size - 1) {
             return false;  // Buffer full
         }
-        buf[head] = data;
+        buf_in[head] = data;
         return true;
     }
 


### PR DESCRIPTION
## Summary

- **MAC module** now passes Yosys `synth_xilinx` — was blocked by optimizer const_propagate replacing reassigned variable with literal, and array+field access codegen producing `a[i]_field` instead of flat struct name
- **&& / || precedence** — `bitand`/`bitor` parsers now check lexeme to exclude `&&`/`||` tokens. Fixes `a == 0 && b == 1` being parsed as `a == (0 && b) == 1`
- **Field access codegen** — `ExprFieldAccess` after `ExprIndex` now flattens to `structname_field` (matches flat register declarations)
- **bridge.t27** — `buf` renamed to `buf_in` (Verilog reserved keyword)

## Verification

| Module | Yosys synth_xilinx |
|--------|-------------------|
| ZeroDSP_MAC | PASS |
| ZeroDSP_UART | PASS |
| SPI_Master | PASS |
| ZeroDSP_TopLevel | PASS |
| FPGA_Bridge | FAIL (tuple destructuring) |

Full synthesis: **112 cells, 27 FDRE, 4 submodules**.

Closes #367