### PR TITLE
chore(zenodo): PASS-9 add missing doi field to CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,6 +2,7 @@ cff-version: 1.2.0
 message: "If you use T27/GoldenFloat in research or software, please cite it as below."
 title: "GoldenFloat: φ-Optimal Floating-Point Formats for Ternary Computing (T27)"
 version: 0.1.0
+doi: 10.5281/zenodo.19456875
 date-released: 2026-04-07
 authors:
   - family-names: Vasilev

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -3,6 +3,8 @@
 **Last updated:** 2026-05-12
 **Note:** GF16 4×4 matmul validated on FPGA @ 323 MHz, 40350 LUTs, 64 DSP48E1, 0 latches. **TinyTapeout TTSKY26a submitted** — `gHashTag/tt-trinity-gf16`, CI running. 41.2 GOPS @ 323 MHz | 12.8 GOPS @ 100 MHz.
 
+**PASS-9 (2026-05-12 UTC):** R5-honest fix — added missing `doi: 10.5281/zenodo.19456875` field to CITATION.cff so machine-readable citation metadata matches the GoldenFloat v0.1.0 Zenodo deposit. Companion PASS-9 PRs: gHashTag/trios#767 (image-gate root-fix + broken refs), gHashTag/trinity-fpga (CITATION.cff rewrite).
+
 ---
 
 ## R5-PASS-7 Honest Audit (Issue #598 — invalid ORCID + wrong community slug in `.zenodo.json`)


### PR DESCRIPTION
Closes #602

## PASS-9 R5-honest fix — CITATION.cff missing `doi:` field

`CITATION.cff` declared `version: 0.1.0` and `date-released: 2026-04-07` but omitted the `doi:` field entirely. The README badge and the SOT disclosure block both already point at `10.5281/zenodo.19456875` (GoldenFloat v0.1.0), so automated citation tools (Zotero, scholar.google, Citation File Format consumers) silently failed to resolve the right artefact for this repo.

### Fix

- `CITATION.cff`: added `doi: 10.5281/zenodo.19456875` between `version: 0.1.0` and `date-released: 2026-04-07`.
- `docs/NOW.md`: appended PASS-9 R5-honest note (satisfies `check-now-freshness` UTC gate and `now-sync-gate-diff.sh` diff-presence gate; date 2026-05-12 UTC is current).

### Verification

- ✅ DOI `10.5281/zenodo.19456875` HEAD HTTP 200 (re-verified PASS-9)
- ✅ ORCID `0009-0008-4294-6159` canonical (PASS-7 fix #599 holds)
- ✅ All other CITATION.cff metadata already correct (title, authors, version, date-released)
- ✅ `docs/NOW.md` UTC date `2026-05-12` matches CI clock window

### Cross-refs

- Tracking issue: #602
- Companion PASS-9 in trios: [gHashTag/trios#767](https://github.com/gHashTag/trios/pull/767) (image-gate root-fix + broken refs)
- Companion PASS-9 in trinity-fpga: [gHashTag/trinity-fpga#46](https://github.com/gHashTag/trinity-fpga/issues/46) (CITATION.cff rewrite)
- Throne: [gHashTag/trios#264](https://github.com/gHashTag/trios/issues/264)
- Single source of truth: https://zenodo.org/communities/trinity-s3ai/

φ² + φ⁻² = 3 · TRINITY · R5-HONEST · PASS-9
