### PR TITLE
fix(ci): source Vivado settings64.sh

### DIFF
--- a/.github/workflows/vivado-bitstream.yml
+++ b/.github/workflows/vivado-bitstream.yml
@@ -13,7 +13,7 @@ jobs:
         run: |
           docker run --rm -v "$PWD:/work" -w /work/fpga/vivado \
             kkrizka/vivado:2019.2 \
-            vivado -mode batch -nojournal -nolog -source build.tcl
+            bash -c "source /opt/Xilinx/Vivado/*/settings64.sh && vivado -mode batch -nojournal -nolog -source build.tcl"
 
       - name: Upload bitstream
         uses: actions/upload-artifact@v4

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,7 +1,7 @@
 # Current Work — Trinity t27
 
 **Last updated:** 2026-05-07
-**Note:** DARPA CLARA PA-25-07-02 submission package migrated to [ghashTag/trinity-clara](https://github.com/gHashTag/trinity-clara). FPGA Vivado cloud synthesis workflow added.
+**Note:** DARPA CLARA PA-25-07-02 submission package migrated to [ghashTag/trinity-clara](https://github.com/gHashTag/trinity-clara). FPGA Vivado cloud synthesis workflow (settings64.sh fix).
 
 ---
 


### PR DESCRIPTION
Vivado binary not in PATH — source settings64.sh first. (Closes #305)