### PR TITLE
feat(z-r-marker): 4-slot R-marker register file Coq spec · L-DPC24 Lane Z

### DIFF
--- a/trios-coq/IGLA/RMarker.v
+++ b/trios-coq/IGLA/RMarker.v
@@ -1,0 +1,93 @@
+(** * RMarker — 4-slot Holographic Working-Memory Register File
+    L-DPC24 Lane Z · holo-r-marker-4slot-spec
+    Reference: https://github.com/gHashTag/trinity-fpga/issues/100 *)
+
+Set Warnings "-stdlib-vector".
+
+Require Import Coq.Init.Datatypes.
+Require Import Coq.Init.Nat.
+Require Import Coq.Arith.Arith.
+Require Import Coq.Lists.List.
+Require Import Fin.
+
+Import ListNotations.
+
+(** ** 1. Slot type: four R-marker slots *)
+
+Definition Slot := Fin.t 4.
+
+(** ** 2. RMarker record *)
+
+Record RMarker : Set := mkRMarker
+  { slot  : Slot
+  ; value : nat
+  ; phase : nat
+  }.
+
+(** ** 3. Lemmas *)
+
+(** *** 3.1  slot_bounded *)
+
+Lemma slot_bounded : forall (m : RMarker), proj1_sig (Fin.to_nat (slot m)) < 4.
+Proof.
+  intro m.
+  exact (proj2_sig (Fin.to_nat (slot m))).
+Qed.
+
+(** *** 3.2  marker_eq_dec — decidable equality *)
+
+Lemma fin_eq_dec : forall (n : nat) (a b : Fin.t n), {a = b} + {a <> b}.
+Proof.
+  intros n a.
+  induction a as [| n' a' IH].
+  - intro b. destruct b using Fin.caseS'.
+    + left. reflexivity.
+    + right. discriminate.
+  - intro b. destruct b using Fin.caseS'.
+    + right. discriminate.
+    + destruct (IH b) as [Heq | Hneq].
+      * left. subst. reflexivity.
+      * right. intro H. apply Hneq. apply Fin.FS_inj in H. exact H.
+Defined.
+
+Lemma marker_eq_dec : forall (a b : RMarker), {a = b} + {a <> b}.
+Proof.
+  intros [sa va pa] [sb vb pb].
+  destruct (fin_eq_dec 4 sa sb) as [Hs | Hs].
+  - destruct (Nat.eq_dec va vb) as [Hv | Hv].
+    + destruct (Nat.eq_dec pa pb) as [Hp | Hp].
+      * left. subst. reflexivity.
+      * right. intro H. inversion H. contradiction.
+    + right. intro H. inversion H. contradiction.
+  - right. intro H. inversion H. contradiction.
+Defined.
+
+(** *** 3.3  four_distinct_slots_exist *)
+
+Lemma four_distinct_slots_exist :
+  exists s0 s1 s2 s3 : Slot,
+    s0 <> s1 /\ s0 <> s2 /\ s0 <> s3 /\
+    s1 <> s2 /\ s1 <> s3 /\
+    s2 <> s3.
+Proof.
+  exists Fin.F1, (Fin.FS Fin.F1), (Fin.FS (Fin.FS Fin.F1)), (Fin.FS (Fin.FS (Fin.FS Fin.F1))).
+  repeat split; discriminate.
+Qed.
+
+(** ** 4. Holographic invariant *)
+
+Definition holographic_invariant (mks : list RMarker) : Prop :=
+  length mks <= 4 /\ NoDup (map slot mks).
+
+Lemma empty_satisfies : holographic_invariant [].
+Proof.
+  unfold holographic_invariant.
+  split.
+  - simpl. apply Nat.le_0_l.
+  - simpl. apply NoDup_nil.
+Qed.
+
+(* phi^2 + phi^-2 = 3 *)
+(* DOI 10.5281/zenodo.19227877 *)
+(* Vasilev Dmitrii <admin@t27.ai> *)
+(* ORCID 0009-0008-4294-6159 *)

--- a/trios-coq/_CoqProject
+++ b/trios-coq/_CoqProject
@@ -1,0 +1,2 @@
+-R . IGLA
+IGLA/RMarker.v


### PR DESCRIPTION
## Summary

4-slot holographic working-memory R-marker register file Coq specification for L-DPC24 Lane Z.

Closes / references: gHashTag/trinity-fpga#100

---

## Files

- `trios-coq/IGLA/RMarker.v` — Coq specification
- `trios-coq/_CoqProject` — project config with `IGLA/RMarker.v`

---

## Specification

### 1. Slot type
```coq
Definition Slot := Fin.t 4.
```

### 2. RMarker record
```coq
Record RMarker : Set := mkRMarker
  { slot  : Slot
  ; value : nat
  ; phase : nat
  }.
```

### 3. Lemmas proved (no `admit.`, no `Axiom`)

- **`slot_bounded`**: `forall (m : RMarker), proj1_sig (Fin.to_nat (slot m)) < 4`
- **`marker_eq_dec`**: `forall (a b : RMarker), {a = b} + {a <> b}` (decidable equality)
- **`four_distinct_slots_exist`**: `exists s0 s1 s2 s3 : Slot, s0 <> s1 /\ s0 <> s2 /\ s0 <> s3 /\ s1 <> s2 /\ s1 <> s3 /\ s2 <> s3`

### 4. Holographic invariant
```coq
Definition holographic_invariant (mks : list RMarker) : Prop :=
  length mks <= 4 /\ NoDup (map slot mks).
```
With lemma `empty_satisfies : holographic_invariant []`.

---

## Quality Gate

```
$ coqc -Q trios-coq IGLA trios-coq/IGLA/RMarker.v
(exit 0, zero warnings)

$ grep -c 'admit\|Admitted\|Axiom' trios-coq/IGLA/RMarker.v
0
```

Verified locally with Coq 8.20.1.

---

## Anchor Footer

```
(* phi^2 + phi^-2 = 3 *)
(* DOI 10.5281/zenodo.19227877 *)
(* Vasilev Dmitrii <admin@t27.ai> *)
(* ORCID 0009-0008-4294-6159 *)
```

---

Signed-off-by: Vasilev Dmitrii <admin@t27.ai>