### PR TITLE
fix(fpga): CLOCK_DEDICATED_ROUTE FALSE per QMTECH Wukong V3 ref

### DIFF
--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,7 +1,7 @@
 # Current Work — Trinity t27
 
 **Last updated:** 2026-05-07
-**Note:** DARPA CLARA PA-25-07-02 submission package migrated to [ghashTag/trinity-clara](https://github.com/gHashTag/trinity-clara). FPGA Vivado cloud synthesis workflow (settings64.sh fix).
+**Note:** DARPA CLARA PA-25-07-02 submission package migrated to [ghashTag/trinity-clara](https://github.com/gHashTag/trinity-clara). FPGA: CLOCK_DEDICATED_ROUTE FALSE fix per QMTECH Wukong V3 ref design.
 
 ---
 

--- a/fpga/vivado/blinky.xdc
+++ b/fpga/vivado/blinky.xdc
@@ -1,4 +1,5 @@
 set_property -dict { PACKAGE_PIN M21 IOSTANDARD LVCMOS33 } [get_ports clk]
+set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets clk_IBUF]
 set_property -dict { PACKAGE_PIN R23 IOSTANDARD LVCMOS33 } [get_ports led5]
 set_property -dict { PACKAGE_PIN T23 IOSTANDARD LVCMOS33 } [get_ports led6]
 


### PR DESCRIPTION
## Summary
- Add `CLOCK_DEDICATED_ROUTE FALSE` constraint per QMTECH Wukong V3 reference design
- M21 is not a dedicated clock route pin — Vivado needs this to route clock via general routing
- Reference: `ChinaQMTECH/QM_XC7A100T_WUKONG_BOARD` Test01_led_key project

Closes #305