### PR TITLE
wave-31: t27c gen-verilog ExprArrayLiteral in expression context emits parseable placeholder (R-CA-2 fix) (Closes #749)

### DIFF
--- a/bootstrap/src/compiler.rs
+++ b/bootstrap/src/compiler.rs
@@ -4469,16 +4469,19 @@ impl VerilogCodegen {
                 }
             }
             NodeKind::ExprArrayLiteral => {
+                // R-CA-2 (wave-31): array literals in expression context
+                // (e.g. as function-call arguments) used to emit a
+                // comment-only token `/* array [...]{} */`, which Yosys
+                // rejects with `syntax error, unexpected ','` when the
+                // argument list reduces to whitespace + comma. We follow
+                // the precedent established by `ExprStructLit` below and
+                // emit a synthesizable scalar `0` plus an explanatory
+                // TODO comment, so the surrounding expression remains
+                // parseable Verilog.
                 self.write(&format!(
-                    "/* array [{}]{}{{",
+                    "0 /* TODO: array literal [{}]{} not yet lowered to Verilog */",
                     node.extra_size, node.extra_type
                 ));
-                for elem in &node.children {
-                    self.write(" ");
-                    self.gen_verilog_expr(elem);
-                    self.write(",");
-                }
-                self.write("} */");
             }
             NodeKind::ExprStructLit => {
                 // Verilog has no struct literals — emit as comment + value 0

--- a/bootstrap/tests/verilog_array_literal_expr.rs
+++ b/bootstrap/tests/verilog_array_literal_expr.rs
@@ -1,0 +1,211 @@
+// =============================================================================
+// Wave 31 -- R-CA-2 compliance test for the gen-verilog ExprArrayLiteral
+// emitter in expression context.
+//
+// `gen_verilog_expr` for `NodeKind::ExprArrayLiteral` used to write a
+// comment-only token of the form `/* array [...]{} */`. When such an
+// array literal appeared as a function-call argument, the entire
+// argument reduced to whitespace plus the `,` separator, and Yosys
+// rejected the call with `syntax error, unexpected ','`. The bug was
+// first observed in CI on PR #748 at `bridge.v:166`:
+//
+//     mac_dot_product(/* array [operand_a]{} */, /* array [operand_b]{} */, 1, unit_byte);
+//
+// Wave 31 patches the emitter to follow the precedent established by
+// `ExprStructLit` and emit a synthesizable scalar `0` plus an
+// explanatory TODO comment, so the surrounding expression remains
+// parseable Verilog:
+//
+//     mac_dot_product(0 /* TODO: array literal [operand_a] not yet lowered to Verilog */,
+//                     0 /* TODO: array literal [operand_b] not yet lowered to Verilog */,
+//                     1, unit_byte);
+//
+// We assert:
+//   (a) the emitted Verilog never contains a comment-only function-call
+//       argument of the form `(/* ... */,` or `,/* ... */,` or
+//       `,/* ... */)`;
+//   (b) at least one `0 /* TODO: array literal ... */` placeholder is
+//       present in the regression spec (i.e. the new emit path is
+//       actually exercised, not just dead-code-removed).
+//
+// We also run a regression check against the real `specs/fpga/bridge.t27`
+// spec, which is where the bug was first observed in CI.
+//
+// phi^2 + 1/phi^2 = 3 | TRINITY
+// Closes #749
+// =============================================================================
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Minimal spec exercising the ExprArrayLiteral path in expression
+/// context (passing an array literal as a function argument).
+const SPEC: &str = r#"module RCA2Probe {
+    fn consume(values: [4]u32) {
+        return
+    }
+
+    fn driver() {
+        consume([1, 2, 3, 4])
+        return
+    }
+}
+"#;
+
+fn compile_spec(spec_text: &str, file_stem: &str) -> Option<String> {
+    let bin = env!("CARGO_BIN_EXE_t27c");
+    let tmp_dir = std::env::temp_dir();
+    let spec_path = tmp_dir.join(format!("{}.t27", file_stem));
+    {
+        let mut f = std::fs::File::create(&spec_path).ok()?;
+        f.write_all(spec_text.as_bytes()).ok()?;
+    }
+    let out = Command::new(bin)
+        .args(["gen-verilog", spec_path.to_str()?])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        eprintln!(
+            "t27c gen-verilog exited with status {:?}\nstderr: {}",
+            out.status.code(),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        return None;
+    }
+    Some(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+/// Strip Verilog block comments `/* ... */` (single-line only -- the
+/// emitter never produces multi-line block comments). Used to detect
+/// when, after comment removal, a function-call argument reduces to
+/// empty whitespace.
+fn strip_block_comments(line: &str) -> String {
+    let mut out = String::with_capacity(line.len());
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if i + 1 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'*' {
+            // Skip until matching `*/` on the same line.
+            let mut j = i + 2;
+            while j + 1 < bytes.len() && !(bytes[j] == b'*' && bytes[j + 1] == b'/') {
+                j += 1;
+            }
+            i = j.saturating_add(2);
+        } else {
+            out.push(bytes[i] as char);
+            i += 1;
+        }
+    }
+    out
+}
+
+/// Detect the R-CA-2 violation pattern: a function-call argument that,
+/// after stripping block comments, reduces to empty / whitespace. We
+/// scan lines and look for `(<arg>,`, `,<arg>,`, or `,<arg>)` where
+/// `<arg>` is empty after stripping comments.
+fn has_comment_only_call_argument(src: &str) -> Option<String> {
+    for (idx, line) in src.lines().enumerate() {
+        let bare = strip_block_comments(line);
+        // Look for `(` or `,` followed by only whitespace before the next `,` or `)`.
+        // This is a deliberately conservative check that catches the
+        // specific bug shape without trying to fully parse Verilog.
+        let chars: Vec<char> = bare.chars().collect();
+        let mut i = 0;
+        while i < chars.len() {
+            let c = chars[i];
+            if c == '(' || c == ',' {
+                // Skip whitespace and look for next non-space.
+                let mut j = i + 1;
+                while j < chars.len() && chars[j].is_whitespace() {
+                    j += 1;
+                }
+                if j < chars.len() && (chars[j] == ',' || chars[j] == ')') {
+                    // Empty argument between `c` and `chars[j]`.
+                    // Allow truly empty `()` (no-arg call): only flag when
+                    // c == ',' (so there is at least one prior argument
+                    // separator) OR when c == '(' and chars[j] == ',' (so
+                    // there IS a next argument after the empty one).
+                    if c == ',' || chars[j] == ',' {
+                        return Some(format!(
+                            "line {}: comment-only call argument: {}",
+                            idx + 1,
+                            line
+                        ));
+                    }
+                }
+            }
+            i += 1;
+        }
+    }
+    None
+}
+
+// -----------------------------------------------------------------------------
+// Test 1: synthetic spec.
+// -----------------------------------------------------------------------------
+
+#[test]
+fn r_ca_2_synthetic_no_comment_only_call_argument() {
+    let Some(src) = compile_spec(SPEC, "wave31_r_ca_2_probe") else {
+        panic!("t27c gen-verilog failed on synthetic R-CA-2 probe spec");
+    };
+
+    if let Some(viol) = has_comment_only_call_argument(&src) {
+        panic!(
+            "R-CA-2 regression: {}\n--- emitted Verilog ---\n{}",
+            viol, src
+        );
+    }
+
+    // Positive check: the placeholder TODO marker should appear at least
+    // once in the synthetic spec emission. This guarantees the new emit
+    // path is actually exercised.
+    assert!(
+        src.contains("TODO: array literal"),
+        "Expected the new `0 /* TODO: array literal ... */` placeholder \
+         in the synthetic spec emission, but none was found.\n\
+         --- emitted Verilog ---\n{}",
+        src
+    );
+}
+
+// -----------------------------------------------------------------------------
+// Test 2: regression against the real bridge.t27 spec (the one that broke
+// CI on PR #748).
+// -----------------------------------------------------------------------------
+
+fn find_repo_root() -> Option<PathBuf> {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut cur: &std::path::Path = &manifest;
+    loop {
+        let candidate = cur.join("specs").join("fpga").join("bridge.t27");
+        if candidate.is_file() {
+            return Some(cur.to_path_buf());
+        }
+        cur = cur.parent()?;
+    }
+}
+
+#[test]
+fn r_ca_2_real_bridge_spec_no_comment_only_call_argument() {
+    let Some(repo) = find_repo_root() else {
+        panic!("Could not locate repo root containing specs/fpga/bridge.t27");
+    };
+    let bridge_path = repo.join("specs").join("fpga").join("bridge.t27");
+    let bin = env!("CARGO_BIN_EXE_t27c");
+    let out = Command::new(bin)
+        .args(["gen-verilog", bridge_path.to_str().expect("path utf8")])
+        .output()
+        .expect("t27c gen-verilog on bridge.t27 should run");
+    assert!(
+        out.status.success(),
+        "t27c gen-verilog failed on real bridge.t27 spec:\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let src = String::from_utf8_lossy(&out.stdout).into_owned();
+
+    if let Some(viol) = has_comment_only_call_argument(&src) {
+        panic!("R-CA-2 regression on real bridge.t27: {}", viol);
+    }
+}

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,24 @@
 
 Last updated: 2026-05-23
 
+## wave-31 -- t27c gen-verilog: ExprArrayLiteral in expression context emits parseable placeholder (R-CA-2 fix, Closes #749)
+
+- **WHERE** (bootstrap-only, surgical): `bootstrap/src/compiler.rs` -- single hunk in `VerilogCodegen::gen_verilog_expr` for `NodeKind::ExprArrayLiteral` (around line 4471). **Zero edits** under `gen/`, `coq/`, `trios-coq/`, `proofs/`, `specs/`, `conformance/`, `architecture/`, `rings/`, root `Cargo.toml`. Doc-only update to this file. New test file `bootstrap/tests/verilog_array_literal_expr.rs` (additive).
+- **Why** (R-CA-2): after Wave 30 (R-TR-1) landed on master, `fpga-synthesis` CI advanced further but still failed on `bridge.v:166` with `syntax error, unexpected ','`. Root cause: `gen_verilog_expr` for `ExprArrayLiteral` emitted a **comment-only token** of the form `/* array [...]{} */`. When such a literal appears as a function-call argument (e.g. `mac_dot_product(/* array [operand_a]{} */, /* array [operand_b]{} */, 1, unit_byte)`), Yosys strips the comments leaving `mac_dot_product(, , 1, unit_byte)` -- the bare commas trigger the parse error. Sibling of Wave 28's R-CA-1 fix, which addressed the same bug class in `gen_verilog_const` (declaration position); R-CA-2 addresses the **expression position** code path.
+- **What changed**: `ExprArrayLiteral` now writes a parseable placeholder `0 /* TODO: array literal [<size>]<type> not yet lowered to Verilog */`. The leading `0` makes the expression a valid Verilog integer literal that can stand in any expression context (call argument, RHS of assignment, operand of arithmetic, etc.); the trailing block comment preserves the original metadata for future lowering work. No semantic regression: array-literal lowering was already a stub.
+- **Before / after on bridge.v:166**:
+  ```verilog
+  // BEFORE (broken: comment-only call arguments collapse to bare commas)
+  mac_dot_product(/* array [operand_a]{} */, /* array [operand_b]{} */, 1, unit_byte);
+
+  // AFTER (valid Verilog: each argument is a literal integer with a trailing TODO comment)
+  mac_dot_product(0 /* TODO: array literal [operand_a] not yet lowered to Verilog */, 0 /* TODO: array literal [operand_b] not yet lowered to Verilog */, 1, unit_byte);
+  ```
+- **New integration tests** (`bootstrap/tests/verilog_array_literal_expr.rs`, 2 `#[test]`s, both green): shells out to the built `t27c` via `env!("CARGO_BIN_EXE_t27c")` and asserts that, after stripping all `/* ... */` block comments from the emitted Verilog, no function-call argument list contains an empty slot (no `(,`, `,,`, `,)`, or `()` where a non-empty argument list is expected). (i) Synthetic spec with a `consume([1,2,3,4])` call. (ii) Real `specs/fpga/bridge.t27` regression (the spec that blocked CI after PR #748).
+- **Local result**: `cargo test -p t27c --release --test verilog_array_literal_expr` -> **2 passed; 0 failed**. Cross-wave regression: Wave 27 (`verilog_r_si_1`), Wave 28 (`verilog_const_array`), Wave 29 (`verilog_initial_decl`), Wave 30 (`verilog_translate_off`) all still **2 passed; 0 failed** = **10/10 across W27-W31**.
+- **Constitution checklist**: L1 `Closes #749` in title + body + commit; L2 edits only in `bootstrap/` + this NOW.md + new `bootstrap/tests/`; L3 ASCII source, English doc-comments; L4 2 new tests, passing; L5 numeric kernel untouched, trinity invariant preserved; L6 zero spec/kernel changes; L7 no new `*.sh`.
+- **Out of scope (explicit, honest)**: (a) `fpga-formal` inherited infra failure (`pip install sby` no matching distribution) is not addressed; (b) `fpga-synthesis-arty` inherited CLI drift (`error: unexpected argument '--board' found`) is not addressed; (c) bare `as;` / `u8;` statements visible at bridge.v:170-178 (from `as`-cast emitter lowering a cast to two bare statements) are a separate bug class and will be a future wave; (d) any further downstream emitter bugs that may surface once `bridge.v` parses cleanly past line 166 will get their own wave.
+
 ## wave-30 -- t27c gen-verilog: emit standalone `// synthesis translate_off` and `translate_on` (R-TR-1 fix, Closes #747)
 
 - **WHERE** (bootstrap-only, surgical): `bootstrap/src/compiler.rs` -- single hunk in the bench-section loop of `VerilogCodegen::gen_verilog` (around line 3748). **Zero edits** under `gen/`, `coq/`, `trios-coq/`, `proofs/`, `specs/`, `conformance/`, `architecture/`, `rings/`, root `Cargo.toml`. Doc-only update to this file. New test file `bootstrap/tests/verilog_translate_off.rs` (additive).


### PR DESCRIPTION
## Wave 31 -- R-CA-2 fix (Closes #749)

**Sibling of R-CA-1 (Wave 28).** After Wave 30 (R-TR-1) merged, the `fpga-synthesis` CI advanced further on `bridge.v` but still failed at `bridge.v:166` with `syntax error, unexpected ','`.

### Root cause
In `VerilogCodegen::gen_verilog_expr`, the `NodeKind::ExprArrayLiteral` arm emitted a **comment-only token** `/* array [...]{} */`. When such a literal appears as a function-call argument, Yosys strips the comments and is left with bare commas:

```verilog
// BEFORE (broken)
mac_dot_product(/* array [operand_a]{} */, /* array [operand_b]{} */, 1, unit_byte);
// Yosys sees: mac_dot_product(, , 1, unit_byte);  -- unexpected ','
```

Wave 28 (R-CA-1) addressed the same bug class in `gen_verilog_const` (declaration position). Wave 31 addresses the **expression-position** code path.

### Fix
Emit a parseable placeholder `0 /* TODO: array literal [<size>]<type> not yet lowered to Verilog */`. The leading literal `0` is a valid Verilog integer expression that can stand in any expression context.

```verilog
// AFTER (valid Verilog)
mac_dot_product(0 /* TODO: array literal [operand_a] not yet lowered to Verilog */, 0 /* TODO: array literal [operand_b] not yet lowered to Verilog */, 1, unit_byte);
```

No semantic regression: array-literal lowering was already a stub.

### Tests
New `bootstrap/tests/verilog_array_literal_expr.rs` -- 2 `#[test]`s, both green:
1. `r_ca_2_synthetic_no_comment_only_call_argument` -- synthetic spec with `consume([1,2,3,4])` call.
2. `r_ca_2_real_bridge_spec_no_comment_only_call_argument` -- real-spec regression on `specs/fpga/bridge.t27`.

Local: `cargo test -p t27c --release --test verilog_array_literal_expr` -> **2 passed; 0 failed**. Cross-wave regression: W27/W28/W29/W30/W31 all **2 passed; 0 failed** = **10/10**.

### Constitution checklist
- **L1 TRACEABILITY**: `Closes #749` in title + this body + commit message.
- **L2 GENERATION**: edits only in `bootstrap/src/compiler.rs`, `bootstrap/tests/` (new file), `docs/NOW.md`. Zero edits under `gen/`, `coq/`, `trios-coq/`, `proofs/`, `specs/`, `conformance/`, `architecture/`, `rings/`, root `Cargo.toml`.
- **L3**: ASCII source, English doc-comments.
- **L4**: 2 new `#[test]`s, passing.
- **L5**: numeric kernel untouched, trinity invariant preserved.
- **L6**: zero spec/kernel changes.
- **L7**: no new `*.sh`.

### Out of scope (inherited, explicit)
- `fpga-formal`: `pip install sby` no matching distribution (infra).
- `fpga-synthesis-arty`: `error: unexpected argument '--board' found` (CLI drift).
- Bare `as;` / `u8;` statements visible at `bridge.v:170-178` (separate bug class in `as`-cast emitter, future wave).
- Any further downstream emitter bugs that may surface once `bridge.v` parses cleanly past line 166 will get their own wave.

Closes #749
