### PR TITLE
wave-29: t27c gen-verilog hoist bench integer counter out of initial begin (R-VD-1 fix) (Closes #745)

### DIFF
--- a/bootstrap/src/compiler.rs
+++ b/bootstrap/src/compiler.rs
@@ -3719,6 +3719,12 @@ impl VerilogCodegen {
         }
 
         // Section: Bench → initial blocks with timing
+        //
+        // R-VD-1 (wave-29): variable declarations are NOT allowed inside
+        // procedural blocks in Verilog-2005 (Yosys/iverilog reject
+        // `integer x = 0;` between `initial begin` and `end`). We therefore
+        // hoist each bench's cycle counter to module scope using a unique
+        // sanitized name, and reset/increment it inside the initial block.
         if !benches.is_empty() {
             self.write_indent();
             self.write_line("// -------------------------------------------------------");
@@ -3726,7 +3732,24 @@ impl VerilogCodegen {
             self.write_line("// Benchmark blocks (simulation only)");
             self.write_indent();
             self.write_line("// -------------------------------------------------------");
+            // Module-scope counter declarations (R-VD-1 fix).
+            self.write_indent();
+            self.write_line("// synthesis translate_off");
             for b in &benches {
+                let counter = format!(
+                    "_bench_{}_cycles",
+                    Self::sanitize_identifier(&b.name)
+                );
+                self.write_indent();
+                self.write_line(&format!("integer {} = 0;", counter));
+            }
+            self.write_indent();
+            self.write_line("// synthesis translate_on");
+            for b in &benches {
+                let counter = format!(
+                    "_bench_{}_cycles",
+                    Self::sanitize_identifier(&b.name)
+                );
                 self.write_indent();
                 self.write_line(&format!(
                     "initial begin : {}_bench // synthesis translate_off",
@@ -3736,16 +3759,16 @@ impl VerilogCodegen {
                 self.write_indent();
                 self.write_line(&format!("$display(\"[BENCH] {} : starting\");", b.name));
                 self.write_indent();
-                self.write_line("integer _bench_cycles = 0;");
+                self.write_line(&format!("{} = 0;", counter));
                 for child in &b.children {
                     self.gen_verilog_test_stmt(child, &b.name);
                     self.write_indent();
-                    self.write_line("_bench_cycles = _bench_cycles + 1;");
+                    self.write_line(&format!("{} = {} + 1;", counter, counter));
                 }
                 self.write_indent();
                 self.write_line(&format!(
-                    "$display(\"[BENCH] {} : %%0d cycles\", _bench_cycles);",
-                    b.name
+                    "$display(\"[BENCH] {} : %%0d cycles\", {});",
+                    b.name, counter
                 ));
                 self.write_indent();
                 self.write_line(&format!("$display(\"[BENCH] {} : DONE\");", b.name));

--- a/bootstrap/tests/verilog_initial_decl.rs
+++ b/bootstrap/tests/verilog_initial_decl.rs
@@ -1,0 +1,224 @@
+// =============================================================================
+// Wave 29 -- R-VD-1 compliance test for the gen-verilog bench emitter.
+//
+// `gen_verilog_module` used to emit
+//
+//     initial begin : NAME_bench
+//         $display("[BENCH] NAME : starting");
+//         integer _bench_cycles = 0;      // <-- R-VD-1 violation
+//         ...
+//     end
+//
+// Verilog-2005 forbids variable declarations inside procedural blocks
+// (Yosys/iverilog reject this with `syntax error, unexpected TOK_INITIAL`).
+// Wave 29 patches the bench-section emitter to hoist a uniquely-named
+// `integer _bench_<name>_cycles = 0;` to module scope and only assign/use
+// the counter inside the `initial begin ... end` block.
+//
+// This integration test shells out to the built `t27c` binary, feeds it a
+// spec that contains a `bench` block, and asserts the emitted Verilog
+// (a) contains no `integer ... ;` declaration inside any
+// `initial begin ... end` block; and (b) contains a module-scope
+// `integer _bench_<name>_cycles = 0;` line for each bench.
+//
+// We also run a regression check against the real `specs/fpga/uart.t27`
+// spec, which is where the bug was first observed in CI on PR #744.
+//
+// phi^2 + 1/phi^2 = 3 | TRINITY
+// Closes #745
+// =============================================================================
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Minimal spec exercising the bench-block emitter path.
+const SPEC: &str = r#"module RVD1Probe {
+    bench probe_latency_a
+        measure: nanoseconds to probe_a()
+        target: < 10ns
+
+    bench probe_latency_b
+        measure: nanoseconds to probe_b()
+        target: < 20ns
+}
+"#;
+
+fn compile_spec(spec_text: &str, file_stem: &str) -> Option<String> {
+    let bin = env!("CARGO_BIN_EXE_t27c");
+    let tmp_dir = std::env::temp_dir();
+    let spec_path = tmp_dir.join(format!("{}.t27", file_stem));
+    {
+        let mut f = std::fs::File::create(&spec_path).ok()?;
+        f.write_all(spec_text.as_bytes()).ok()?;
+    }
+    let out = Command::new(bin)
+        .args(["gen-verilog", spec_path.to_str()?])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        eprintln!(
+            "t27c gen-verilog exited with status {:?}\nstderr: {}",
+            out.status.code(),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        return None;
+    }
+    Some(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+/// Return true if the source contains an `integer <name> ... ;` line
+/// somewhere between an `initial begin` and its matching `end`. We use a
+/// brace-free, line-oriented scan rather than a full parser because the
+/// emitted Verilog is line-formatted and the only constructs we care about
+/// are `initial begin`, `end`, and `integer`.
+fn has_integer_decl_inside_initial(src: &str) -> bool {
+    let mut depth: i32 = 0;
+    for line in src.lines() {
+        let trimmed = line.trim_start();
+        // Track entry into an `initial begin` block.
+        if trimmed.starts_with("initial begin") {
+            depth += 1;
+            continue;
+        }
+        // Track exit of any `end` line (we only count `end` when we are
+        // inside an initial block; nested `begin`/`end` pairs are not
+        // expected at the bench emitter level, but we conservatively only
+        // close at the FIRST `end` after a depth increment).
+        if depth > 0 && (trimmed == "end" || trimmed.starts_with("end ") || trimmed.starts_with("end//") || trimmed.starts_with("end /*")) {
+            depth -= 1;
+            continue;
+        }
+        if depth > 0 && trimmed.starts_with("integer ") {
+            eprintln!("BAD: integer decl inside initial block: {}", line);
+            return true;
+        }
+    }
+    false
+}
+
+/// Return the set of module-scope `integer ... = 0;` counter declarations
+/// of the form `integer _bench_<name>_cycles = 0;`.
+fn module_scope_bench_counters(src: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut inside_initial = false;
+    for line in src.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("initial begin") {
+            inside_initial = true;
+            continue;
+        }
+        if inside_initial
+            && (trimmed == "end"
+                || trimmed.starts_with("end ")
+                || trimmed.starts_with("end//")
+                || trimmed.starts_with("end /*"))
+        {
+            inside_initial = false;
+            continue;
+        }
+        if inside_initial {
+            continue;
+        }
+        if let Some(rest) = trimmed.strip_prefix("integer ") {
+            if let Some(name_end) = rest.find(|c: char| c.is_whitespace() || c == '=' || c == ';')
+            {
+                let name = &rest[..name_end];
+                if name.starts_with("_bench_") && name.ends_with("_cycles") {
+                    out.push(name.to_string());
+                }
+            }
+        }
+    }
+    out
+}
+
+// -----------------------------------------------------------------------------
+// Test 1: synthetic spec.
+// -----------------------------------------------------------------------------
+
+#[test]
+fn r_vd_1_synthetic_no_integer_decl_inside_initial() {
+    let Some(src) = compile_spec(SPEC, "wave29_r_vd_1_probe") else {
+        panic!("t27c gen-verilog failed on synthetic R-VD-1 probe spec");
+    };
+
+    assert!(
+        !has_integer_decl_inside_initial(&src),
+        "R-VD-1 regression: emitter produced `integer ...;` inside an `initial begin ... end` block.\n\
+         --- emitted Verilog ---\n{}",
+        src
+    );
+
+    let counters = module_scope_bench_counters(&src);
+    assert_eq!(
+        counters.len(),
+        2,
+        "Expected exactly 2 module-scope `_bench_<name>_cycles` counters \
+         (one per bench in synthetic spec), got {:?}.\n\
+         --- emitted Verilog ---\n{}",
+        counters,
+        src
+    );
+    assert!(
+        counters.iter().any(|c| c.contains("probe_latency_a")),
+        "Missing module-scope counter for probe_latency_a in {:?}",
+        counters
+    );
+    assert!(
+        counters.iter().any(|c| c.contains("probe_latency_b")),
+        "Missing module-scope counter for probe_latency_b in {:?}",
+        counters
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Test 2: regression against the real uart.t27 spec (the one that broke CI
+// on PR #744).
+// -----------------------------------------------------------------------------
+
+fn find_repo_root() -> Option<PathBuf> {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut cur: &std::path::Path = &manifest;
+    loop {
+        let candidate = cur.join("specs").join("fpga").join("uart.t27");
+        if candidate.is_file() {
+            return Some(cur.to_path_buf());
+        }
+        cur = cur.parent()?;
+    }
+}
+
+#[test]
+fn r_vd_1_real_uart_spec_no_integer_decl_inside_initial() {
+    let Some(repo) = find_repo_root() else {
+        panic!("Could not locate repo root containing specs/fpga/uart.t27");
+    };
+    let uart_path = repo.join("specs").join("fpga").join("uart.t27");
+    let bin = env!("CARGO_BIN_EXE_t27c");
+    let out = Command::new(bin)
+        .args(["gen-verilog", uart_path.to_str().expect("path utf8")])
+        .output()
+        .expect("t27c gen-verilog on uart.t27 should run");
+    assert!(
+        out.status.success(),
+        "t27c gen-verilog failed on real uart.t27 spec:\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let src = String::from_utf8_lossy(&out.stdout).into_owned();
+
+    assert!(
+        !has_integer_decl_inside_initial(&src),
+        "R-VD-1 regression on real uart.t27: emitter produced \
+         `integer ...;` inside an `initial begin ... end` block."
+    );
+
+    let counters = module_scope_bench_counters(&src);
+    assert!(
+        counters.len() >= 3,
+        "Expected at least 3 module-scope `_bench_<name>_cycles` counters \
+         on real uart.t27 (3 benches), got {} ({:?}).",
+        counters.len(),
+        counters
+    );
+}

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,6 +1,39 @@
 # NOW -- Trinity t27 sync
 
-Last updated: 2026-05-22
+Last updated: 2026-05-23
+
+## wave-29 -- t27c gen-verilog: hoist bench `integer` counter out of `initial begin` (R-VD-1 fix, Closes #745)
+
+- **WHERE** (bootstrap-only, surgical): `bootstrap/src/compiler.rs` -- single edit in the bench section of `VerilogCodegen::gen_verilog`. **Zero edits** under `gen/`, `coq/`, `trios-coq/`, `proofs/`, `specs/`, `conformance/`, `architecture/`, `rings/`, root `Cargo.toml`. Doc-only update to this file. New test file `bootstrap/tests/verilog_initial_decl.rs` (additive).
+- **Why** (R-VD-1): Verilog-2005 forbids variable declarations inside procedural blocks. The previous emitter wrote `integer _bench_cycles = 0;` between `initial begin` and `end`, which Yosys/iverilog reject with `syntax error, unexpected TOK_INITIAL` (observed on `uart.v:213` in the CI log of PR #744). This blocked the `fpga-synthesis` gate from going green even after the Wave 28 R-CA-1 fix unblocked `mac.v`.
+- **What changed:** the bench-section loop now (i) emits a module-scope `// synthesis translate_off` / `// synthesis translate_on` band that contains one `integer _bench_<sanitized_name>_cycles = 0;` declaration per bench BEFORE any `initial begin`, and (ii) inside each `initial begin ... end` block, only assigns/uses that already-declared counter -- never re-declares it. Each counter gets a unique per-bench name to avoid collisions when a module has multiple benches.
+- **Before / after on uart.v line 213**:
+  ```verilog
+  // BEFORE (broken: integer decl inside initial block)
+  initial begin : uart_tx_ready_latency_bench // synthesis translate_off
+      $display("[BENCH] uart_tx_ready_latency : starting");
+      integer _bench_cycles = 0;        // <-- Yosys rejects
+      $display("[BENCH] uart_tx_ready_latency : %%0d cycles", _bench_cycles);
+      $display("[BENCH] uart_tx_ready_latency : DONE");
+  end // synthesis translate_on
+
+  // AFTER (hoisted to module scope, valid Verilog-2005)
+  // synthesis translate_off
+  integer _bench_uart_tx_ready_latency_cycles = 0;
+  integer _bench_uart_rx_ready_latency_cycles = 0;
+  integer _bench_uart_reset_latency_cycles    = 0;
+  // synthesis translate_on
+  initial begin : uart_tx_ready_latency_bench // synthesis translate_off
+      $display("[BENCH] uart_tx_ready_latency : starting");
+      _bench_uart_tx_ready_latency_cycles = 0;
+      $display("[BENCH] uart_tx_ready_latency : %%0d cycles", _bench_uart_tx_ready_latency_cycles);
+      $display("[BENCH] uart_tx_ready_latency : DONE");
+  end // synthesis translate_on
+  ```
+- **New integration tests** (`bootstrap/tests/verilog_initial_decl.rs`, 2 `#[test]`s, both green): shells out to the built `t27c` via `env!("CARGO_BIN_EXE_t27c")`. (i) Synthetic spec with two `bench` blocks -- asserts no `integer ...;` line is ever emitted inside an `initial begin ... end` block, and asserts exactly 2 module-scope `_bench_<name>_cycles` counter declarations are present, one per bench. (ii) Real `specs/fpga/uart.t27` regression -- runs the emitter on the spec that broke CI on PR #744 and asserts the same two properties (>= 3 counters because `uart.t27` has 3 benches).
+- **Local result**: `cargo test -p t27c --release --test verilog_initial_decl` -> **2 passed; 0 failed**. `cargo test -p t27c --release --test verilog_r_si_1` (Wave 27 regression) -> **2 passed; 0 failed**.
+- **Constitution checklist**: L1 `Closes #745` in title + body + commit; L2 edits only in `bootstrap/` + this NOW.md + new `bootstrap/tests/`; L3 ASCII source, English doc-comments; L4 2 new tests, passing; L5 numeric kernel untouched, trinity invariant preserved; L6 zero spec/kernel changes; L7 no new `*.sh`.
+- **Out of scope (explicit, honest)**: (a) `fpga-formal` inherited infra failure (`pip install sby` no matching distribution) is not addressed; (b) `fpga-synthesis-arty` inherited CLI drift (`error: unexpected argument '--board' found`) is not addressed; (c) full lowering of aggregate-literal const initializers (the Wave 28 fix is still a TODO placeholder) is not addressed -- a future wave can land real lowering once an HIR-level refactor is scoped.
 
 ## wave-28 -- t27c gen-verilog const-array aggregate initializer no longer emits unparseable `localparam = /* ... */;` (this PR, Closes #743)
 


### PR DESCRIPTION
## Summary

R-VD-1 fix in t27c VerilogCodegen.

Verilog-2005 forbids variable declarations inside procedural blocks. The previous emitter wrote `integer _bench_cycles = 0;` between `initial begin` and `end`, which Yosys/iverilog reject with **syntax error, unexpected TOK_INITIAL**.

This was observed on `uart.v:213` in the CI log of [PR #744](https://github.com/gHashTag/t27/pull/744): the Wave 28 R-CA-1 fix successfully unblocked `mac.v`, but synthesis then proceeded to `uart.v` and hit this next downstream emitter bug.

## What changed

`bootstrap/src/compiler.rs`, in the bench-section loop of `VerilogCodegen::gen_verilog` (around line 3721):

1. Before any `initial begin`, emit a module-scope `// synthesis translate_off ... translate_on` band containing one `integer _bench_<sanitized_name>_cycles = 0;` declaration per bench.
2. Inside each `initial begin ... end` block, only assign and use the pre-declared counter; never re-declare it. Each counter gets a unique per-bench sanitized name to avoid collisions when a module contains multiple benches.

## Before / after on `uart.v:213`

**Before** (broken: integer decl inside initial block):

    initial begin : uart_tx_ready_latency_bench // synthesis translate_off
        $display("[BENCH] uart_tx_ready_latency : starting");
        integer _bench_cycles = 0;          // <-- Yosys rejects
        $display("[BENCH] uart_tx_ready_latency : %%0d cycles", _bench_cycles);
        $display("[BENCH] uart_tx_ready_latency : DONE");
    end // synthesis translate_on

**After** (hoisted to module scope, valid Verilog-2005):

    // synthesis translate_off
    integer _bench_uart_tx_ready_latency_cycles = 0;
    integer _bench_uart_rx_ready_latency_cycles = 0;
    integer _bench_uart_reset_latency_cycles    = 0;
    // synthesis translate_on
    initial begin : uart_tx_ready_latency_bench // synthesis translate_off
        $display("[BENCH] uart_tx_ready_latency : starting");
        _bench_uart_tx_ready_latency_cycles = 0;
        $display("[BENCH] uart_tx_ready_latency : %%0d cycles", _bench_uart_tx_ready_latency_cycles);
        $display("[BENCH] uart_tx_ready_latency : DONE");
    end // synthesis translate_on

## Tests

Two new `#[test]`s in `bootstrap/tests/verilog_initial_decl.rs`:

1. `r_vd_1_synthetic_no_integer_decl_inside_initial` — synthetic spec with two `bench` blocks. Asserts no `integer ...;` line is emitted inside any `initial begin ... end` block, and asserts exactly 2 module-scope `_bench_<name>_cycles` counter declarations are present.
2. `r_vd_1_real_uart_spec_no_integer_decl_inside_initial` — regression test against the real `specs/fpga/uart.t27` spec (the one that broke CI on PR #744). Same assertions, expects at least 3 counters (3 benches in `uart.t27`).

Local result: **2 passed; 0 failed**. Wave 27 regression test (`verilog_r_si_1`) also still passes: **2 passed; 0 failed**.

## Constitution checklist

- **L1 TRACEABILITY**: Closes #745
- **L2 GENERATION**: edits only under `bootstrap/`, `docs/NOW.md`, new `bootstrap/tests/`
- **L3 ASCII**: ASCII source, English doc-comments
- **L4 TESTS**: 2 new `#[test]`s, passing locally
- **L5 TRINITY**: numeric kernel untouched; trinity invariant preserved
- **L6 SPEC/KERNEL**: zero changes under `specs/`, `coq/`, `trios-coq/`, `proofs/`, `conformance/`, `architecture/`, `rings/`, `gen/`
- **L7 NO BASH**: no new `*.sh` files

## Out of scope (explicit, honest)

- **fpga-formal** inherited infrastructure failure: `pip install sby` no matching distribution.
- **fpga-synthesis-arty** inherited CLI drift: `error: unexpected argument '--board' found`.
- **Real lowering of aggregate-literal const initializers** (the Wave 28 fix is still a TODO placeholder). Needs an HIR-level refactor; deferred to a future wave.
- **Subsequent downstream emitter bugs** that may surface in `fpga-synthesis` once `uart.v` parses (we cannot predict them without seeing the next CI log). Each such bug will get its own wave.

Closes #745