### PR TITLE
feat(bootstrap): gen-behavior-sva-v2 -- multi-clause antecedents, ##N delay, s_eventually (R-BV-1, Closes #775)

### DIFF
--- a/bootstrap/src/behavior_sva.rs
+++ b/bootstrap/src/behavior_sva.rs
@@ -68,10 +68,10 @@ fn contains_ci(haystack: &str, needle: &str) -> bool {
 ///
 /// Default fallback: `1'b1` (always-true antecedent).
 pub fn parse_given_clause(given: &str) -> &'static str {
-    if contains_ci(given, "running") {
+    if contains_ci(given, "running") && !contains_ci(given, "counter") && !contains_ci(given, "count") {
         return "running";
     }
-    if contains_ci(given, "active") {
+    if contains_ci(given, "active") && !contains_ci(given, "inactive") {
         return "active";
     }
     if contains_ci(given, "valid") {

--- a/bootstrap/src/behavior_sva_v2.rs
+++ b/bootstrap/src/behavior_sva_v2.rs
@@ -1,0 +1,657 @@
+//! Wave 37 -- R-BV-1 (Extended behavior-DSL to SystemVerilog Assertions emitter)
+//!
+//! Extends the Wave 34 (R-SV-1) `behavior_sva.rs` with three temporal-logic
+//! features required for spec-emit work (W38+):
+//!
+//! 1. **Multi-clause antecedents** -- conjunction of two or more predicates
+//!    joined by `and` / `,` / `&&`, e.g. `given = "valid and ready"` emits
+//!    `(valid_in && ready)`.
+//! 2. **`##N` delay-clock** -- delayed implication `A |-> ##N B` so the
+//!    consequent is required `N` cycles after the antecedent fires. Parsed
+//!    from "then" clauses like `then = "after 3 cycles done"`.
+//! 3. **`s_eventually`** -- strong-fairness operator (`A |-> s_eventually B`)
+//!    for liveness properties, triggered when the "then" clause contains
+//!    `eventually`.
+//!
+//! The v1 emitter (`behavior_sva.rs`) is frozen for backward compatibility.
+//! This module is a separate file with a separate CLI subcommand
+//! `gen-behavior-sva-v2`.
+//!
+//! Closes #775.
+
+use crate::behavior_sva::{parse_when_clause, Behavior};
+
+/// Extended consequent for the v2 emitter.
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConsequentV2 {
+    Plain(String),
+    Delayed { cycles: usize, expr: String },
+    Eventually(String),
+}
+
+/// Single-token identifiers recognised by the v2 given-clause parser.
+const GIVEN_TOKENS: &[(&str, &str)] = &[
+    ("running", "running"),
+    ("active", "active"),
+    ("valid", "valid_in"),
+    ("ready", "ready"),
+    ("reset", "!rst_n"),
+    ("idle", "(state == IDLE)"),
+    ("process", "(state == PROCESS)"),
+    ("full", "full"),
+    ("empty", "empty"),
+    ("busy", "busy"),
+    ("done", "done"),
+    ("start", "start"),
+    ("error", "error"),
+];
+
+fn contains_ci(haystack: &str, needle: &str) -> bool {
+    haystack.to_ascii_lowercase().contains(&needle.to_ascii_lowercase())
+}
+
+/// Map a single given-atom (one word or short phrase) to an SVA expression.
+///
+/// Falls back to passthrough: if the atom contains no recognised keyword it is
+/// emitted verbatim (allowing arbitrary signal names like `irq_status[2]`).
+fn map_given_atom(atom: &str) -> String {
+    let a = atom.trim();
+    if a.is_empty() {
+        return "1'b1".to_string();
+    }
+    if contains_ci(a, "not") {
+        if contains_ci(a, "reset") {
+            return "rst_n".to_string();
+        }
+        if contains_ci(a, "full") {
+            return "!full".to_string();
+        }
+        if contains_ci(a, "empty") {
+            return "!empty".to_string();
+        }
+        if contains_ci(a, "busy") {
+            return "!busy".to_string();
+        }
+    }
+    if contains_ci(a, "reset") {
+        if contains_ci(a, "not") || contains_ci(a, "inactive") {
+            return "rst_n".to_string();
+        }
+        return "!rst_n".to_string();
+    }
+    if contains_ci(a, "counter") || contains_ci(a, "count") {
+        if contains_ci(a, "max") {
+            return "(count == MAX_VALUE)".to_string();
+        }
+        if contains_ci(a, "zero") || contains_ci(a, "0") {
+            return "(count == 0)".to_string();
+        }
+        return "(count > 0)".to_string();
+    }
+    if contains_ci(a, "fifo") {
+        if contains_ci(a, "not") && contains_ci(a, "full") {
+            return "!full".to_string();
+        }
+        if contains_ci(a, "not") && contains_ci(a, "empty") {
+            return "!empty".to_string();
+        }
+        if contains_ci(a, "full") {
+            return "full".to_string();
+        }
+        if contains_ci(a, "empty") {
+            return "empty".to_string();
+        }
+        return "!empty".to_string();
+    }
+    for &(keyword, sva_expr) in GIVEN_TOKENS {
+        if contains_ci(a, keyword) {
+            return sva_expr.to_string();
+        }
+    }
+    a.to_string()
+}
+
+/// Split a given clause on conjunction separators (`and`, `,`, `&&`) and map
+/// each atom individually.
+///
+/// Returns the conjunction as a parenthesised expression:
+/// - single atom -> the atom itself (no parens needed)
+/// - multiple atoms -> `(a && b && c)`
+pub fn parse_given_clause_v2(given: &str) -> String {
+    let atoms = split_conjunctions(given);
+    let mapped: Vec<String> = atoms.iter().map(|a| map_given_atom(a)).collect();
+    match mapped.len() {
+        0 => "1'b1".to_string(),
+        1 => mapped.into_iter().next().unwrap(),
+        _ => format!("({})", mapped.join(" && ")),
+    }
+}
+
+/// Split a clause on conjunction separators: `and`, `,`, `&&`.
+fn split_conjunctions(clause: &str) -> Vec<&str> {
+    let mut atoms = Vec::new();
+    let mut rest = clause;
+    loop {
+        if let Some(pos) = find_conjunction_sep(rest) {
+            let (head, tail) = rest.split_at(pos);
+            atoms.push(head.trim());
+            rest = skip_sep(tail).trim_start();
+        } else {
+            let trimmed = rest.trim();
+            if !trimmed.is_empty() {
+                atoms.push(trimmed);
+            }
+            break;
+        }
+    }
+    if atoms.is_empty() {
+        atoms.push(clause.trim());
+    }
+    atoms
+}
+
+/// Find the earliest conjunction separator (` and `, `,`, `&&`) in the string.
+fn find_conjunction_sep(s: &str) -> Option<usize> {
+    let lower = s.to_ascii_lowercase();
+    if let Some(pos) = lower.find(" and ") {
+        return Some(pos);
+    }
+    if let Some(pos) = s.find("&&") {
+        return Some(pos);
+    }
+    if let Some(pos) = s.find(',') {
+        return Some(pos);
+    }
+    None
+}
+
+/// Skip past a conjunction separator at the start of `s`.
+fn skip_sep(s: &str) -> &str {
+    let lower_start = s.to_ascii_lowercase();
+    if lower_start.starts_with(" and ") {
+        return &s[5..];
+    }
+    if s.starts_with("&&") {
+        return &s[2..];
+    }
+    if s.starts_with(',') {
+        return &s[1..];
+    }
+    s
+}
+
+/// Map a single then-atom to a plain consequent string (reuses v1 vocabulary).
+fn map_then_atom(atom: &str) -> String {
+    let a = atom.trim();
+    if a.is_empty() {
+        return "1'b1".to_string();
+    }
+    if contains_ci(a, "increment") || contains_ci(a, "add") {
+        if contains_ci(a, "count") {
+            return "(count == $past(count) + 1)".to_string();
+        }
+        return "($past(data_out) + 1)".to_string();
+    }
+    if contains_ci(a, "decrement") || contains_ci(a, "subtract") {
+        if contains_ci(a, "count") {
+            return "(count == $past(count) - 1)".to_string();
+        }
+        return "($past(data_out) - 1)".to_string();
+    }
+    if contains_ci(a, "zero") || contains_ci(a, "clear") {
+        if contains_ci(a, "count") {
+            return "(count == 0)".to_string();
+        }
+        if contains_ci(a, "overflow") {
+            return "(!overflow)".to_string();
+        }
+        return "(data_out == 0)".to_string();
+    }
+    if contains_ci(a, "set") && contains_ci(a, "flag") {
+        if contains_ci(a, "overflow") {
+            return "overflow".to_string();
+        }
+        if contains_ci(a, "valid") {
+            return "valid_out".to_string();
+        }
+        if contains_ci(a, "done") {
+            return "done".to_string();
+        }
+        if contains_ci(a, "full") {
+            return "full".to_string();
+        }
+        if contains_ci(a, "empty") {
+            return "empty".to_string();
+        }
+        return "flag".to_string();
+    }
+    if contains_ci(a, "set") && contains_ci(a, "full") {
+        return "full".to_string();
+    }
+    if contains_ci(a, "set") && contains_ci(a, "empty") {
+        return "empty".to_string();
+    }
+    if contains_ci(a, "valid") && contains_ci(a, "output") {
+        return "valid_out".to_string();
+    }
+    if contains_ci(a, "wrap") {
+        return "(count == 0)".to_string();
+    }
+    for &(keyword, sva_expr) in &[("done", "done"), ("busy", "busy"), ("error", "error"), ("start", "start")] {
+        if contains_ci(a, keyword) {
+            return sva_expr.to_string();
+        }
+    }
+    a.to_string()
+}
+
+/// Parse the "then" clause into an extended consequent.
+///
+/// Three branches:
+/// - `eventually` / `liveness` -> `ConsequentV2::Eventually(expr)`
+/// - `after N cycles` / `##N` -> `ConsequentV2::Delayed { cycles, expr }`
+/// - otherwise -> `ConsequentV2::Plain(expr)`
+pub fn parse_then_clause_v2(then: &str) -> ConsequentV2 {
+    if contains_ci(then, "eventually") || contains_ci(then, "liveness") {
+        let cleaned = then
+            .replace("eventually-set", "")
+            .replace("eventually", "")
+            .replace("liveness", "");
+        let expr = map_then_atom(&cleaned);
+        let expr = if expr.is_empty() || expr.trim().is_empty() {
+            "1'b1".to_string()
+        } else {
+            expr
+        };
+        return ConsequentV2::Eventually(expr);
+    }
+
+    if let Some(cycles) = extract_delay_cycles(then) {
+        let cleaned = remove_delay_phrase(then);
+        let expr = map_then_atom(&cleaned);
+        return ConsequentV2::Delayed { cycles, expr };
+    }
+
+    ConsequentV2::Plain(map_then_atom(then))
+}
+
+/// Extract the cycle count from `after N cycles` or `##N` in a then-clause.
+fn extract_delay_cycles(then: &str) -> Option<usize> {
+    let lower = then.to_ascii_lowercase();
+    if let Some(pos) = lower.find("after") {
+        let rest = &then[pos + 5..].trim();
+        if let Some(n) = rest.split_whitespace().next() {
+            if let Ok(cycles) = n.parse::<usize>() {
+                return Some(cycles);
+            }
+        }
+    }
+    if let Some(pos) = lower.find("##") {
+        let rest = &then[pos + 2..].trim();
+        if let Some(n) = rest.split_whitespace().next() {
+            if let Ok(cycles) = n.parse::<usize>() {
+                return Some(cycles);
+            }
+        }
+    }
+    None
+}
+
+/// Remove the delay phrase (`after N cycles` or `##N`) from a then-clause.
+fn remove_delay_phrase(then: &str) -> String {
+    let lower = then.to_ascii_lowercase();
+    if let Some(pos) = lower.find("after") {
+        let rest = &lower[pos + 5..].trim();
+        if let Some(n) = rest.split_whitespace().next() {
+            if n.parse::<usize>().is_ok() {
+                let phrase = &then[pos..pos + 5 + n.len() + " cycles".len().min(rest.len())];
+                let cleaned = then.replace(phrase.trim(), "");
+                return cleaned.trim().to_string();
+            }
+        }
+    }
+    if let Some(pos) = lower.find("##") {
+        let rest = &lower[pos + 2..].trim();
+        if let Some(n) = rest.split_whitespace().next() {
+            if n.parse::<usize>().is_ok() {
+                let phrase = format!("##{}", n);
+                return then.replace(&phrase, "").trim().to_string();
+            }
+        }
+    }
+    then.to_string()
+}
+
+/// Build one full SVA block (property + assert + cover) from a single behavior
+/// using the v2 extended consequent.
+pub fn build_behavior_sva_v2_block(behavior: &Behavior<'_>, index: usize) -> String {
+    let timing = parse_when_clause(behavior.when);
+    let antecedent = parse_given_clause_v2(behavior.given);
+    let consequent = parse_then_clause_v2(behavior.then);
+
+    let consequent_sva = match &consequent {
+        ConsequentV2::Plain(expr) => expr.clone(),
+        ConsequentV2::Delayed { cycles, expr } => {
+            if *cycles == 0 {
+                expr.clone()
+            } else {
+                format!("##{} {}", cycles, expr)
+            }
+        }
+        ConsequentV2::Eventually(expr) => format!("s_eventually {}", expr),
+    };
+
+    let mut out = String::with_capacity(640);
+    out.push_str("// ----------------------------------------------------------------------------\n");
+    out.push_str(&format!("// Behavior: {}\n", behavior.name));
+    out.push_str(&format!("// Given:    {}\n", behavior.given));
+    out.push_str(&format!("// When:     {}\n", behavior.when));
+    out.push_str(&format!("// Then:     {}\n", behavior.then));
+    out.push_str("// ----------------------------------------------------------------------------\n");
+    out.push_str(&format!("property p_{};\n", behavior.name));
+    out.push_str(&format!("    @({}) disable iff (!rst_n)\n", timing));
+    out.push_str(&format!("    {} |-> {};\n", antecedent, consequent_sva));
+    out.push_str("endproperty\n\n");
+    out.push_str(&format!(
+        "assert_{}_{}: assert property (p_{})\n",
+        index, behavior.name, behavior.name
+    ));
+    out.push_str(&format!(
+        "    else $error(\"Assertion failed: {}\");\n\n",
+        behavior.name
+    ));
+    out.push_str(&format!(
+        "cover_{}_{}: cover property (p_{});\n",
+        index, behavior.name, behavior.name
+    ));
+    out
+}
+
+/// Build a complete SVA file containing one or more behavior blocks (v2).
+pub fn build_behavior_sva_v2_file(behaviors: &[Behavior<'_>]) -> String {
+    let mut out = String::with_capacity(1024 + behaviors.len() * 640);
+    out.push_str(HEADER_V2);
+    for (i, b) in behaviors.iter().enumerate() {
+        if i > 0 {
+            out.push('\n');
+        }
+        out.push_str(&build_behavior_sva_v2_block(b, i));
+    }
+    out.push_str(FOOTER_V2);
+    out
+}
+
+const HEADER_V2: &str = "\
+// ============================================================================
+// Behavior-DSL SystemVerilog Assertions (v2)
+// Generated by t27c gen-behavior-sva-v2 (Wave 37, R-BV-1, Closes #775)
+//
+// Extensions: multi-clause antecedents, ##N delay, s_eventually
+// Vocabulary ported from gHashTag/vibee-lang src/vibeec/verilog_codegen.zig
+// (lines 2415-2531). Original author: Dmitrii Vasilev.
+// phi^2 + 1/phi^2 = 3 | TRINITY
+// ============================================================================
+
+`timescale 1ns / 1ps
+`default_nettype none
+
+";
+
+const FOOTER_V2: &str = "\
+\n`default_nettype wire
+// ============================================================================
+// End of behavior SVA v2 block.
+// ============================================================================
+";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn given_single_keyword_passthrough() {
+        assert_eq!(parse_given_clause_v2("running"), "running");
+        assert_eq!(parse_given_clause_v2("valid"), "valid_in");
+        assert_eq!(parse_given_clause_v2("ready"), "ready");
+    }
+
+    #[test]
+    fn given_two_clause_and() {
+        assert_eq!(
+            parse_given_clause_v2("valid and ready"),
+            "(valid_in && ready)"
+        );
+    }
+
+    #[test]
+    fn given_three_clause_and() {
+        assert_eq!(
+            parse_given_clause_v2("valid and ready and busy"),
+            "(valid_in && ready && busy)"
+        );
+    }
+
+    #[test]
+    fn given_comma_separator() {
+        assert_eq!(
+            parse_given_clause_v2("running, active"),
+            "(running && active)"
+        );
+    }
+
+    #[test]
+    fn given_double_amp_separator() {
+        assert_eq!(
+            parse_given_clause_v2("valid && ready"),
+            "(valid_in && ready)"
+        );
+    }
+
+    #[test]
+    fn given_default_empty() {
+        assert_eq!(parse_given_clause_v2(""), "1'b1");
+    }
+
+    #[test]
+    fn given_reset_variants() {
+        assert_eq!(parse_given_clause_v2("not reset"), "rst_n");
+        assert_eq!(parse_given_clause_v2("reset"), "!rst_n");
+    }
+
+    #[test]
+    fn given_fifo_not_full() {
+        assert_eq!(parse_given_clause_v2("fifo not full"), "!full");
+    }
+
+    #[test]
+    fn given_passthrough_unknown_signal() {
+        assert_eq!(parse_given_clause_v2("irq_status[2]"), "irq_status[2]");
+    }
+
+    #[test]
+    fn given_mixed_known_and_unknown() {
+        assert_eq!(
+            parse_given_clause_v2("valid and custom_signal"),
+            "(valid_in && custom_signal)"
+        );
+    }
+
+    #[test]
+    fn then_plain_keyword() {
+        assert_eq!(
+            parse_then_clause_v2("increment count"),
+            ConsequentV2::Plain("(count == $past(count) + 1)".to_string())
+        );
+    }
+
+    #[test]
+    fn then_delay_after_cycles() {
+        assert_eq!(
+            parse_then_clause_v2("after 3 cycles done"),
+            ConsequentV2::Delayed {
+                cycles: 3,
+                expr: "done".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn then_delay_hash_hash() {
+        assert_eq!(
+            parse_then_clause_v2("##5 valid_out"),
+            ConsequentV2::Delayed {
+                cycles: 5,
+                expr: "valid_out".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn then_eventually_keyword() {
+        assert_eq!(
+            parse_then_clause_v2("eventually done"),
+            ConsequentV2::Eventually("done".to_string())
+        );
+    }
+
+    #[test]
+    fn then_eventually_liveness() {
+        assert_eq!(
+            parse_then_clause_v2("liveness check for done"),
+            ConsequentV2::Eventually("done".to_string())
+        );
+    }
+
+    #[test]
+    fn then_default_fallback() {
+        assert_eq!(
+            parse_then_clause_v2("something"),
+            ConsequentV2::Plain("something".to_string())
+        );
+    }
+
+    #[test]
+    fn then_delay_with_increment() {
+        assert_eq!(
+            parse_then_clause_v2("after 2 cycles increment count"),
+            ConsequentV2::Delayed {
+                cycles: 2,
+                expr: "(count == $past(count) + 1)".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn block_plain_consequent() {
+        let b = Behavior {
+            name: "plain_test",
+            given: "valid and ready",
+            when: "rising edge",
+            then: "increment count",
+        };
+        let block = build_behavior_sva_v2_block(&b, 0);
+        assert!(block.contains("property p_plain_test;"));
+        assert!(block.contains("(valid_in && ready) |-> (count == $past(count) + 1);"));
+        assert!(block.contains("endproperty"));
+        assert!(block.contains("assert_0_plain_test:"));
+        assert!(block.contains("cover_0_plain_test:"));
+    }
+
+    #[test]
+    fn block_delay_consequent() {
+        let b = Behavior {
+            name: "delayed",
+            given: "start",
+            when: "posedge clk",
+            then: "after 3 cycles done",
+        };
+        let block = build_behavior_sva_v2_block(&b, 1);
+        assert!(block.contains("start |-> ##3 done;"));
+    }
+
+    #[test]
+    fn block_eventually_consequent() {
+        let b = Behavior {
+            name: "live",
+            given: "start",
+            when: "posedge clk",
+            then: "eventually done",
+        };
+        let block = build_behavior_sva_v2_block(&b, 2);
+        assert!(block.contains("start |-> s_eventually done;"));
+    }
+
+    #[test]
+    fn file_header_footer_v2() {
+        let behaviors = [Behavior {
+            name: "x",
+            given: "running",
+            when: "rising",
+            then: "done",
+        }];
+        let file = build_behavior_sva_v2_file(&behaviors);
+        assert!(file.contains("`timescale 1ns / 1ps"));
+        assert!(file.contains("`default_nettype none"));
+        assert!(file.contains("`default_nettype wire"));
+        assert!(file.contains("gen-behavior-sva-v2"));
+        assert!(file.contains("Wave 37"));
+    }
+
+    #[test]
+    fn file_multi_behavior() {
+        let behaviors = [
+            Behavior {
+                name: "a",
+                given: "valid",
+                when: "rising",
+                then: "done",
+            },
+            Behavior {
+                name: "b",
+                given: "ready",
+                when: "falling",
+                then: "after 2 cycles busy",
+            },
+        ];
+        let file = build_behavior_sva_v2_file(&behaviors);
+        assert!(file.contains("property p_a;"));
+        assert!(file.contains("property p_b;"));
+        assert!(file.contains("assert_0_a"));
+        assert!(file.contains("assert_1_b"));
+        assert!(file.contains("##2"));
+    }
+
+    #[test]
+    fn split_conjunctions_basic() {
+        let atoms = split_conjunctions("valid and ready");
+        assert_eq!(atoms, vec!["valid", "ready"]);
+    }
+
+    #[test]
+    fn split_conjunctions_comma() {
+        let atoms = split_conjunctions("running, active");
+        assert_eq!(atoms, vec!["running", "active"]);
+    }
+
+    #[test]
+    fn split_conjunctions_double_amp() {
+        let atoms = split_conjunctions("valid && ready");
+        assert_eq!(atoms, vec!["valid", "ready"]);
+    }
+
+    #[test]
+    fn extract_delay_after_n_cycles() {
+        assert_eq!(extract_delay_cycles("after 3 cycles done"), Some(3));
+        assert_eq!(extract_delay_cycles("after 10 cycles busy"), Some(10));
+    }
+
+    #[test]
+    fn extract_delay_hash_hash() {
+        assert_eq!(extract_delay_cycles("##5 valid_out"), Some(5));
+    }
+
+    #[test]
+    fn extract_delay_none() {
+        assert_eq!(extract_delay_cycles("increment count"), None);
+    }
+}

--- a/bootstrap/src/main.rs
+++ b/bootstrap/src/main.rs
@@ -26,6 +26,7 @@ mod ternary;
 mod memory;
 mod trit_stdlib;
 mod behavior_sva;
+mod behavior_sva_v2;
 mod phi_selfcheck;
 mod weight_bram;
 mod bitnet_pipeline;
@@ -133,6 +134,23 @@ enum Commands {
         /// `cover_<index>_<name>`. Defaults to 0.
         #[arg(long, default_value_t = 0)]
         index: usize,
+
+        /// Output file path. If omitted, the Verilog is written to stdout.
+        #[arg(short, long)]
+        output: Option<String>,
+    },
+
+    /// Emit extended behavior-DSL SVA blocks with multi-clause antecedents,
+    /// `##N` delay, and `s_eventually` (Wave 37, R-BV-1).
+    ///
+    /// Reads a JSON array of behavior objects and emits self-contained
+    /// SystemVerilog Assertions with IEEE 1800 temporal operators.
+    #[command(name = "gen-behavior-sva-v2")]
+    GenBehaviorSvaV2 {
+        /// Path to a JSON file containing an array of behavior objects.
+        /// Each object has fields: name, given, when, then.
+        #[arg(long)]
+        behaviors_json: String,
 
         /// Output file path. If omitted, the Verilog is written to stdout.
         #[arg(short, long)]
@@ -7589,6 +7607,10 @@ async fn main() -> anyhow::Result<()> {
             index,
             output,
         } => run_gen_behavior_sva(&name, &given, &when, &then, index, output.as_deref())?,
+        Commands::GenBehaviorSvaV2 {
+            behaviors_json,
+            output,
+        } => run_gen_behavior_sva_v2(&behaviors_json, output.as_deref())?,
         Commands::GenPhiSelfcheck {
             tolerance,
             wrap,
@@ -7764,8 +7786,36 @@ async fn main() -> anyhow::Result<()> {
             }
         }
      }
- 
     Ok(())
+}
+
+#[derive(serde::Deserialize)]
+struct BehaviorJson {
+    name: String,
+    given: String,
+    when: String,
+    then: String,
+}
+
+fn run_gen_behavior_sva_v2(
+    behaviors_json: &str,
+    output: Option<&str>,
+) -> anyhow::Result<()> {
+    let json_str = fs::read_to_string(behaviors_json)
+        .with_context(|| format!("failed to read behaviors JSON from {}", behaviors_json))?;
+    let behaviors_json: Vec<BehaviorJson> = serde_json::from_str(&json_str)
+        .with_context(|| "failed to parse behaviors JSON")?;
+    let behaviors: Vec<behavior_sva::Behavior<'_>> = behaviors_json
+        .iter()
+        .map(|b| behavior_sva::Behavior {
+            name: &b.name,
+            given: &b.given,
+            when: &b.when,
+            then: &b.then,
+        })
+        .collect();
+    let verilog = behavior_sva_v2::build_behavior_sva_v2_file(&behaviors);
+    write_verilog_to_output(&verilog, output, "behavior SVA v2")
 }
 
 #[cfg(not(feature = "server"))]
@@ -7787,6 +7837,10 @@ fn main() -> anyhow::Result<()> {
             index,
             output,
         } => run_gen_behavior_sva(&name, &given, &when, &then, index, output.as_deref())?,
+        Commands::GenBehaviorSvaV2 {
+            behaviors_json,
+            output,
+        } => run_gen_behavior_sva_v2(&behaviors_json, output.as_deref())?,
         Commands::GenPhiSelfcheck {
             tolerance,
             wrap,

--- a/bootstrap/src/proxy.rs
+++ b/bootstrap/src/proxy.rs
@@ -231,7 +231,7 @@ pub async fn check_container_health(service_id: &str) -> anyhow::Result<bool> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "server"))]
 mod tests {
     use super::*;
 

--- a/bootstrap/tests/behavior_sva_v2.rs
+++ b/bootstrap/tests/behavior_sva_v2.rs
@@ -1,0 +1,314 @@
+//! Wave 37 -- R-BV-1 integration tests for the extended behavior-DSL SVA v2 emitter.
+//!
+//! Strategy: create a JSON file with behavior objects, shell out to the built
+//! t27c binary via `CARGO_BIN_EXE_t27c`, run `gen-behavior-sva-v2`, capture
+//! stdout or file output, and assert structural invariants on the emitted SVA.
+//!
+//! Closes #775.
+
+use std::fs;
+use std::process::Command;
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn write_behaviors_json(behaviors: &[(&str, &str, &str, &str)]) -> String {
+    let dir = std::env::temp_dir().join("t27c_test_behavior_sva_v2");
+    let _ = fs::create_dir_all(&dir);
+    let counter = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let json = format!(
+        "[{}]",
+        behaviors
+            .iter()
+            .map(|(name, given, when, then)| {
+                format!(
+                    r#"{{"name":"{}","given":"{}","when":"{}","then":"{}"}}"#,
+                    name, given, when, then
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(",")
+    );
+    let path = dir.join(format!("behaviors_{}_{}.json", std::process::id(), counter));
+    fs::write(&path, &json).expect("write json");
+    path.to_string_lossy().to_string()
+}
+
+fn run_gen_behavior_sva_v2(
+    behaviors: &[(&str, &str, &str, &str)],
+) -> String {
+    let json_path = write_behaviors_json(behaviors);
+    let bin = env!("CARGO_BIN_EXE_t27c");
+    let output = Command::new(bin)
+        .arg("gen-behavior-sva-v2")
+        .arg("--behaviors-json")
+        .arg(&json_path)
+        .output()
+        .expect("failed to spawn t27c gen-behavior-sva-v2");
+    assert!(
+        output.status.success(),
+        "t27c gen-behavior-sva-v2 exited with {:?}, stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).expect("non-UTF-8 output")
+}
+
+fn run_gen_behavior_sva_v2_to_file(
+    behaviors: &[(&str, &str, &str, &str)],
+) -> (String, String) {
+    let json_path = write_behaviors_json(behaviors);
+    let counter = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let out_path = std::env::temp_dir()
+        .join("t27c_test_behavior_sva_v2")
+        .join(format!("output_{}_{}.sv", std::process::id(), counter));
+    let bin = env!("CARGO_BIN_EXE_t27c");
+    let output = Command::new(bin)
+        .arg("gen-behavior-sva-v2")
+        .arg("--behaviors-json")
+        .arg(&json_path)
+        .arg("--output")
+        .arg(&out_path)
+        .output()
+        .expect("failed to spawn t27c gen-behavior-sva-v2");
+    assert!(
+        output.status.success(),
+        "t27c gen-behavior-sva-v2 exited with {:?}, stderr={}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let content = fs::read_to_string(&out_path).expect("read output file");
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    (content, stderr)
+}
+
+#[test]
+fn v2_multi_clause_given_emits_conjunction() {
+    let v = run_gen_behavior_sva_v2(&[
+        ("multi_and", "valid and ready", "posedge clk", "done"),
+    ]);
+    assert!(v.contains("(valid_in && ready) |->"), "expected conjunction");
+    assert!(v.contains("property p_multi_and;"));
+}
+
+#[test]
+fn v2_comma_separator_emits_conjunction() {
+    let v = run_gen_behavior_sva_v2(&[
+        ("comma_test", "running, active", "rising edge", "done"),
+    ]);
+    assert!(v.contains("(running && active) |->"), "expected comma conjunction");
+}
+
+#[test]
+fn v2_double_amp_separator() {
+    let v = run_gen_behavior_sva_v2(&[
+        ("amp_test", "valid && ready", "rising", "done"),
+    ]);
+    assert!(v.contains("(valid_in && ready) |->"), "expected && conjunction");
+}
+
+#[test]
+fn v2_three_clause_conjunction() {
+    let v = run_gen_behavior_sva_v2(&[
+        ("three", "valid and ready and busy", "rising", "done"),
+    ]);
+    assert!(
+        v.contains("(valid_in && ready && busy) |->"),
+        "expected three-way conjunction"
+    );
+}
+
+#[test]
+fn v2_delay_after_cycles() {
+    let v = run_gen_behavior_sva_v2(&[
+        ("delayed", "start", "posedge clk", "after 3 cycles done"),
+    ]);
+    assert!(v.contains("start |-> ##3 done;"), "expected ##3 delay");
+}
+
+#[test]
+fn v2_delay_hash_hash_syntax() {
+    let v = run_gen_behavior_sva_v2(&[
+        ("hash_delay", "start", "rising", "##5 valid_out"),
+    ]);
+    assert!(v.contains("start |-> ##5 valid_out;"), "expected ##5 delay");
+}
+
+#[test]
+fn v2_eventually_emits_s_eventually() {
+    let v = run_gen_behavior_sva_v2(&[
+        ("live", "start", "rising", "eventually done"),
+    ]);
+    assert!(
+        v.contains("start |-> s_eventually done;"),
+        "expected s_eventually"
+    );
+}
+
+#[test]
+fn v2_liveness_keyword() {
+    let v = run_gen_behavior_sva_v2(&[
+        ("liveness", "start", "rising", "liveness check for done"),
+    ]);
+    assert!(
+        v.contains("start |-> s_eventually done;"),
+        "expected s_eventually from liveness keyword"
+    );
+}
+
+#[test]
+fn v2_plain_consequent_matches_v1() {
+    let v = run_gen_behavior_sva_v2(&[
+        ("plain", "running", "rising edge", "increment count"),
+    ]);
+    assert!(
+        v.contains("running |-> (count == $past(count) + 1);"),
+        "expected plain consequent matching v1 vocabulary"
+    );
+}
+
+#[test]
+fn v2_property_assert_cover_structure() {
+    let v = run_gen_behavior_sva_v2(&[
+        ("struct_test", "valid and ready", "posedge clk", "done"),
+    ]);
+    assert!(v.contains("property p_struct_test;"));
+    assert!(v.contains("endproperty"));
+    assert!(v.contains("assert_0_struct_test: assert property (p_struct_test)"));
+    assert!(v.contains("$error(\"Assertion failed: struct_test\")"));
+    assert!(v.contains("cover_0_struct_test: cover property (p_struct_test);"));
+}
+
+#[test]
+fn v2_multi_behavior_indexing() {
+    let v = run_gen_behavior_sva_v2(&[
+        ("first", "running", "rising", "done"),
+        ("second", "valid", "falling", "after 2 cycles busy"),
+        ("third", "ready", "rising", "eventually done"),
+    ]);
+    assert!(v.contains("assert_0_first:"));
+    assert!(v.contains("assert_1_second:"));
+    assert!(v.contains("assert_2_third:"));
+    assert!(v.contains("cover_0_first:"));
+    assert!(v.contains("cover_1_second:"));
+    assert!(v.contains("cover_2_third:"));
+    assert!(v.contains("##2"));
+    assert!(v.contains("s_eventually"));
+}
+
+#[test]
+fn v2_header_footer() {
+    let v = run_gen_behavior_sva_v2(&[
+        ("h", "running", "rising", "done"),
+    ]);
+    assert!(v.contains("`timescale 1ns / 1ps"));
+    assert!(v.contains("`default_nettype none"));
+    assert!(v.contains("`default_nettype wire"));
+    assert!(v.contains("gen-behavior-sva-v2"));
+    assert!(v.contains("Wave 37"));
+}
+
+#[test]
+fn v2_header_comments_quote_clauses() {
+    let v = run_gen_behavior_sva_v2(&[
+        ("doc_test", "valid and ready", "posedge clk", "after 3 cycles done"),
+    ]);
+    assert!(v.contains("// Behavior: doc_test"));
+    assert!(v.contains("// Given:    valid and ready"));
+    assert!(v.contains("// When:     posedge clk"));
+    assert!(v.contains("// Then:     after 3 cycles done"));
+}
+
+#[test]
+fn v2_falling_edge_timing() {
+    let v = run_gen_behavior_sva_v2(&[
+        ("fall", "running", "falling edge", "done"),
+    ]);
+    assert!(v.contains("@(negedge clk) disable iff (!rst_n)"));
+}
+
+#[test]
+fn v2_disable_iff_rst_n() {
+    let v = run_gen_behavior_sva_v2(&[
+        ("rst", "running", "rising", "done"),
+    ]);
+    assert!(v.contains("disable iff (!rst_n)"));
+}
+
+#[test]
+fn v2_file_output() {
+    let (content, stderr) = run_gen_behavior_sva_v2_to_file(&[
+        ("file_out", "running", "rising", "done"),
+    ]);
+    assert!(content.contains("property p_file_out;"));
+    assert!(stderr.contains("behavior SVA v2 written to"));
+    assert!(stderr.contains("bytes"));
+}
+
+#[test]
+fn v2_passthrough_unknown_signal() {
+    let v = run_gen_behavior_sva_v2(&[
+        ("custom", "irq_status[2]", "rising", "custom_done"),
+    ]);
+    assert!(v.contains("irq_status[2] |->"), "unknown given signal should passthrough");
+}
+
+#[test]
+fn v2_given_reset_not() {
+    let v = run_gen_behavior_sva_v2(&[
+        ("rst_test", "not reset", "rising", "done"),
+    ]);
+    assert!(v.contains("rst_n |-> done;"));
+}
+
+#[test]
+fn v2_given_fifo_not_empty() {
+    let v = run_gen_behavior_sva_v2(&[
+        ("fifo_test", "fifo not empty", "rising", "done"),
+    ]);
+    assert!(v.contains("!empty |-> done;"));
+}
+
+#[test]
+fn v2_delay_with_keyword_consequent() {
+    let v = run_gen_behavior_sva_v2(&[
+        ("delay_inc", "start", "rising", "after 2 cycles increment count"),
+    ]);
+    assert!(
+        v.contains("start |-> ##2 (count == $past(count) + 1);"),
+        "expected delayed increment consequent"
+    );
+}
+
+#[test]
+fn v2_mixed_conjunction_and_delay() {
+    let v = run_gen_behavior_sva_v2(&[
+        ("combo", "valid and start", "rising", "after 5 cycles done"),
+    ]);
+    assert!(v.contains("(valid_in && start) |-> ##5 done;"));
+}
+
+#[test]
+fn v2_determinism() {
+    let behaviors: (&str, &str, &str, &str) = ("det", "valid and ready", "rising", "after 3 cycles done");
+    let v1 = run_gen_behavior_sva_v2(&[behaviors]);
+    let v2 = run_gen_behavior_sva_v2(&[behaviors]);
+    assert_eq!(v1, v2, "emitter must be deterministic");
+}
+
+#[test]
+fn v2_empty_given_defaults() {
+    let v = run_gen_behavior_sva_v2(&[
+        ("empty_g", "", "rising", "done"),
+    ]);
+    assert!(v.contains("1'b1 |-> done;"), "empty given defaults to 1'b1");
+}
+
+#[test]
+fn v2_ascii_only_output() {
+    let v = run_gen_behavior_sva_v2(&[
+        ("ascii", "valid and ready", "rising", "done"),
+    ]);
+    assert!(v.is_ascii(), "emitted SVA must be ASCII-only (L3)");
+}

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,6 +1,6 @@
 # NOW -- Trinity t27 sync
 
-Last updated: 2026-05-24
+Last updated: 2026-05-23
 
 ## wave-37 -- t27c gen-behavior-sva-v2 -- multi-clause antecedents, ##N delay, s_eventually (R-BV-1, Closes #775)
 

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,6 +1,19 @@
 # NOW -- Trinity t27 sync
 
-Last updated: 2026-05-23
+Last updated: 2026-05-24
+
+## wave-37 -- t27c gen-behavior-sva-v2 -- multi-clause antecedents, ##N delay, s_eventually (R-BV-1, Closes #775)
+
+- **WHERE** (bootstrap-only, additive): new file `bootstrap/src/behavior_sva_v2.rs` (extended SVA emitter + 28 inline unit tests); new `mod behavior_sva_v2;` declaration in `bootstrap/src/main.rs`; new CLI subcommand `Commands::GenBehaviorSvaV2 { behaviors_json, output }` registered in the `Commands` enum and dispatched in both HTTP-server and CLI match arms via `run_gen_behavior_sva_v2(...)`. Bugfix: `behavior_sva.rs` v1 keyword priority (inactive/active collision, counter/running collision). Bugfix: `proxy.rs` test module gated behind `#[cfg(all(test, feature = "server"))]`. New test file `bootstrap/tests/behavior_sva_v2.rs` (24 integration tests).
+- **Why** (R-BV-1): the Wave 34 v1 emitter (`gen-behavior-sva`) supports only simple `A |-> B` assertions with single-keyword antecedents and consequents. Temporal verification (multi-cycle delay, liveness) and compound guard conditions are required before the behavior-DSL can be wired into existing `gen_verilog_*` spec emits (W38+). The v2 emitter adds three IEEE 1800 SVA extensions: multi-clause conjunction antecedents (`and`/`,`/`&&`), `##N` cycle-delayed implication, and `s_eventually` strong-fairness operator. The v1 emitter and its 8 integration + 12 unit tests are untouched (backward-compatible, frozen).
+- **What changed**:
+  - `behavior_sva_v2.rs`: `parse_given_clause_v2(given)` splits on `and`/`,`/`&&` and maps each atom via keyword vocabulary, emitting `(a && b && c)` for multi-clause or bare signal for single-clause. Unknown signals passthrough verbatim.
+  - `behavior_sva_v2.rs`: `parse_then_clause_v2(then)` returns `ConsequentV2` enum: `Plain(expr)`, `Delayed { cycles, expr }` (from `after N cycles` or `##N`), `Eventually(expr)` (from `eventually`/`liveness`).
+  - `behavior_sva_v2.rs`: `build_behavior_sva_v2_block` emits `A |-> ##N B` for delayed, `A |-> s_eventually B` for liveness, `A |-> B` for plain.
+  - CLI: `t27c gen-behavior-sva-v2 --behaviors-json <path> [--output <path>]` reads JSON array of `{name, given, when, then}` objects.
+  - Bugfix v1: `parse_given_clause` now guards "active" check with `!contains_ci(given, "inactive")` and "running" check with `!contains_ci(given, "counter") && !contains_ci(given, "count")`.
+  - Bugfix proxy: test module gated behind `#[cfg(all(test, feature = "server"))]` to fix compilation without `server` feature.
+- **Tests**: 28 inline unit tests in `behavior_sva_v2.rs` (given single/multi-clause, comma/amp/and splitting, reset/fifo/unknown passthrough, then plain/delayed/eventually, block structure, file structure, delay extraction) + 24 integration tests in `behavior_sva_v2.rs` test file (multi-clause conjunction via CLI, delay `after N cycles`, delay `##N`, `s_eventually`, liveness, plain consequent, property/assert/cover structure, multi-behavior indexing, header/footer, header comments, falling edge, disable iff, file output, passthrough, reset, fifo, delay+keyword, mixed conjunction+delay, determinism, empty given, ASCII-only). V1 regression sweep: 12 unit + 8 integration = 20/20 pass. **Total new: 52 / 52. Pre-existing: 185 integration + 706 unit = 891.**
 
 ## L-TRI-3 V2 + Verilog codegen fixes (synced from main branch)
 


### PR DESCRIPTION
## Wave 37 -- R-BV-1: Extended behavior-DSL SVA emitter

Closes #775

### What changed

New file `bootstrap/src/behavior_sva_v2.rs` + CLI subcommand `gen-behavior-sva-v2` with three IEEE 1800 SVA extensions over the frozen v1 emitter (W34, R-SV-1):

1. **Multi-clause antecedents** — `and`/`,`/`&&` conjunction: `"valid and ready"` → `(valid_in && ready)`
2. **`##N` delay** — `"after 3 cycles done"` or `"##5 valid_out"` → `##N` delayed implication
3. **`s_eventually`** — `"eventually done"` or `"liveness"` → strong-fairness operator

Also fixes v1 keyword priority bugs (`inactive` matching `active`, `counter running` matching `running`) and gates `proxy.rs` tests behind `#[cfg(feature = "server")]`.

### Test counts

- 28 inline unit tests (v2 emitter)
- 24 integration tests (CLI)
- **52 new tests total**
- V1 regression sweep: 20/20 pass
- Pre-existing integration suite: 185/185 pass

### Constitutional gates

- L1: `Closes #775` in title + body + commit
- L2: edits only in `bootstrap/src/{behavior_sva_v2.rs,behavior_sva.rs,main.rs,proxy.rs}`, `bootstrap/tests/behavior_sva_v2.rs`, `docs/NOW.md`
- L3: ASCII only, English doc-comments
- L4: 52 new tests; v1 20/20 preserved
- L5: numeric kernel untouched
- L6: zero spec/kernel changes
- L7: no new shell scripts

### CLI surface

```bash
echo '[{"name":"b1","given":"valid and ready","when":"posedge clk","then":"after 3 cycles done"}]' > /tmp/b.json
t27c gen-behavior-sva-v2 --behaviors-json /tmp/b.json
```

phi^2 + 1/phi^2 = 3 | TRINITY