### PR TITLE
feat(fpga): Vivado cloud synthesis workflow

### DIFF
--- a/.github/workflows/vivado-bitstream.yml
+++ b/.github/workflows/vivado-bitstream.yml
@@ -1,0 +1,24 @@
+name: Vivado Bitstream
+
+on:
+  workflow_dispatch:
+
+jobs:
+  vivado-build:
+    runs-on: ubuntu-latest
+    container:
+      image: kkrizka/vivado:2019.2
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Synthesize blinky with Vivado
+        run: |
+          cd fpga/vivado
+          vivado -mode batch -nojournal -nolog -source build.tcl
+
+      - name: Upload bitstream
+        uses: actions/upload-artifact@v4
+        with:
+          name: vivado-bitstream
+          path: fpga/vivado/blinky.bit
+          retention-days: 30

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,6 +1,6 @@
 # Current Work — Trinity t27
 
-**Last updated:** 2026-04-29
+**Last updated:** 2026-05-08
 **Note:** DARPA CLARA PA-25-07-02 submission package migrated to [ghashTag/trinity-clara](https://github.com/gHashTag/trinity-clara)
 
 ---
@@ -16,16 +16,10 @@
 - Golden tests for N={5,10,15,20,50,152}, all pass
 - Closes #339 #287
 
-**GF Competitive Analysis** (PR #560 — merged)
+**GF Competitive Analysis** (PR pending)
 - verify_precision.py with mpmath 100-digit sacred constants
 - gf_competitive.t27 + pellis_verify.t27 specs
 - Closes #289
-
-**Pipeline E2E + Memory Primitives** (PR pending)
-- specs/pipeline/e2e_test.t27, experience_save.t27, benchmarks.t27
-- specs/memory/memory_primitives.t27 — remember/recall/forget/reflect
-- docs/TECH_TREE.md — 5-level technology tree
-- Closes #490 #517
 
 **Pre-commit Gate (Ring 073)** (PR #554)
 - 4 gates: NOW freshness, seal coverage, L7 no-new-shell, cargo check

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,6 +1,6 @@
 # Current Work — Trinity t27
 
-**Last updated:** 2026-05-08
+**Last updated:** 2026-05-07
 **Note:** DARPA CLARA PA-25-07-02 submission package migrated to [ghashTag/trinity-clara](https://github.com/gHashTag/trinity-clara)
 
 ---

--- a/fpga/vivado/blinky.v
+++ b/fpga/vivado/blinky.v
@@ -1,0 +1,16 @@
+module blinky (
+    input  wire clk,
+    output wire led5,
+    output wire led6
+);
+
+    reg [26:0] counter = 0;
+
+    always @(posedge clk) begin
+        counter <= counter + 1;
+    end
+
+    assign led5 = ~counter[23];
+    assign led6 = ~counter[22];
+
+endmodule

--- a/fpga/vivado/blinky.xdc
+++ b/fpga/vivado/blinky.xdc
@@ -1,0 +1,6 @@
+set_property -dict { PACKAGE_PIN M21 IOSTANDARD LVCMOS33 } [get_ports clk]
+set_property -dict { PACKAGE_PIN R23 IOSTANDARD LVCMOS33 } [get_ports led5]
+set_property -dict { PACKAGE_PIN T23 IOSTANDARD LVCMOS33 } [get_ports led6]
+
+set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]
+set_property BITSTREAM.CONFIG.UNUSEDPIN PULLDOWN [current_design]

--- a/fpga/vivado/build.tcl
+++ b/fpga/vivado/build.tcl
@@ -1,0 +1,18 @@
+set part xc7a100tfgg676-1
+
+create_project -in_memory -part $part
+
+read_verilog blinky.v
+read_xdc blinky.xdc
+
+synth_design -top blinky -part $part
+opt_design
+place_design
+route_design
+
+report_utilization
+report_timing
+
+write_bitstream -force blinky.bit
+
+puts "DONE: bitstream written"

--- a/scripts/tri
+++ b/scripts/tri
@@ -1,14 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-T27C="${TRI_T27C:-}"
-if [[ -z "$T27C" ]]; then
-  for p in "$ROOT/bootstrap/target/release/t27c" "$ROOT/bootstrap/target/debug/t27c"; do
-    [[ -x "$p" ]] && T27C="$p" && break
-  done
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+T27C="${TRI_T27C:-$REPO_ROOT/bootstrap/target/release/t27c}"
+if [[ ! -x "$T27C" && -x "$REPO_ROOT/bootstrap/target/debug/t27c" ]]; then
+  T27C="$REPO_ROOT/bootstrap/target/debug/t27c"
 fi
-[[ -n "${T27C:-}" && -x "$T27C" ]] || {
+if [[ ! -x "$T27C" ]]; then
   echo "tri: t27c not found. Run: cd bootstrap && cargo build --release" >&2
   exit 1
-}
-exec "$T27C" --repo-root "$ROOT" "$@"
+fi
+exec "$T27C" --repo-root "$REPO_ROOT" "$@"


### PR DESCRIPTION
## Summary
- GitHub Actions workflow for Vivado bitstream synthesis (manual trigger)
- Uses `kkrizka/vivado:2019.2` Docker image (Vivado pre-installed)
- Blinky design: 27-bit counter, M21 clock, R23/T23 LEDs, XC7A100T-1FGG676
- Fix merge conflict in `scripts/tri`

Closes #305