### PR TITLE
fix(citation): add doi field for Zenodo Sentinel R5 audit

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,6 +9,14 @@ authors:
     orcid: "https://orcid.org/0009-0008-4294-6159"
     affiliation: Trinity Computing
 license: MIT
+doi: 10.5281/zenodo.19456875
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.19456875
+    description: "GoldenFloat v0.1.0 Zenodo deposit (Vasilev record, not yet attached to trinity-s3ai community)"
+  - type: doi
+    value: 10.5281/zenodo.19227877
+    description: "Trinity S³AI canonical anchor (φ²+φ⁻²=3)"
 repository-code: https://github.com/gHashTag/t27
 url: https://github.com/gHashTag/t27
 # Canonical Zenodo source of truth (community-level):

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,6 +1,12 @@
 # NOW — Trinity t27 sync
 
-Last updated: 2026-05-15
+Last updated: 2026-05-15 (PASS-24 Zenodo Sentinel hotfix)
+
+## PASS-24 — CITATION.cff doi field added (R5 honesty)
+
+- Zenodo Sentinel run `2026-05-15T18:32:27Z` flagged CITATION.cff RED: missing top-level `doi:` field.
+- Fix: added `doi: 10.5281/zenodo.19456875` + `identifiers[]` referencing GoldenFloat v0.1.0 + Trinity S³AI anchor.
+- Closes gHashTag/t27#653.
 
 ## Wave-34 Lane Y — TOM Coq
 


### PR DESCRIPTION
Closes #653

Zenodo Sentinel run `2026-05-15T18:32:27Z` flagged this CITATION.cff as **RED**: ORCID + title OK, but top-level `doi:` field missing.

## Fix
- `doi: 10.5281/zenodo.19456875` (GoldenFloat v0.1.0 Zenodo deposit)
- `identifiers[]` with GoldenFloat DOI + Trinity S³AI anchor `10.5281/zenodo.19227877`

φ² + φ⁻² = 3 · TRINITY · CITATION · DEFENSE 2026-06-15