### PR TITLE
fix(fpga): ring oscillator test — bypass M21

### DIFF
--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,7 +1,7 @@
 # Current Work — Trinity t27
 
 **Last updated:** 2026-05-07
-**Note:** DARPA CLARA PA-25-07-02 submission package migrated to [ghashTag/trinity-clara](https://github.com/gHashTag/trinity-clara). FPGA: debugging M21 clock on QMTECH Wukong V1 — capturing Vivado log.
+**Note:** DARPA CLARA PA-25-07-02 submission package migrated to [ghashTag/trinity-clara](https://github.com/gHashTag/trinity-clara). FPGA: ring oscillator test on QMTECH Wukong V1 — bypassing M21 oscillator.
 
 ---
 

--- a/fpga/vivado/blinky.v
+++ b/fpga/vivado/blinky.v
@@ -1,36 +1,29 @@
 module blinky (
-    input sys_clk,
-    input sys_rst_n,
-    output led_g20,
-    output led_g21,
-    output led_r23,
-    output led_t23
+    output wire led_r23,
+    output wire led_t23
 );
 
-reg [31:0] count;
-reg r_led;
+    (* KEEP = "TRUE" *) wire osc;
+    (* KEEP = "TRUE" *) wire chain [19:0];
+    reg [22:0] counter = 0;
 
-always @(posedge sys_clk or negedge sys_rst_n) begin
-    if (!sys_rst_n)
-        count <= 32'd0;
-    else if (count == 32'd50_000_000)
-        count <= 32'd0;
-    else
-        count <= count + 32'd1;
-end
+    assign chain[0] = ~chain[19];
+    genvar i;
+    generate
+        for (i = 1; i < 20; i = i + 1) begin : inv_chain
+            (* KEEP = "TRUE" *) LUT1 #(.INIT(2'b01)) inv (
+                .I0(chain[i-1]),
+                .O(chain[i])
+            );
+        end
+    endgenerate
+    assign osc = chain[19];
 
-always @(posedge sys_clk or negedge sys_rst_n) begin
-    if (!sys_rst_n)
-        r_led <= 1'b0;
-    else if (count < 32'd25_000_000)
-        r_led <= 1'b1;
-    else
-        r_led <= 1'b0;
-end
+    always @(posedge osc) begin
+        counter <= counter + 1;
+    end
 
-assign led_g20 = r_led;
-assign led_g21 = ~r_led;
-assign led_r23 = r_led;
-assign led_t23 = ~r_led;
+    assign led_r23 = ~counter[20];
+    assign led_t23 = ~counter[19];
 
 endmodule

--- a/fpga/vivado/blinky.xdc
+++ b/fpga/vivado/blinky.xdc
@@ -1,10 +1,7 @@
-set_property -dict { PACKAGE_PIN M21 IOSTANDARD LVCMOS33 } [get_ports sys_clk]
-set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets sys_clk_IBUF]
-set_property -dict { PACKAGE_PIN H7 IOSTANDARD LVCMOS33 } [get_ports sys_rst_n]
-set_property -dict { PACKAGE_PIN G20 IOSTANDARD LVCMOS33 } [get_ports led_g20]
-set_property -dict { PACKAGE_PIN G21 IOSTANDARD LVCMOS33 } [get_ports led_g21]
 set_property -dict { PACKAGE_PIN R23 IOSTANDARD LVCMOS33 } [get_ports led_r23]
 set_property -dict { PACKAGE_PIN T23 IOSTANDARD LVCMOS33 } [get_ports led_t23]
 
 set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]
 set_property BITSTREAM.CONFIG.UNUSEDPIN PULLDOWN [current_design]
+set_property CLOCK_DEDICATED_ROUTE FALSE [get_nets osc]
+set_property ALLOW_COMBINATORIAL_LOOPS TRUE [get_nets osc]


### PR DESCRIPTION
20-stage ring oscillator using LUT1 primitives — no external clock needed. Tests if FPGA combinational logic works. (Closes #305)