### PR TITLE
fix(ci): repair notebook-sync workflow syntax (Closes #695)

### DIFF
--- a/.github/workflows/notebook-sync.yml
+++ b/.github/workflows/notebook-sync.yml
@@ -18,23 +18,22 @@ on:
     types: [submitted, edited]
   push:
     branches: ['feature/**', 'fix/**', 'ring-*/**', 'issue-*/**']
-
-# Allow manual trigger
-workflow_dispatch:
-  inputs:
-    issue_number:
-      description: 'Issue number to sync'
-      required: true
-      type: number
-    sync_type:
-      description: 'Type of sync'
-      required: false
-      type: choice
-      default: 'push'
-      options:
-        - push
-        - comment
-        - activity
+  # Allow manual trigger
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: 'Issue number to sync'
+        required: true
+        type: number
+      sync_type:
+        description: 'Type of sync'
+        required: false
+        type: choice
+        default: 'push'
+        options:
+          - push
+          - comment
+          - activity
 
 jobs:
   # Extract issue number from event
@@ -44,7 +43,7 @@ jobs:
     outputs:
       issue_number: ${{ steps.issue.outputs.number }}
       issue_title: ${{ steps.issue.outputs.title }}
-      event_type: ${{ steps.event.outputs.type }}
+      event_type: ${{ steps.event_type.outputs.type }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -72,12 +71,6 @@ jobs:
               echo "type=pr" >> $GITHUB_OUTPUT
               ;;
             pull_request_review)
-              ISSUE_NUM="${{ github.event.pull_request.number }}"
-              ISSUE_TITLE="${{ github.event.pull_request.title }}"
-              echo "type=pr" >> $GITHUB_OUTPUT
-              ;;
-            pull_request_review)
-              # Extract issue number from PR body or branch
               ISSUE_NUM="${{ github.event.pull_request.number }}"
               ISSUE_TITLE="${{ github.event.pull_request.title }}"
               echo "type=pr" >> $GITHUB_OUTPUT
@@ -123,6 +116,8 @@ jobs:
     needs: extract-issue
     if: needs.extract-issue.outputs.issue_number != ''
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -177,19 +172,65 @@ jobs:
             exit 0
           }
 
-      - name: Update sync status as commit
+      - name: Update sync status as commit (best-effort)
         if: github.event_name == 'issues' || github.event_name == 'pull_request'
-        uses: peter-evans/create-or-update-file@v3
+        continue-on-error: true
+        uses: actions/github-script@v7
+        env:
+          SYNC_TIME: ${{ github.event.repository.updated_at }}
+          EVENT_NAME: ${{ github.event_name }}
+          ISSUE_NUM: ${{ needs.extract-issue.outputs.issue_number }}
         with:
-          path: .trinity/notebook_sync_status.json
-          content: |
-            {
-              "last_sync": "${{ github.event.repository.updated_at }}",
-              "last_event": "${{ github.event_name }}",
-              "last_issue": ${{ needs.extract-issue.outputs.issue_number }},
-              "synced_at": "${{ github.event.repository.updated_at }}"
+          script: |
+            const path = '.trinity/notebook_sync_status.json';
+            const content = JSON.stringify({
+              last_sync: process.env.SYNC_TIME,
+              last_event: process.env.EVENT_NAME,
+              last_issue: Number(process.env.ISSUE_NUM),
+              synced_at: process.env.SYNC_TIME,
+            }, null, 2) + '\n';
+            const contentB64 = Buffer.from(content).toString('base64');
+
+            // On 'issues' and 'pull_request' events the workflow has no
+            // single canonical branch to commit to (PRs from forks have a
+            // read-only token; 'issues' has no ref at all). Resolve the
+            // repository's default branch and commit there as best-effort.
+            const repoInfo = await github.rest.repos.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            const branch = repoInfo.data.default_branch;
+
+            let sha;
+            try {
+              const { data } = await github.rest.repos.getContent({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                path,
+                ref: branch,
+              });
+              sha = data.sha;
+            } catch (e) {
+              if (e.status !== 404) throw e;
             }
-          message: "Update NotebookLM sync status [skip ci]"
+
+            try {
+              await github.rest.repos.createOrUpdateFileContents({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                path,
+                message: 'Update NotebookLM sync status [skip ci]',
+                content: contentB64,
+                branch,
+                ...(sha ? { sha } : {}),
+              });
+              core.info(`Wrote ${path} on ${branch}`);
+            } catch (e) {
+              // 403/422 are expected when the workflow runs from a fork or
+              // when branch protection blocks the write. This step is a
+              // book-keeping nicety, not a correctness gate — log and pass.
+              core.warning(`Status commit skipped (${e.status} ${e.message})`);
+            }
 
   # Sync activity.md periodically
   sync-activity:

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,8 +1,20 @@
 # NOW — Trinity t27 sync
 
-Last updated: 2026-05-17
+Last updated: 2026-05-18
 
-## docs(TRI-NET) — positioning package (this PR, #693, Closes #627)
+## ci(notebook-sync) — repair workflow syntax causing instant failures (this PR, #694, Closes #695)
+
+- **Fixed**: `.github/workflows/notebook-sync.yml` was failing instantly on every push since #693 merged — runs completed in seconds with `conclusion=failure`, zero jobs dispatched, `gh run view --log-failed` reported *log not found*.
+- **Root cause (three combined defects)**:
+  1. `workflow_dispatch:` was declared at the top level instead of nested under `on:` — Actions rejected the file at parse time (bare `on` is interpreted as YAML `True`).
+  2. `extract-issue.outputs.event_type` referenced `steps.event.outputs.type` while the step id is `event_type`.
+  3. Duplicate `pull_request_review)` case in the bash event dispatch.
+- **Latent runtime defect surfaced once jobs began dispatching**: `sync-notebook` referenced `peter-evans/create-or-update-file@v3`, which does not exist on github.com (404). Replaced with `actions/github-script@v7` using `github.rest.repos.createOrUpdateFileContents`; added `permissions.contents: write` on the `sync-notebook` job. Step targets the repo's default branch (resolved via `repos.get`) because on `issues` / `pull_request` events there is no canonical branch to commit to, and is wrapped in `continue-on-error` + internal `try/catch` so a 403/422 from fork PRs or branch protection logs a warning instead of failing the sync job — matches the existing best-effort pattern around the `python sync.py || warnings; exit 0` block immediately above.
+- **Validation**: `actionlint 1.7.12` — all syntax-check and expression errors cleared. `yaml.safe_load` confirms `on:` contains all 6 triggers including `workflow_dispatch` with `inputs: [issue_number, sync_type]`.
+- **L7 UNITY held**: YAML/actions-side repair only — no `*.sh` added, no `gen/` edits, no spec changes. RTL/GDS/`verdict.json` gates untouched. TRI-NET docs package from #693 untouched.
+- Closes #695
+
+## docs(TRI-NET) — positioning package (#693, Closes #627)
 
 - **NEW** (root-level, docs-only): `STATUS.md`, `LINEUP.md`, `FORMAT_REGISTRY.md`, `COMPETITORS.md`, `BENCHMARKS.md`, `CLARA_TRACEABILITY.md`
 - **README.md first screen**: additive "What this repo is" block linking to the six new docs; rest of README unchanged


### PR DESCRIPTION
Closes #695

## Summary

`.github/workflows/notebook-sync.yml` has been failing instantly on every push since the merge of PR #693 — runs complete in seconds with `conclusion=failure`, **zero jobs dispatched**, and `gh run view --log-failed` reports *log not found*. Latest broken example before this PR: [run 26011951927](https://github.com/gHashTag/t27/actions/runs/26011951927).

Three syntax-level defects combined to make GitHub Actions reject the workflow during parse, and one latent runtime defect surfaced once jobs began dispatching.

1. **`workflow_dispatch:` declared at the top level** instead of nested under `on:`. In YAML, the bare key `on` is parsed as boolean `True`, and a sibling top-level `workflow_dispatch:` is rejected as an unexpected workflow section. All `${{ inputs.* }}` references inside `manual-sync` became undefined.
2. **`extract-issue.outputs.event_type` referenced `steps.event.outputs.type`** while the actual step id is `event_type`.
3. **Duplicate `pull_request_review)` case** in the bash event dispatch (lines 74-78 and 79-84 of the original file).
4. **`peter-evans/create-or-update-file@v3` does not exist** on github.com (`gh api repos/peter-evans/create-or-update-file` → 404). The canonical peter-evans actions are `create-pull-request`, `create-or-update-comment`, `create-issue-from-file`, etc. Replaced with `actions/github-script@v7` using `github.rest.repos.createOrUpdateFileContents` via the REST API; granted `permissions.contents: write` on the `sync-notebook` job (default GITHUB_TOKEN scope was `Contents: read`). The status-file commit targets the repo's **default branch** (resolved via `repos.get`) because `issues` and `pull_request` events do not have a single canonical branch to commit to; the step is wrapped in `continue-on-error` plus an internal `try/catch` so a 403/422 from fork PRs or branch protection logs a warning instead of failing the sync — matching the existing best-effort pattern around the `python sync.py || warnings; exit 0` block immediately above.

## Files changed

- `.github/workflows/notebook-sync.yml` — syntax repair (3 defects) + replacement of the broken `sync-notebook` "Update sync status as commit" step with an `actions/github-script` API call. Added a tight `permissions: contents: write` block on the `sync-notebook` job.
- `docs/NOW.md` — entry added per the NOW Sync Gate.

## Validation

**`actionlint 1.7.12` before fix:**

```
:23:1: unexpected key "workflow_dispatch" for "workflow" section ... [syntax-check]
:47:23: property "event" is not defined in object type {event_type: ...} [expression]
:244:26: property "issue_number" is not defined ... [expression]
:245:26: property "sync_type" is not defined ... [expression]
:266:13: property "sync_type" is not defined ... [expression]
```

**`actionlint 1.7.12` after fix:** all syntax-check and expression errors clear. Only the pre-existing low-severity advisory about `github.event.issue.title` being interpolated into an inline script remains — unrelated to the instant-failure issue and out of scope here.

**Python `yaml.safe_load`:**

```
on triggers: ['issues', 'issue_comment', 'pull_request',
              'pull_request_review', 'push', 'workflow_dispatch']
workflow_dispatch inputs: ['issue_number', 'sync_type']
jobs: ['extract-issue', 'sync-notebook', 'sync-activity', 'manual-sync']
sync-notebook permissions: {'contents': 'write'}
```

**Action existence verified via `gh api`:**

```
$ gh api repos/peter-evans/create-or-update-file
{"message":"Not Found","status":"404"}
```

## Testing

- [x] `actionlint` syntax-check passes.
- [x] `yaml.safe_load` confirms `on:` contains all six triggers and `workflow_dispatch.inputs` is properly nested.
- [x] CI on this PR now schedules all four jobs (`extract-issue`, `sync-notebook`, `sync-activity`, `manual-sync`) instead of failing instantly with empty job list.
- [x] `sync-notebook` job is green on this PR (status-file write resolves the default branch and uses `continue-on-error` + internal try/catch).
- [ ] After merge: verify the "Run workflow" button appears in the Actions UI for `notebook-sync` (proves `workflow_dispatch` is valid), and that a push to any `feature/**` / `fix/**` / `ring-*/**` / `issue-*/**` branch dispatches jobs cleanly.

## L7 UNITY note

YAML/actions-side repair only. No `*.sh` added, no `gen/` edits, no spec changes. RTL/GDS/`verdict.json` gates untouched. TRI-NET docs package from #693 untouched.