### PR TITLE
feat(math): --weinberg diagnostic — phi^-3 vs PDG sin^2(theta_W) (Closes #295)

### DIFF
--- a/bootstrap/src/math_compare.rs
+++ b/bootstrap/src/math_compare.rs
@@ -24,6 +24,8 @@ const CKM_V_US: f64 = 0.225;
 const CKM_V_CB: f64 = 0.0418;
 const CKM_V_UB: f64 = 0.0037;
 
+const SIN2_THETA_W_REF: f64 = 0.23122;
+
 #[derive(Subcommand, Debug)]
 pub enum MathCommands {
     /// Compare L5 anchors; optional Pellis, extended SM proxies, hybrid map, sensitivity.
@@ -49,6 +51,9 @@ pub enum MathCommands {
         /// Numeric partials of TRINITY and (if --hybrid) hybrid score w.r.t. phi.
         #[arg(long)]
         sensitivity: bool,
+        /// Weinberg angle diagnostic: phi^-3 vs PDG sin^2(theta_W).
+        #[arg(long)]
+        weinberg: bool,
     },
 }
 
@@ -62,6 +67,7 @@ pub fn run_math_command(cmd: MathCommands, repo_root: &Path) -> anyhow::Result<(
             n,
             theta,
             sensitivity,
+            weinberg,
         } => run_compare(
             repo_root,
             CompareOpts {
@@ -72,6 +78,7 @@ pub fn run_math_command(cmd: MathCommands, repo_root: &Path) -> anyhow::Result<(
                 n,
                 theta,
                 sensitivity,
+                weinberg,
             },
         ),
     }
@@ -85,6 +92,7 @@ pub struct CompareOpts {
     pub n: u32,
     pub theta: bool,
     pub sensitivity: bool,
+    pub weinberg: bool,
 }
 
 #[inline]
@@ -323,6 +331,30 @@ fn run_compare(repo_root: &Path, opts: CompareOpts) -> anyhow::Result<()> {
         record["pellis_spec_seal_hash"] = json!(h);
     }
 
+    if opts.weinberg {
+        let phi_inv_cubed = phi_inv.powi(3);
+        let delta_abs = (phi_inv_cubed - SIN2_THETA_W_REF).abs();
+        let delta_rel = delta_abs / SIN2_THETA_W_REF;
+
+        println!("=== Weinberg Angle Diagnostic (issue #295) ===");
+        println!("phi^-3           = {:.10}", phi_inv_cubed);
+        println!("sin^2(theta_W)   = {:.10}  (PDG MS-bar)", SIN2_THETA_W_REF);
+        println!("delta_abs        = {:.10}", delta_abs);
+        println!("delta_rel        = {:.6} ({:.2}%)", delta_rel, delta_rel * 100.0);
+
+        let bound = 0.005_f64;
+        if delta_abs < bound {
+            println!("golden test: |phi^-3 - sin^2(theta_W)| = {:.10} < {} PASS", delta_abs, bound);
+        } else {
+            println!("golden test: |phi^-3 - sin^2(theta_W)| = {:.10} >= {} NOT MET", delta_abs, bound);
+        }
+
+        record["weinberg_enabled"] = json!(true);
+        record["phi_inv_cubed"] = json!(phi_inv_cubed);
+        record["sin2_theta_w_ref"] = json!(SIN2_THETA_W_REF);
+        record["delta_abs"] = json!(delta_abs);
+        record["delta_rel"] = json!(delta_rel);
+    }
 
     append_experience(repo_root, &record)?;
     println!(
@@ -438,6 +470,27 @@ mod tests {
             (theta - 15.8995).abs() < 0.01,
             "theta: got {:.4} deg",
             theta
+        );
+    }
+
+    #[test]
+    fn test_weinberg_golden_bound() {
+        let phi_inv_cubed = (1.0 / phi()).powi(3);
+        let delta = (phi_inv_cubed - SIN2_THETA_W_REF).abs();
+        assert!(
+            delta < 0.005,
+            "golden test: |phi^-3 - sin^2(theta_W)| = {:.10} >= 0.005",
+            delta
+        );
+    }
+
+    #[test]
+    fn test_phi_inv_cubed_approx() {
+        let phi_inv_cubed = (1.0 / phi()).powi(3);
+        assert!(
+            (phi_inv_cubed - 0.236068).abs() < 0.001,
+            "phi^-3 should be ~0.236, got {:.10}",
+            phi_inv_cubed
         );
     }
 }


### PR DESCRIPTION
## Summary

Clean replacement for PR #556 (which had 2669 files of conflicting history).

Adds `--weinberg` flag to `tri math compare`:
- Computes phi^-3 ≈ 0.236068
- Compares with PDG sin^2(theta_W) = 0.23122 (MS-bar scheme)
- Golden test: |phi^-3 - sin^2(theta_W)| < 0.005
- 2 new unit tests + JSONL experience logging

## Test plan
- [x] `cargo test -p t27c math_compare` passes
- [x] Single commit, clean history, L1 TRACEABILITY compliant

Closes #295