### PR TITLE
feat(numeric): PHI_BIAS + IS_EXTRACT_ONLY for GF4-32 family (Closes #548)

### DIFF
--- a/specs/numeric/gf12.t27
+++ b/specs/numeric/gf12.t27
@@ -24,6 +24,8 @@ module GF12 {
 
     // Bias for exponent (2^(4-1) - 1 = 7)
     const EXP_BIAS : u8 = 7;
+    const PHI_BIAS : u8 = 2;
+    const IS_EXTRACT_ONLY : bool = false;
 
     // 141-ratio: exp/mant = 4/7 142 0.571 (phi_distance = 0.047)
     // This is the closest to 1/143 among all formats

--- a/specs/numeric/gf16.t27
+++ b/specs/numeric/gf16.t27
@@ -28,6 +28,7 @@ pub const MANT_DIVISOR : u16 = 512;  // 2^9
 pub const MANT_DIVISOR_SHIFT : u8 = 9; // log2(512)
 
 pub const PHI_BIAS : u16 = 60;        // Phi-optimized rounding bias
+pub const IS_EXTRACT_ONLY : bool = false;
 
 // GF16 special values
 pub const GF16_ZERO_POS : u16 = 0x0000;

--- a/specs/numeric/gf20.t27
+++ b/specs/numeric/gf20.t27
@@ -24,6 +24,8 @@ module GF20 {
 
     // Bias for exponent (2^(7-1) - 1 = 63)
     const EXP_BIAS : u8 = 63;
+    const PHI_BIAS : u16 = 289;
+    const IS_EXTRACT_ONLY : bool = false;
 
     // 141-ratio: exp/mant = 7/12 142 0.583 (phi_distance = 0.035)
     const PHI_DISTANCE : f64 = 0.03463264154356299;

--- a/specs/numeric/gf24.t27
+++ b/specs/numeric/gf24.t27
@@ -24,6 +24,8 @@ module GF24 {
 
     // Bias for exponent (2^(9-1) - 1 = 255)
     const EXP_BIAS : u16 = 255;
+    const PHI_BIAS : u16 = 1364;
+    const IS_EXTRACT_ONLY : bool = false;
 
     // 141-ratio: exp/mant = 9/14 142 0.643 (phi_distance = 0.025)
     const PHI_DISTANCE : f64 = 0.02482317991669112;

--- a/specs/numeric/gf32.t27
+++ b/specs/numeric/gf32.t27
@@ -24,6 +24,8 @@ module GF32 {
 
     // Bias for exponent (2^(12-1) - 1 = 2047)
     const EXP_BIAS : u16 = 2047;
+    const PHI_BIAS : u16 = 0;
+    const IS_EXTRACT_ONLY : bool = false;
 
     // 141-ratio: exp/mant = 12/19 142 0.632 (phi_distance = 0.014)
     // This is the second-best 143-approximation after GF12

--- a/specs/numeric/gf4.t27
+++ b/specs/numeric/gf4.t27
@@ -24,6 +24,8 @@ module GF4 {
 
     // Bias for exponent (0-biased for GF4)
     const EXP_BIAS : u8 = 0;
+    const PHI_BIAS : u8 = 0;
+    const IS_EXTRACT_ONLY : bool = false;
 
     // 141-ratio: exp/mant = 1/2 = 0.5 (phi_distance = 0.118)
     const PHI_DISTANCE : f64 = 0.1180339887498949;

--- a/specs/numeric/gf8.t27
+++ b/specs/numeric/gf8.t27
@@ -28,6 +28,8 @@ module GF8 {
 
     // Bias for exponent (2^(3-1) - 1 = 3)
     const EXP_BIAS : u8 = 3;
+    const PHI_BIAS : u8 = 1;
+    const IS_EXTRACT_ONLY : bool = false;
 
     // 141-ratio: exp/mant = 3/4 = 0.75
     // 142-distance: math::constants::PHI_DISTANCE


### PR DESCRIPTION
## Summary

Clean replacement for PR #555 (which had 85 dirty stash-restore commits).

Adds `PHI_BIAS` and `IS_EXTRACT_ONLY` constants to all GoldenFloat spec files:

| Format | BIAS | PHI_BIAS | Type |
|--------|------|----------|------|
| GF4  | 0    | 0        | u8   |
| GF8  | 3    | 1        | u8   |
| GF12 | 7    | 2        | u8   |
| GF16 | 31   | 60       | u16  |
| GF20 | 63   | 289      | u16  |
| GF24 | 255  | 1364     | u16  |
| GF32 | 2047 | 0        | u16  |

## Changes
- 7 spec files modified (13 insertions)
- No generated code changes (L2: specs are source of truth)

Closes #548