### PR TITLE
wave-30: t27c gen-verilog emit standalone synthesis translate_off and translate_on for bench blocks (R-TR-1 fix) (Closes #747)

### DIFF
--- a/bootstrap/src/compiler.rs
+++ b/bootstrap/src/compiler.rs
@@ -3750,9 +3750,18 @@ impl VerilogCodegen {
                     "_bench_{}_cycles",
                     Self::sanitize_identifier(&b.name)
                 );
+                // R-TR-1 (wave-30): emit `// synthesis translate_off` and
+                // `// synthesis translate_on` on STANDALONE comment lines
+                // wrapping the full `initial begin ... end` block. Inline
+                // placement (on the same line as `initial begin :NAME` or
+                // `end`) causes Yosys to consume the matching `end` inside
+                // the skipped region and emit `unexpected TOK_INITIAL` at
+                // the next initial block.
+                self.write_indent();
+                self.write_line("// synthesis translate_off");
                 self.write_indent();
                 self.write_line(&format!(
-                    "initial begin : {}_bench // synthesis translate_off",
+                    "initial begin : {}_bench",
                     Self::sanitize_identifier(&b.name)
                 ));
                 self.indent();
@@ -3774,7 +3783,9 @@ impl VerilogCodegen {
                 self.write_line(&format!("$display(\"[BENCH] {} : DONE\");", b.name));
                 self.dedent();
                 self.write_indent();
-                self.write_line("end // synthesis translate_on");
+                self.write_line("end");
+                self.write_indent();
+                self.write_line("// synthesis translate_on");
             }
             self.write_line("");
         }

--- a/bootstrap/tests/verilog_translate_off.rs
+++ b/bootstrap/tests/verilog_translate_off.rs
@@ -1,0 +1,210 @@
+// =============================================================================
+// Wave 30 -- R-TR-1 compliance test for the gen-verilog bench emitter.
+//
+// `gen_verilog` used to emit `initial begin :NAME // synthesis translate_off`
+// and `end // synthesis translate_on` with the translate_off / translate_on
+// markers INLINE on the same line as the `initial begin` and `end`
+// keywords. Yosys treats `translate_off` as a line-range skip directive:
+// when the skip starts on the same line as `initial begin :NAME`, the
+// matching `end` keyword is consumed inside the skipped region. The
+// parser is left mid-`initial begin`, hits the next `initial begin`,
+// and emits:
+//
+//     ERROR: syntax error, unexpected TOK_INITIAL
+//
+// Wave 30 patches the bench-section emitter to write
+// `// synthesis translate_off` and `// synthesis translate_on` as
+// STANDALONE comment lines wrapping the full `initial begin ... end`
+// block. This guarantees the entire block is uniformly inside the
+// skip region OR uniformly outside, never split.
+//
+// This integration test shells out to the built `t27c` binary, feeds it a
+// spec that contains a `bench` block, and asserts the emitted Verilog
+// (a) never places `translate_off` or `translate_on` on the same line as
+// `initial begin` or `end`; (b) emits at least one standalone
+// `// synthesis translate_off` line and one standalone
+// `// synthesis translate_on` line per bench.
+//
+// We also run a regression check against the real `specs/fpga/uart.t27`
+// spec, which is where the bug was first observed in CI on PR #746.
+//
+// phi^2 + 1/phi^2 = 3 | TRINITY
+// Closes #747
+// =============================================================================
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Minimal spec exercising the bench-block emitter path.
+const SPEC: &str = r#"module RTR1Probe {
+    bench probe_latency_a
+        measure: nanoseconds to probe_a()
+        target: < 10ns
+
+    bench probe_latency_b
+        measure: nanoseconds to probe_b()
+        target: < 20ns
+}
+"#;
+
+fn compile_spec(spec_text: &str, file_stem: &str) -> Option<String> {
+    let bin = env!("CARGO_BIN_EXE_t27c");
+    let tmp_dir = std::env::temp_dir();
+    let spec_path = tmp_dir.join(format!("{}.t27", file_stem));
+    {
+        let mut f = std::fs::File::create(&spec_path).ok()?;
+        f.write_all(spec_text.as_bytes()).ok()?;
+    }
+    let out = Command::new(bin)
+        .args(["gen-verilog", spec_path.to_str()?])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        eprintln!(
+            "t27c gen-verilog exited with status {:?}\nstderr: {}",
+            out.status.code(),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        return None;
+    }
+    Some(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+/// Return true if any line that begins with `initial begin` or `end`
+/// (i.e. starts a Verilog initial-block boundary) contains a
+/// `translate_off` or `translate_on` marker as an inline trailing
+/// comment. Both are R-TR-1 violations: they cause Yosys to split the
+/// initial-block tokens across a skip boundary.
+fn has_inline_translate_marker(src: &str) -> Option<String> {
+    for (idx, line) in src.lines().enumerate() {
+        let trimmed = line.trim_start();
+        let starts_initial = trimmed.starts_with("initial begin");
+        // Look for `end` as a statement boundary: an `end` keyword followed
+        // by whitespace, end-of-line, or a comment. We deliberately do NOT
+        // match `endmodule`, `endfunction`, `endtask`, `endcase`, etc.
+        let starts_end = trimmed == "end"
+            || trimmed.starts_with("end ")
+            || trimmed.starts_with("end//")
+            || trimmed.starts_with("end /*");
+        if !(starts_initial || starts_end) {
+            continue;
+        }
+        if line.contains("translate_off") || line.contains("translate_on") {
+            return Some(format!(
+                "line {}: inline translate marker on initial/end boundary: {}",
+                idx + 1,
+                line
+            ));
+        }
+    }
+    None
+}
+
+/// Count standalone `// synthesis translate_off` lines (i.e. the line,
+/// after trimming, equals exactly `// synthesis translate_off`).
+fn count_standalone_translate_off(src: &str) -> usize {
+    src.lines()
+        .filter(|l| l.trim() == "// synthesis translate_off")
+        .count()
+}
+
+fn count_standalone_translate_on(src: &str) -> usize {
+    src.lines()
+        .filter(|l| l.trim() == "// synthesis translate_on")
+        .count()
+}
+
+// -----------------------------------------------------------------------------
+// Test 1: synthetic spec.
+// -----------------------------------------------------------------------------
+
+#[test]
+fn r_tr_1_synthetic_no_inline_translate_marker() {
+    let Some(src) = compile_spec(SPEC, "wave30_r_tr_1_probe") else {
+        panic!("t27c gen-verilog failed on synthetic R-TR-1 probe spec");
+    };
+
+    if let Some(viol) = has_inline_translate_marker(&src) {
+        panic!(
+            "R-TR-1 regression: {}\n--- emitted Verilog ---\n{}",
+            viol, src
+        );
+    }
+
+    // Each of the 2 benches in the synthetic spec must be wrapped in its
+    // own standalone translate_off / translate_on pair. We also have one
+    // pair around the module-scope `integer` counter declarations from
+    // Wave 29, so we expect AT LEAST 3 of each marker (1 counter band +
+    // 1 per bench).
+    let off_count = count_standalone_translate_off(&src);
+    let on_count = count_standalone_translate_on(&src);
+    assert!(
+        off_count >= 3,
+        "Expected >= 3 standalone `// synthesis translate_off` lines, got {}.\n\
+         --- emitted Verilog ---\n{}",
+        off_count,
+        src
+    );
+    assert!(
+        on_count >= 3,
+        "Expected >= 3 standalone `// synthesis translate_on` lines, got {}.\n\
+         --- emitted Verilog ---\n{}",
+        on_count,
+        src
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Test 2: regression against the real uart.t27 spec.
+// -----------------------------------------------------------------------------
+
+fn find_repo_root() -> Option<PathBuf> {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut cur: &std::path::Path = &manifest;
+    loop {
+        let candidate = cur.join("specs").join("fpga").join("uart.t27");
+        if candidate.is_file() {
+            return Some(cur.to_path_buf());
+        }
+        cur = cur.parent()?;
+    }
+}
+
+#[test]
+fn r_tr_1_real_uart_spec_no_inline_translate_marker() {
+    let Some(repo) = find_repo_root() else {
+        panic!("Could not locate repo root containing specs/fpga/uart.t27");
+    };
+    let uart_path = repo.join("specs").join("fpga").join("uart.t27");
+    let bin = env!("CARGO_BIN_EXE_t27c");
+    let out = Command::new(bin)
+        .args(["gen-verilog", uart_path.to_str().expect("path utf8")])
+        .output()
+        .expect("t27c gen-verilog on uart.t27 should run");
+    assert!(
+        out.status.success(),
+        "t27c gen-verilog failed on real uart.t27 spec:\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let src = String::from_utf8_lossy(&out.stdout).into_owned();
+
+    if let Some(viol) = has_inline_translate_marker(&src) {
+        panic!("R-TR-1 regression on real uart.t27: {}", viol);
+    }
+
+    // uart.t27 has 3 benches; with the Wave 29 counter band we expect
+    // >= 4 standalone translate_off and >= 4 standalone translate_on.
+    let off_count = count_standalone_translate_off(&src);
+    let on_count = count_standalone_translate_on(&src);
+    assert!(
+        off_count >= 4,
+        "Expected >= 4 standalone translate_off on real uart.t27, got {}",
+        off_count
+    );
+    assert!(
+        on_count >= 4,
+        "Expected >= 4 standalone translate_on on real uart.t27, got {}",
+        on_count
+    );
+}

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,34 @@
 
 Last updated: 2026-05-23
 
+## wave-30 -- t27c gen-verilog: emit standalone `// synthesis translate_off` and `translate_on` (R-TR-1 fix, Closes #747)
+
+- **WHERE** (bootstrap-only, surgical): `bootstrap/src/compiler.rs` -- single hunk in the bench-section loop of `VerilogCodegen::gen_verilog` (around line 3748). **Zero edits** under `gen/`, `coq/`, `trios-coq/`, `proofs/`, `specs/`, `conformance/`, `architecture/`, `rings/`, root `Cargo.toml`. Doc-only update to this file. New test file `bootstrap/tests/verilog_translate_off.rs` (additive).
+- **Why** (R-TR-1): after Wave 28 (R-CA-1) and Wave 29 (R-VD-1) landed on master, `fpga-synthesis` CI advanced further but still failed on `uart.v:218` with `syntax error, unexpected TOK_INITIAL`. Root cause: the bench-block emitter placed `// synthesis translate_off` and `// synthesis translate_on` **inline** on the same line as `initial begin :NAME` and `end`. Yosys treats `translate_off` as a line-range skip directive: when the skip starts on the same line as `initial begin :NAME`, the matching `end` keyword is consumed inside the skipped region. The parser is left mid-`initial begin`, hits the next `initial begin`, and emits `unexpected TOK_INITIAL`.
+- **What changed**: the bench-section loop now writes the translate markers as **standalone comment lines** wrapping the full `initial begin ... end` block, never inline. The pre-existing module-scope `// synthesis translate_off ... translate_on` band around the Wave 29 counter declarations is unchanged (it was already on its own lines).
+- **Before / after on the bench block**:
+  ```verilog
+  // BEFORE (broken: inline translate markers split initial-block tokens)
+  initial begin : uart_tx_ready_latency_bench // synthesis translate_off
+      $display("[BENCH] uart_tx_ready_latency : starting");
+      _bench_uart_tx_ready_latency_cycles = 0;
+      ...
+  end // synthesis translate_on
+
+  // AFTER (standalone translate markers wrapping the full block)
+  // synthesis translate_off
+  initial begin : uart_tx_ready_latency_bench
+      $display("[BENCH] uart_tx_ready_latency : starting");
+      _bench_uart_tx_ready_latency_cycles = 0;
+      ...
+  end
+  // synthesis translate_on
+  ```
+- **New integration tests** (`bootstrap/tests/verilog_translate_off.rs`, 2 `#[test]`s, both green): shells out to the built `t27c` via `env!("CARGO_BIN_EXE_t27c")`. (i) Synthetic spec with two `bench` blocks -- asserts no line that starts with `initial begin` or `end` carries a trailing `translate_off`/`translate_on` marker, AND asserts at least 3 standalone `// synthesis translate_off` and 3 standalone `// synthesis translate_on` lines (one band around the Wave 29 counter declarations + one wrapper per bench). (ii) Real `specs/fpga/uart.t27` regression (the spec that blocked CI in PR #746) -- same assertions, expects >= 4 of each marker because `uart.t27` has 3 benches.
+- **Local result**: `cargo test -p t27c --release --test verilog_translate_off` -> **2 passed; 0 failed**. Cross-wave regression: Wave 27 (`verilog_r_si_1`), Wave 28 (`verilog_const_array`), Wave 29 (`verilog_initial_decl`) all still **2 passed; 0 failed**.
+- **Constitution checklist**: L1 `Closes #747` in title + body + commit; L2 edits only in `bootstrap/` + this NOW.md + new `bootstrap/tests/`; L3 ASCII source, English doc-comments; L4 2 new tests, passing; L5 numeric kernel untouched, trinity invariant preserved; L6 zero spec/kernel changes; L7 no new `*.sh`.
+- **Out of scope (explicit, honest)**: (a) `fpga-formal` inherited infra failure (`pip install sby` no matching distribution) is not addressed; (b) `fpga-synthesis-arty` inherited CLI drift (`error: unexpected argument '--board' found`) is not addressed; (c) any further downstream emitter bugs that may surface in `fpga-synthesis` once `uart.v` parses cleanly past line 218 will get their own wave.
+
 ## wave-29 -- t27c gen-verilog: hoist bench `integer` counter out of `initial begin` (R-VD-1 fix, Closes #745)
 
 - **WHERE** (bootstrap-only, surgical): `bootstrap/src/compiler.rs` -- single edit in the bench section of `VerilogCodegen::gen_verilog`. **Zero edits** under `gen/`, `coq/`, `trios-coq/`, `proofs/`, `specs/`, `conformance/`, `architecture/`, `rings/`, root `Cargo.toml`. Doc-only update to this file. New test file `bootstrap/tests/verilog_initial_decl.rs` (additive).


### PR DESCRIPTION
## Summary

R-TR-1 fix in t27c VerilogCodegen.

After Wave 28 (R-CA-1, [#743](https://github.com/gHashTag/t27/issues/743)) and Wave 29 (R-VD-1, [#745](https://github.com/gHashTag/t27/issues/745)) landed on master, `fpga-synthesis` CI advanced further (24+ `.v` files OK including `mac.v`) but still failed on `uart.v:218` with **syntax error, unexpected TOK_INITIAL**.

Root cause: the bench-block emitter placed `// synthesis translate_off` and `// synthesis translate_on` **inline** on the same line as `initial begin :NAME` and `end`. Yosys treats `translate_off` as a line-range skip directive: when the skip starts on the same line as `initial begin :NAME`, the matching `end` keyword is consumed inside the skipped region. The parser is left mid-`initial begin`, hits the next `initial begin`, and emits `unexpected TOK_INITIAL`.

## What changed

`bootstrap/src/compiler.rs`, in the bench-section loop of `VerilogCodegen::gen_verilog` (around line 3748): emit `// synthesis translate_off` and `// synthesis translate_on` as **standalone comment lines** wrapping the full `initial begin ... end` block, never inline. The entire block is now uniformly inside the skip region or uniformly outside — never split.

## Before / after

**Before** (broken: inline translate markers split initial-block tokens):

    initial begin : uart_tx_ready_latency_bench // synthesis translate_off
        $display("[BENCH] uart_tx_ready_latency : starting");
        _bench_uart_tx_ready_latency_cycles = 0;
        ...
    end // synthesis translate_on

**After** (standalone translate markers wrapping the full block):

    // synthesis translate_off
    initial begin : uart_tx_ready_latency_bench
        $display("[BENCH] uart_tx_ready_latency : starting");
        _bench_uart_tx_ready_latency_cycles = 0;
        ...
    end
    // synthesis translate_on

## Tests

Two new `#[test]`s in `bootstrap/tests/verilog_translate_off.rs`:

1. `r_tr_1_synthetic_no_inline_translate_marker` — synthetic spec with two `bench` blocks. Asserts no line that starts with `initial begin` or `end` carries a trailing `translate_off`/`translate_on` marker, AND asserts at least 3 standalone `// synthesis translate_off` and 3 standalone `// synthesis translate_on` lines.
2. `r_tr_1_real_uart_spec_no_inline_translate_marker` — regression test against the real `specs/fpga/uart.t27` spec (the one that blocked CI on PR #746). Same assertions, expects at least 4 of each marker (uart.t27 has 3 benches plus the Wave 29 counter band).

Local result: **2 passed; 0 failed**. Cross-wave regression: Wave 27, Wave 28, Wave 29 tests all still **2 passed; 0 failed**.

## Constitution checklist

- **L1 TRACEABILITY**: Closes #747
- **L2 GENERATION**: edits only under `bootstrap/`, `docs/NOW.md`, new `bootstrap/tests/`
- **L3 ASCII**: ASCII source, English doc-comments
- **L4 TESTS**: 2 new `#[test]`s, passing locally
- **L5 TRINITY**: numeric kernel untouched; trinity invariant preserved
- **L6 SPEC/KERNEL**: zero changes under `specs/`, `coq/`, `trios-coq/`, `proofs/`, `conformance/`, `architecture/`, `rings/`, `gen/`
- **L7 NO BASH**: no new `*.sh` files

## Out of scope (explicit, honest)

- **fpga-formal** inherited infrastructure failure: `pip install sby` no matching distribution.
- **fpga-synthesis-arty** inherited CLI drift: `error: unexpected argument '--board' found`.
- **Subsequent downstream emitter bugs** that may surface in `fpga-synthesis` once `uart.v` parses cleanly past line 218 will get their own wave.

Closes #747