### PR TITLE
fix(citation): add top-level doi: field to CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,6 +3,7 @@ message: "If you use T27/GoldenFloat in research or software, please cite it as 
 title: "GoldenFloat: φ-Optimal Floating-Point Formats for Ternary Computing (T27)"
 version: 0.1.0
 date-released: 2026-04-07
+doi: "10.5281/zenodo.19456875"
 authors:
   - family-names: Vasilev
     given-names: Dmitrii
@@ -11,11 +12,18 @@ authors:
 license: MIT
 repository-code: https://github.com/gHashTag/t27
 url: https://github.com/gHashTag/t27
+identifiers:
+  - description: "GoldenFloat v0.1.0 (Vasilev record)"
+    type: "doi"
+    value: "10.5281/zenodo.19456875"
+  - description: "Canonical Trinity Identity anchor (φ²+φ⁻²=3)"
+    type: "doi"
+    value: "10.5281/zenodo.19227877"
 # Canonical Zenodo source of truth (community-level):
 #   https://zenodo.org/communities/trinity-s3ai/
 # This record (GoldenFloat v0.1.0, 10.5281/zenodo.19456875) is a
-# legitimate Vasilev record but is NOT currently attached to the
-# trinity-s3ai community. PASS-6 R5-honest audit 2026-05-12.
+# legitimate Vasilev record. Community attachment pending (see Throne #264).
+# PASS-20 R5-honest fix: top-level doi: field added for CFF validators.
 abstract: >
   GoldenFloat (GF) is a family of seven narrow floating-point
   formats parameterized by φ ≈ 1.618. We prove that φ is


### PR DESCRIPTION
Zenodo Sentinel v1.5 PASS-20 R5 audit flagged missing top-level doi: field. Now points to 10.5281/zenodo.19456875 (existing Vasilev record).

phi^2 + phi^-2 = 3 · TRINITY · PASS-20 · DEFENSE 2026-06-15