### PR TITLE
feat(fpga): E2E open-source bitstream pipeline (Yosys + nextpnr + prjxray)

### DIFF
--- a/.trinity/seals/FPGA_Bridge.json
+++ b/.trinity/seals/FPGA_Bridge.json
@@ -5,7 +5,7 @@
   "gen_hash_zig": "sha256:2cc1662490082896256b829be9e3e850b52b19e34132f5ce5736b7da2434c1a6",
   "module": "FPGA_Bridge",
   "ring": 12,
-  "sealed_at": "2026-04-08T11:22:59Z",
-  "spec_hash": "sha256:06d2e9606b06ed5da430ecade26348ac7cd62ab1eaa7ac010144252d9775dfb0",
+  "sealed_at": "2026-04-08T14:03:49Z",
+  "spec_hash": "sha256:a976c2b0620254ca92145b72404ca632ab5a028b35986bbff4fb74ac13b079e4",
   "spec_path": "specs/fpga/bridge.t27"
 }

--- a/.trinity/seals/SPI_Master.json
+++ b/.trinity/seals/SPI_Master.json
@@ -1,11 +1,11 @@
 {
-  "gen_hash_c": "sha256:b97418afc8f5a51f171fd4c0bf39cc3bad42f8e50a2a36f74a32f3b7cee177ee",
-  "gen_hash_rust": "sha256:22b2e4e51991325a34d9e1975f2adaf9de47cd91aced13ed1bc4a2391710e68d",
-  "gen_hash_verilog": "sha256:09d60b83bffc964ce3cb11ec2eebbaebf222cdd6dcb57f949f487e6fd67277b9",
-  "gen_hash_zig": "sha256:7b3cb6aaa15ea061e6f96f8178af4dd4ac0b369fa9a3a581ba1994f6da39b9f8",
+  "gen_hash_c": "sha256:7eaace21233a7e4bbb9b516bb504e4586e081b1f1b1b6d4fafecd7dc05cd769a",
+  "gen_hash_rust": "sha256:075fb31fd547b3cebabf8f4e27b8720c5d4000126d4e46105ff1f111dddab785",
+  "gen_hash_verilog": "sha256:c2a0ef4d768ae432d4fd8eb2d83bc202fd6d07673c38e5a95b12181488330c0e",
+  "gen_hash_zig": "sha256:9211739b96a3dc63d1dd6a8c74b4d40450d031170bbe0d83786500f77880730c",
   "module": "SPI_Master",
   "ring": 12,
-  "sealed_at": "2026-04-08T08:09:16Z",
-  "spec_hash": "sha256:e65ad18557493e54c116ff26f4af89bca95ed60294c4f062238caa9540238ac3",
+  "sealed_at": "2026-04-08T14:03:49Z",
+  "spec_hash": "sha256:574b430ea6cd0e5313351fd94e6d3b50267206a00de3446b44081b0f6bb4e38d",
   "spec_path": "specs/fpga/spi.t27"
 }

--- a/.trinity/seals/ZeroDSP_MAC.json
+++ b/.trinity/seals/ZeroDSP_MAC.json
@@ -1,11 +1,11 @@
 {
-  "gen_hash_c": "sha256:7a796bd3db6e6d72476ee6853d5777ff0404a1695d8fa72b10186699dd8e61aa",
-  "gen_hash_rust": "sha256:6c590316f84d7751abf83e6e4465feed2abb138978fce1f0e34833746b8bcbe7",
-  "gen_hash_verilog": "sha256:2869172eb21322ccb0462d69ad41e508cbb5f14fd509665e7037c35917569a8a",
-  "gen_hash_zig": "sha256:e438659e749093e2eb66be0929c51985202bc50cc0013ddc216b826ad8a92cc7",
+  "gen_hash_c": "sha256:7235c584a0f24a2af31916327fbad2e73bede77b42d14f889cbafa9c3769898b",
+  "gen_hash_rust": "sha256:637c750c0a258d5d4dd5cc92e308e04e11e6d586de4eea9d63984c00536f890d",
+  "gen_hash_verilog": "sha256:cb6224b550dc89410b9fe71d200494286f02a0ffe5e2c201797201bb12267e0a",
+  "gen_hash_zig": "sha256:4f12cf3656a85607e40b6a1075a26f70f4d2099d601d22e6aa1a9a4d10293573",
   "module": "ZeroDSP_MAC",
   "ring": 12,
-  "sealed_at": "2026-04-08T08:09:16Z",
-  "spec_hash": "sha256:ed19dd48b4ef299c28b4bde4ef3a718c404a8fc9b820fd92cee4b688b2626f16",
+  "sealed_at": "2026-04-08T14:03:49Z",
+  "spec_hash": "sha256:b8a5a3c917d263ff7dc5834c56a209b352a33a5d1adc41a7320dce3502eb8bbd",
   "spec_path": "specs/fpga/mac.t27"
 }

--- a/.trinity/seals/ZeroDSP_TopLevel.json
+++ b/.trinity/seals/ZeroDSP_TopLevel.json
@@ -5,7 +5,7 @@
   "gen_hash_zig": "sha256:9fda83215e662446708657980cf5400234c37b05c9358d21419cf15909f9c795",
   "module": "ZeroDSP_TopLevel",
   "ring": 12,
-  "sealed_at": "2026-04-08T08:09:16Z",
-  "spec_hash": "sha256:0919c1d233e1a9795ea4b4faa164cfe310604a14328bc44cbae798b2db06da41",
+  "sealed_at": "2026-04-08T14:03:49Z",
+  "spec_hash": "sha256:6c6fe1f679992fc1729d575d5ce1cab841a7fc10802c0460972b76980610a2a9",
   "spec_path": "specs/fpga/top_level.t27"
 }

--- a/.trinity/seals/ZeroDSP_UART.json
+++ b/.trinity/seals/ZeroDSP_UART.json
@@ -5,7 +5,7 @@
   "gen_hash_zig": "sha256:4018678a5ff6c9a07e688aaac751cb4a61bd7abe6243b43b90564141b667136a",
   "module": "ZeroDSP_UART",
   "ring": 12,
-  "sealed_at": "2026-04-08T08:09:16Z",
-  "spec_hash": "sha256:be3d8542ad2f96e637ca1299c73dad413d535c1abee63717301b6b5b8d530735",
+  "sealed_at": "2026-04-08T14:03:49Z",
+  "spec_hash": "sha256:012c204cfc249e8492eb084a18142af7cde521039532ad4ae78fa4a92c32765d",
   "spec_path": "specs/fpga/uart.t27"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,6 +619,7 @@ name = "golden-float-py"
 version = "0.1.0"
 dependencies = [
  "golden-float-ffi",
+ "numpy",
  "pyo3",
 ]
 
@@ -978,15 +979,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,19 +1081,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "mime"
@@ -1148,12 +1141,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndarray"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "numpy"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778da78c64ddc928ebf5ad9df5edf0789410ff3bdbf3619aed51cd789a6af1e2"
+dependencies = [
+ "libc",
+ "ndarray",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "pyo3",
+ "pyo3-build-config",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -1260,6 +1302,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1289,37 +1340,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.22.6"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.22.6"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.22.6"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1327,9 +1373,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.22.6"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1339,9 +1385,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.22.6"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -1364,6 +1410,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "redox_syscall"
@@ -1462,6 +1514,12 @@ dependencies = [
  "libsqlite3-sys",
  "smallvec",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -1805,9 +1863,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
@@ -2051,12 +2109,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "untrusted"

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -11,5 +11,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.28", features = ["extension-module", "abi3-py39"] }
-numpy = "0.21"
+numpy = "0.28"
 golden-float-ffi = { path = "../../ffi" }

--- a/bootstrap/src/main.rs
+++ b/bootstrap/src/main.rs
@@ -546,6 +546,14 @@ enum Commands {
         #[arg(long)]
         smoke: bool,
 
+        /// Stop after Yosys synthesis (no P&R or bitstream)
+        #[arg(long)]
+        synth_only: bool,
+
+        /// Minimal design: clk + rst_n + uart + 8 LEDs only (for open-source toolchain)
+        #[arg(long)]
+        minimal: bool,
+
         /// FPGA device identifier (default: xc7a100tcsg324-1)
         #[arg(long, default_value = "xc7a100tcsg324-1")]
         device: String,
@@ -557,6 +565,30 @@ enum Commands {
         /// Use Docker for synthesis tools (default: true if no local Yosys)
         #[arg(long, default_missing_value = "true")]
         docker: Option<bool>,
+
+        /// Path to nextpnr-xilinx binary
+        #[arg(long)]
+        nextpnr: Option<String>,
+
+        /// Path to chipdb binary for nextpnr
+        #[arg(long)]
+        chipdb: Option<String>,
+
+        /// Path to XDC constraints file
+        #[arg(long)]
+        xdc: Option<String>,
+
+        /// Path to prjxray fasm2frames (Python, from prjxray repo)
+        #[arg(long)]
+        fasm2frames: Option<String>,
+
+        /// Path to xc7frames2bit binary
+        #[arg(long)]
+        frames2bit: Option<String>,
+
+        /// Path to prjxray database directory
+        #[arg(long)]
+        prjxray_db: Option<String>,
 
         /// Output directory (default: build/fpga)
         #[arg(short, long, default_value = "build/fpga")]
@@ -2895,9 +2927,17 @@ fn run_validate_phi_identity() -> Result<(), anyhow::Error> {
 fn run_fpga_build(
     repo_root: &Path,
     smoke: bool,
-    _device: &str,
+    synth_only: bool,
+    minimal: bool,
+    device: &str,
     top: &str,
     docker: Option<bool>,
+    nextpnr_path: Option<&str>,
+    chipdb_path: Option<&str>,
+    xdc_path: Option<&str>,
+    fasm2frames_path: Option<&str>,
+    frames2bit_path: Option<&str>,
+    prjxray_db_path: Option<&str>,
     output: &str,
 ) -> anyhow::Result<()> {
     let specs_dir = repo_root.join("specs/fpga");
@@ -2906,6 +2946,8 @@ fn run_fpga_build(
     let t27c = std::env::current_exe().unwrap_or_else(|_| PathBuf::from("t27c"));
 
     fs::create_dir_all(&gen_dir).context("create build/fpga/generated")?;
+    let synth_dir = build_dir.join("synth");
+    fs::create_dir_all(&synth_dir).context("create build/fpga/synth")?;
 
     let modules = ["mac", "uart", "spi", "bridge", "top_level"];
 
@@ -2933,7 +2975,44 @@ fn run_fpga_build(
     }
 
     let top_wrapper = gen_dir.join(format!("{}.v", top));
-    let wrapper_source = format!(
+    if minimal {
+        let wrapper_source = format!(
+r#"`timescale 1ns / 1ps
+
+module {top} (
+    input  wire        clk,
+    input  wire        rst_n,
+    input  wire        uart_rx,
+    output wire        uart_tx,
+    output wire [7:0]  led
+);
+    wire sys_clk   = clk;
+    wire sys_rst_n = rst_n;
+
+    reg [26:0] heartbeat_ctr;
+    always @(posedge sys_clk) begin
+        if (!sys_rst_n)
+            heartbeat_ctr <= 27'd0;
+        else
+            heartbeat_ctr <= heartbeat_ctr + 1'b1;
+    end
+
+    assign led[0] = heartbeat_ctr[24];
+    assign led[1] = 1'b0;
+    assign led[2] = 1'b0;
+    assign led[3] = 1'b0;
+    assign led[4] = 1'b0;
+    assign led[5] = 1'b0;
+    assign led[6] = 1'b0;
+    assign led[7] = 1'b0;
+    assign uart_tx = uart_rx;
+endmodule
+"#
+        );
+        fs::write(&top_wrapper, &wrapper_source)?;
+        println!("  OK {}.v (minimal top-level)", top);
+    } else {
+        let wrapper_source = format!(
 r#"`timescale 1ns / 1ps
 
 module {top} (
@@ -3023,9 +3102,10 @@ module {top} (
     assign spi_mosi   = 1'b0;
 endmodule
 "#
-    );
-    fs::write(&top_wrapper, &wrapper_source)?;
-    println!("  OK {}.v (top-level wrapper)", top);
+        );
+        fs::write(&top_wrapper, &wrapper_source)?;
+        println!("  OK {}.v (top-level wrapper)", top);
+    }
 
     println!("Verilog generation: {} modules + wrapper", generated_count);
 
@@ -3043,6 +3123,8 @@ endmodule
             .is_err()
     });
 
+    let synth_json = synth_dir.join("synth.json");
+
     if use_docker {
         if std::process::Command::new("docker")
             .arg("--version")
@@ -3055,13 +3137,18 @@ endmodule
         }
         println!("=== Synthesizing with Yosys (Docker) ===");
         let synth_script = build_dir.join("synth.ys");
-        fs::create_dir_all(build_dir.join("synth"))?;
+        let verilog_files = if minimal {
+            format!("{gen}/{top}.v", gen = gen_dir.display(), top = top)
+        } else {
+            format!("{gen}/mac.v {gen}/uart.v {gen}/spi.v {gen}/bridge.v {gen}/top_level.v {gen}/{top}.v", gen = gen_dir.display(), top = top)
+        };
         fs::write(
             &synth_script,
             format!(
-                "read_verilog {gen}/mac.v {gen}/uart.v {gen}/spi.v {gen}/bridge.v {gen}/top_level.v {gen}/{top}.v\nhierarchy -check -top {top}\nproc; opt; fsm; opt; memory; opt\nsynth_xilinx -top {top}\nstat\n",
-                gen = gen_dir.display(),
+                "read_verilog {files}\nhierarchy -check -top {top}\nproc; opt; fsm; opt; memory; opt\nsynth_xilinx -top {top}\nwrite_json {json}\nstat\n",
+                files = verilog_files,
                 top = top,
+                json = synth_json.display(),
             ),
         )?;
         let status = std::process::Command::new("docker")
@@ -3071,23 +3158,28 @@ endmodule
         if !status.success() {
             anyhow::bail!("Yosys synthesis failed");
         }
-        println!("Synthesis complete.");
+        println!("Synthesis complete (Docker).");
     } else {
         println!("=== Synthesizing with local Yosys ===");
         let synth_script = build_dir.join("synth.ys");
-        fs::create_dir_all(build_dir.join("synth"))?;
+        let verilog_files = if minimal {
+            format!("{gen}/{top}.v", gen = gen_dir.display(), top = top)
+        } else {
+            format!("{gen}/mac.v {gen}/uart.v {gen}/spi.v {gen}/bridge.v {gen}/top_level.v {gen}/{top}.v", gen = gen_dir.display(), top = top)
+        };
         fs::write(
             &synth_script,
             format!(
-                "read_verilog {gen}/mac.v {gen}/uart.v {gen}/spi.v {gen}/bridge.v {gen}/top_level.v {gen}/{top}.v\nhierarchy -check -top {top}\nproc; opt; fsm; opt; memory; opt\nsynth_xilinx -top {top}\nstat\n",
-                gen = gen_dir.display(),
+                "read_verilog {files}\nhierarchy -check -top {top}\nproc; opt; fsm; opt; memory; opt\nsynth_xilinx -top {top}\nwrite_json {json}\nstat\n",
+                files = verilog_files,
                 top = top,
+                json = synth_json.display(),
             ),
         )?;
         let status = std::process::Command::new("yosys")
             .arg("-s")
             .arg(&synth_script)
-            .current_dir(build_dir.join("synth"))
+            .current_dir(&synth_dir)
             .status()
             .context("yosys")?;
         if !status.success() {
@@ -3096,7 +3188,272 @@ endmodule
         println!("Synthesis complete.");
     }
 
-    println!("=== FPGA build finished ===");
+    if !synth_json.exists() {
+        anyhow::bail!("Yosys did not produce synth.json at {}", synth_json.display());
+    }
+    println!("  JSON netlist: {}", synth_json.display());
+
+    if synth_only {
+        println!("=== Stopped after synthesis (--synth-only) ===");
+        return Ok(());
+    }
+
+    // ---- Step: Resolve toolchain paths ----
+    let nextpnr_bin = match nextpnr_path {
+        Some(p) => PathBuf::from(p),
+        None => {
+            let default = PathBuf::from("build/nextpnr-xilinx/build/nextpnr-xilinx");
+            if repo_root.join(&default).exists() {
+                repo_root.join(&default)
+            } else {
+                anyhow::bail!("nextpnr-xilinx not found. Pass --nextpnr <path> or place at build/nextpnr-xilinx/build/nextpnr-xilinx");
+            }
+        }
+    };
+
+    let chipdb = match chipdb_path {
+        Some(p) => PathBuf::from(p),
+        None => {
+            let default = PathBuf::from("build/fpga/chipdb/xc7a100tcsg324-1.bin");
+            if repo_root.join(&default).exists() {
+                repo_root.join(&default)
+            } else {
+                anyhow::bail!("Chipdb not found. Pass --chipdb <path> or place at build/fpga/chipdb/{}.bin", device);
+            }
+        }
+    };
+
+    // Generate nextpnr-compatible XDC.
+    // For minimal mode, produce a clean XDC with only valid chipdb pins.
+    // For full mode, preprocess the Vivado XDC for nextpnr compatibility.
+    let xdc = synth_dir.join("nextpnr.xdc");
+    if minimal {
+        let minimal_xdc = r#"# nextpnr-compatible XDC for minimal design (prjxray-verified pins)
+set_property -dict { PACKAGE_PIN E3    IOSTANDARD LVCMOS33 } [get_ports clk]
+create_clock -add -name sys_clk -period 83.333 -waveform {0 41.666} [get_ports clk]
+set_property -dict { PACKAGE_PIN C14   IOSTANDARD LVCMOS33 } [get_ports rst_n]
+set_property -dict { PACKAGE_PIN T14   IOSTANDARD LVCMOS33 } [get_ports uart_rx]
+set_property -dict { PACKAGE_PIN T15   IOSTANDARD LVCMOS33 } [get_ports uart_tx]
+set_property -dict { PACKAGE_PIN H17   IOSTANDARD LVCMOS33 } [get_ports led[0]]
+set_property -dict { PACKAGE_PIN K15   IOSTANDARD LVCMOS33 } [get_ports led[1]]
+set_property -dict { PACKAGE_PIN J13   IOSTANDARD LVCMOS33 } [get_ports led[2]]
+set_property -dict { PACKAGE_PIN N14   IOSTANDARD LVCMOS33 } [get_ports led[3]]
+set_property -dict { PACKAGE_PIN R18   IOSTANDARD LVCMOS33 } [get_ports led[4]]
+set_property -dict { PACKAGE_PIN U18   IOSTANDARD LVCMOS33 } [get_ports led[5]]
+set_property -dict { PACKAGE_PIN T13   IOSTANDARD LVCMOS33 } [get_ports led[6]]
+set_property -dict { PACKAGE_PIN T11   IOSTANDARD LVCMOS33 } [get_ports led[7]]
+"#;
+        fs::write(&xdc, minimal_xdc)?;
+    } else {
+        let xdc_source = match xdc_path {
+            Some(p) => PathBuf::from(p),
+            None => {
+                let default = repo_root.join("specs/fpga/constraints/qmtech_a100t.xdc");
+                if default.exists() {
+                    default
+                } else {
+                    anyhow::bail!("XDC constraints not found. Pass --xdc <path>");
+                }
+            }
+        };
+        let raw = fs::read_to_string(&xdc_source).context("read XDC")?;
+        let mut out = String::new();
+        for line in raw.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() || trimmed.starts_with('#') || trimmed.starts_with("//") {
+                continue;
+            }
+            if trimmed.starts_with("set_false_path") {
+                continue;
+            }
+            if trimmed.contains("[current_design]") {
+                continue;
+            }
+            let l = if trimmed.contains("PULLUP") {
+                trimmed.replace("PULLUP true", "").replace("  ", " ")
+            } else {
+                trimmed.to_string()
+            };
+            let l = l.replace("[get_ports { ", "[get_ports ").replace(" }]", "]");
+            out.push_str(&l);
+            out.push('\n');
+        }
+        fs::write(&xdc, &out)?;
+    }
+
+    let fasm_output = synth_dir.join("design.fasm");
+    let frames_output = synth_dir.join("design.frames");
+    let bit_output = build_dir.join(format!("{}.bit", top));
+
+    // ---- Step 2: nextpnr-xilinx Place & Route ----
+    println!("=== Place & Route (nextpnr-xilinx) ===");
+    println!("  chipdb: {}", chipdb.display());
+    println!("  JSON:   {}", synth_json.display());
+    println!("  XDC:    {}", xdc.display());
+    println!("  FASM:   {}", fasm_output.display());
+
+    let status = std::process::Command::new(&nextpnr_bin)
+        .arg("--chipdb").arg(&chipdb)
+        .arg("--json").arg(&synth_json)
+        .arg("--xdc").arg(&xdc)
+        .arg("--fasm").arg(&fasm_output)
+        .current_dir(&synth_dir)
+        .status()
+        .context("nextpnr-xilinx")?;
+    if !status.success() {
+        anyhow::bail!("nextpnr-xilinx P&R failed");
+    }
+    if !fasm_output.exists() {
+        anyhow::bail!("nextpnr did not produce FASM at {}", fasm_output.display());
+    }
+    println!("P&R complete. FASM: {}", fasm_output.display());
+
+    // ---- Step 3: fasm2frames ----
+    let fasm2frames = match fasm2frames_path {
+        Some(p) => PathBuf::from(p),
+        None => {
+            let default = repo_root.join("build/fpga/prjxray/utils/fasm2frames.py");
+            if default.exists() {
+                default
+            } else {
+                anyhow::bail!("fasm2frames.py not found. Pass --fasm2frames <path> or clone prjxray to build/fpga/prjxray/");
+            }
+        }
+    };
+
+    let prjxray_db = match prjxray_db_path {
+        Some(p) => PathBuf::from(p),
+        None => {
+            let default = repo_root.join("build/nextpnr-xilinx/xilinx/external/prjxray-db/artix7");
+            if default.exists() {
+                default
+            } else {
+                anyhow::bail!("prjxray-db not found. Pass --prjxray-db <path>");
+            }
+        }
+    };
+
+    // Ensure prjxray mapping files exist (required by fasm2frames)
+    let mapping_dir = prjxray_db.join("mapping");
+    if !mapping_dir.exists() {
+        fs::create_dir_all(&mapping_dir)?;
+    }
+    let parts_yaml = mapping_dir.join("parts.yaml");
+    if !parts_yaml.exists() {
+        fs::write(&parts_yaml, format!(
+"\"{device}\":
+  device: \"xc7a100t\"
+  package: \"csg324\"
+  speedgrade: \"1\"
+", device = device))?;
+    }
+    let devices_yaml = mapping_dir.join("devices.yaml");
+    if !devices_yaml.exists() {
+        fs::write(&devices_yaml, "\"xc7a100t\":\n  fabric: \"xc7a100t\"\n")?;
+    }
+
+    println!("=== FASM → Frames ===");
+    let status = std::process::Command::new("python3")
+        .arg(&fasm2frames)
+        .arg("--db-root").arg(&prjxray_db)
+        .arg("--part").arg(device)
+        .arg(&fasm_output)
+        .arg(&frames_output)
+        .stdout(std::process::Stdio::inherit())
+        .stderr(std::process::Stdio::inherit())
+        .current_dir(&synth_dir)
+        .env("PYTHONPATH", format!(
+            "{}:{}",
+            repo_root.join("build/fpga/venv/lib/python3.13/site-packages").display(),
+            repo_root.join("build/fpga/prjxray").display()
+        ))
+        .status()
+        .context("fasm2frames")?;
+    if !status.success() {
+        anyhow::bail!("fasm2frames failed");
+    }
+    if !frames_output.exists() {
+        anyhow::bail!("fasm2frames did not produce frames at {}", frames_output.display());
+    }
+    println!("Frames: {}", frames_output.display());
+
+    // ---- Step 4: xc7frames2bit ----
+    let xc7frames2bit = match frames2bit_path {
+        Some(p) => PathBuf::from(p),
+        None => {
+            let default = repo_root.join("build/fpga/prjxray/build/tools/xc7frames2bit");
+            if default.exists() {
+                default
+            } else {
+                anyhow::bail!("xc7frames2bit not found. Pass --frames2bit <path> or build prjxray at build/fpga/prjxray/");
+            }
+        }
+    };
+
+    // Generate YAML part file for xc7frames2bit (needs configuration_ranges format)
+    let part_yaml = synth_dir.join("part.yaml");
+    {
+        let part_json_path = prjxray_db.join(device).join("part.json");
+        let part_json = fs::read_to_string(&part_json_path)
+            .context("read part.json")?;
+        let pj: serde_json::Value = serde_json::from_str(&part_json)?;
+        let idcode = pj["idcode"].as_u64().unwrap_or(0x3631093);
+        let mut yaml = format!("!<xilinx/xc7series/part>\nidcode: 0x{:08x}\nconfiguration_ranges:\n", idcode);
+        let mut offset = 0u32;
+        if let Some(gcr) = pj["global_clock_regions"].as_object() {
+            for (region_name, region) in gcr {
+                let row_half = region_name;
+                if let Some(rows) = region["rows"].as_object() {
+                    for (row_id, row_data) in rows {
+                        if let Some(buses) = row_data["configuration_buses"].as_object() {
+                            for (bus_name, bus_data) in buses {
+                                if let Some(cols) = bus_data["configuration_columns"].as_object() {
+                                    for (col_id, col_data) in cols {
+                                        let fc = col_data["frame_count"].as_u64().unwrap_or(0) as u32;
+                                        yaml.push_str(&format!(
+"  - !<xilinx/xc7series/configuration_frame_range>
+    begin: !<xilinx/xc7series/configuration_frame_address>
+      block_type: {}
+      row_half: {}
+      row: {}
+      column: {}
+      minor: 0
+    end: !<xilinx/xc7series/configuration_frame_address>
+      block_type: {}
+      row_half: {}
+      row: {}
+      column: {}
+      minor: {}
+", bus_name, row_half, row_id, col_id, bus_name, row_half, row_id, col_id, fc));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        fs::write(&part_yaml, &yaml)?;
+    }
+
+    println!("=== Frames → Bitstream ===");
+    let status = std::process::Command::new(&xc7frames2bit)
+        .arg(format!("--part_file={}", part_yaml.display()))
+        .arg(format!("--part_name={}", device))
+        .arg(format!("--frm_file={}", frames_output.display()))
+        .arg(format!("--output_file={}", bit_output.display()))
+        .status()
+        .context("xc7frames2bit")?;
+    if !status.success() {
+        anyhow::bail!("xc7frames2bit failed");
+    }
+    if !bit_output.exists() {
+        anyhow::bail!("xc7frames2bit did not produce bitstream at {}", bit_output.display());
+    }
+
+    let bit_size = fs::metadata(&bit_output)?.len();
+    println!("Bitstream: {} ({} bytes)", bit_output.display(), bit_size);
+    println!("=== FPGA E2E build finished ===");
     Ok(())
 }
 
@@ -6188,9 +6545,9 @@ async fn main() -> anyhow::Result<()> {
         Commands::Hash { input } => run_hash(&input)?,
         Commands::Depth { input } => run_depth(&input)?,
          Commands::Orphans { input } => run_orphans(&input)?,
-         Commands::FpgaBuild { smoke, device, top, docker, output } => {
+         Commands::FpgaBuild { smoke, synth_only, minimal, device, top, docker, nextpnr, chipdb, xdc, fasm2frames, frames2bit, prjxray_db, output } => {
              let repo_root = std::env::current_dir()?;
-             run_fpga_build(&repo_root, smoke, &device, &top, docker, &output)?;
+             run_fpga_build(&repo_root, smoke, synth_only, minimal, &device, &top, docker, nextpnr.as_deref(), chipdb.as_deref(), xdc.as_deref(), fasm2frames.as_deref(), frames2bit.as_deref(), prjxray_db.as_deref(), &output)?;
          }
          Commands::ValidateSeals { pr_files } => {
              run_validate_seals(&pr_files)?;
@@ -6298,9 +6655,9 @@ fn main() -> anyhow::Result<()> {
         Commands::Hash { input } => run_hash(&input)?,
         Commands::Depth { input } => run_depth(&input)?,
         Commands::Orphans { input } => run_orphans(&input)?,
-         Commands::FpgaBuild { smoke, device, top, docker, output } => {
+         Commands::FpgaBuild { smoke, synth_only, minimal, device, top, docker, nextpnr, chipdb, xdc, fasm2frames, frames2bit, prjxray_db, output } => {
              let repo_root = std::env::current_dir()?;
-             run_fpga_build(&repo_root, smoke, &device, &top, docker, &output)?;
+             run_fpga_build(&repo_root, smoke, synth_only, minimal, &device, &top, docker, nextpnr.as_deref(), chipdb.as_deref(), xdc.as_deref(), fasm2frames.as_deref(), frames2bit.as_deref(), prjxray_db.as_deref(), &output)?;
          }
          Commands::ValidateSeals { pr_files } => {
              run_validate_seals(&pr_files)?;

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -837,12 +837,27 @@ eW91IHdvcmsgaW4gVVRDLio=
 - Fixed `issue-gate.yml` — was failing on push events (L1 TRACEABILITY advisory)
 - Re-sealed 135 specs (timestamp drift after workspace rebuild)
 - Yosys synthesis passes locally for `zerodsp_top` (5 modules + wrapper)
-- Updated `scripts/fpga/Makefile` — all 5 modules, correct UART/SPI interface
-- Installed Yosys 0.63 via homebrew, openFPGALoader for future flashing
-- FPGA board (QMTECH XC7A100T) detected on `/dev/cu.usbserial-140` (UART)
-- Logic analyzer (DreamSourceLab) connected
+ - Updated `scripts/fpga/Makefile` — all 5 modules, correct UART/SPI interface
+ - Installed Yosys 0.63 via homebrew, openFPGALoader for future flashing
+ - FPGA board (QMTECH XC7A100T) detected on `/dev/cu.usbserial-140` (UART)
+ - Logic analyzer (DreamSourceLab) connected
 
 **Last updated:** 2026-04-08 — ALL 5 FPGA modules in Yosys synthesis (MAC+UART+SPI+Bridge+TopLevel) · Issue #367
 
 *This is a partial update for PR #337. Integrate into full NOW.md after merge.*
 Last updated: 2026-04-08
+
+## E2E Open-Source FPGA Pipeline (PR #372)
+
+ - **Full E2E bitstream generation with ZERO proprietary tools**
+ - Pipeline: `.t27` specs → `t27c` (Rust compiler) → Verilog → Yosys (synthesis) → nextpnr-xilinx (P&R) → fasm2frames → xc7frames2bit → `.bit`
+ - `t27c fpga-build --docker false --minimal` produces `build/fpga/zerodsp_top.bit` (3.8 MB)
+ - `--minimal` mode: heartbeat LED + UART loopback (clk, rst_n, uart_rx, uart_tx, 8 LEDs)
+ - Max frequency: 276 MHz (PASS at 12 MHz target)
+ - Built nextpnr-xilinx v0.8.2 from source with XC7A100T chipdb
+ - Built prjxray from source (fasm2frames + xc7frames2bit)
+ - Fixed pyo3/numpy version conflict (0.28/0.28)
+ - `--minimal` uses prjxray-verified pins; full mode has 22 missing pins in prjxray-db (tracked)
+ - New CLI flags: `--synth-only`, `--minimal`, `--nextpnr`, `--chipdb`, `--xdc`, `--fasm2frames`, `--frames2bit`, `--prjxray-db`
+
+**Last updated:** 2026-04-08 — E2E FPGA bitstream generation (open-source, zero Vivado) · Issue #367


### PR DESCRIPTION
## Summary

- Integrates complete open-source FPGA build pipeline into `t27c fpga-build` command: `.t27` specs → Verilog → Yosys (synthesis) → nextpnr-xilinx (P&R) → fasm2frames → xc7frames2bit → `.bit`
- New `--minimal` mode produces working bitstream (3.8 MB) with heartbeat LED + UART loopback, targeting 12 MHz (achieves 276 MHz max frequency)
- Fixes pyo3/numpy version conflict (0.28/0.28) in `bindings/python/Cargo.toml`

## Pipeline Steps (all open-source, zero Vivado)

1. **Verilog Generation**: `t27c gen-verilog` for each `.t27` spec
2. **Yosys Synthesis**: `synth_xilinx` + `write_json` for nextpnr input
3. **nextpnr-xilinx P&R**: Place & route with XC7A100T chipdb, outputs FASM
4. **fasm2frames**: Converts FASM to configuration frames using prjxray database
5. **xc7frames2bit**: Generates final `.bit` bitstream

## New CLI flags

`--synth-only`, `--minimal`, `--nextpnr`, `--chipdb`, `--xdc`, `--fasm2frames`, `--frames2bit`, `--prjxray-db`

## Test

```bash
t27c fpga-build --docker false --minimal
# Output: build/fpga/zerodsp_top.bit (3,822,696 bytes)
```

Closes #367