### PR TITLE
feat(bootstrap): host DMA-driven multi-layer inference flow (Wave 41, R-HS-3)

### DIFF
--- a/bootstrap/src/host/engine.rs
+++ b/bootstrap/src/host/engine.rs
@@ -1,0 +1,316 @@
+use super::csr_map;
+use super::driver::{BitnetDriver, DriverError};
+use super::irq::IrqDrivenDriver;
+use super::mmio::MockMmio;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InferenceReport {
+    pub total_layers: u32,
+    pub layers_completed: u32,
+    pub error_layer: Option<u32>,
+    pub total_writes: usize,
+    pub total_reads: usize,
+}
+
+pub struct InferenceEngine {
+    driver: IrqDrivenDriver<MockMmio>,
+    num_layers: u32,
+    neurons: u32,
+    chunks: u32,
+    threshold: u32,
+    weight_addr: u64,
+}
+
+impl InferenceEngine {
+    pub fn new(driver: BitnetDriver<MockMmio>) -> Self {
+        Self {
+            driver: IrqDrivenDriver::new(driver),
+            num_layers: 2,
+            neurons: 16,
+            chunks: 4,
+            threshold: 1,
+            weight_addr: 0,
+        }
+    }
+
+    pub fn configure(
+        &mut self,
+        num_layers: u32,
+        neurons: u32,
+        chunks: u32,
+        threshold: u32,
+        weight_addr: u64,
+    ) -> Result<(), DriverError> {
+        if num_layers == 0 || neurons == 0 || chunks == 0 {
+            return Err(DriverError::InvalidConfig);
+        }
+        self.num_layers = num_layers;
+        self.neurons = neurons;
+        self.chunks = chunks;
+        self.threshold = threshold;
+        self.weight_addr = weight_addr;
+        Ok(())
+    }
+
+    pub fn run(&mut self, max_rounds_per_stage: u32) -> Result<InferenceReport, DriverError> {
+        self.driver
+            .handler_mut()
+            .driver_mut()
+            .configure(
+                self.num_layers,
+                self.neurons,
+                self.chunks,
+                self.threshold,
+                self.weight_addr,
+            )?;
+        self.driver
+            .handler_mut()
+            .driver_mut()
+            .enable_irqs(csr_map::IRQ_ALL_MASK);
+
+        let mut layers_completed: u32 = 0;
+        let mut error_layer: Option<u32> = None;
+
+        for layer in 0..self.num_layers {
+            let layer_weight_addr = self.weight_addr.wrapping_add(
+                (layer as u64) * 0x1_0000 * (self.neurons as u64) * (self.chunks as u64),
+            );
+            self.driver
+                .handler_mut()
+                .driver_mut()
+                .mmio_mut()
+                .poke(csr_map::WEIGHT_ADDR_LO, layer_weight_addr as u32);
+            self.driver
+                .handler_mut()
+                .driver_mut()
+                .mmio_mut()
+                .poke(csr_map::WEIGHT_ADDR_HI, (layer_weight_addr >> 32) as u32);
+
+            self.driver
+                .handler_mut()
+                .driver_mut()
+                .mmio_mut()
+                .latch_irq(csr_map::IRQ_DMA_DONE_MASK);
+            if let Err(e) = self.wait_dma_done(max_rounds_per_stage) {
+                error_layer = Some(layer);
+                if e == DriverError::EngineError {
+                    break;
+                }
+                return Err(e);
+            }
+
+            self.driver.handler_mut().driver_mut().start();
+            self.driver
+                .handler_mut()
+                .driver_mut()
+                .mmio_mut()
+                .latch_irq(csr_map::IRQ_INFERENCE_DONE_MASK);
+            self.driver
+                .handler_mut()
+                .driver_mut()
+                .mmio_mut()
+                .set_done(true);
+            if let Err(e) = self.wait_inference_done(max_rounds_per_stage) {
+                error_layer = Some(layer);
+                if e == DriverError::EngineError {
+                    break;
+                }
+                return Err(e);
+            }
+
+            self.driver
+                .handler_mut()
+                .driver_mut()
+                .mmio_mut()
+                .latch_irq(csr_map::IRQ_DMA_DONE_MASK);
+            if let Err(e) = self.wait_dma_done(max_rounds_per_stage) {
+                error_layer = Some(layer);
+                if e == DriverError::EngineError {
+                    break;
+                }
+                return Err(e);
+            }
+
+            layers_completed += 1;
+        }
+
+        let total_writes = self.driver.handler().driver().mmio().write_count();
+        let total_reads = self.driver.handler().driver().mmio().read_count();
+
+        Ok(InferenceReport {
+            total_layers: self.num_layers,
+            layers_completed,
+            error_layer,
+            total_writes,
+            total_reads,
+        })
+    }
+
+    fn wait_dma_done(&mut self, max_rounds: u32) -> Result<(), DriverError> {
+        self.driver.wait_irq_mask(csr_map::IRQ_DMA_DONE_MASK, max_rounds)
+    }
+
+    fn wait_inference_done(&mut self, max_rounds: u32) -> Result<(), DriverError> {
+        self.driver.wait_irq_mask(csr_map::IRQ_INFERENCE_DONE_MASK, max_rounds)
+    }
+
+    pub fn driver(&self) -> &IrqDrivenDriver<MockMmio> {
+        &self.driver
+    }
+
+    pub fn driver_mut(&mut self) -> &mut IrqDrivenDriver<MockMmio> {
+        &mut self.driver
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::host::mmio::MockMmio;
+
+    fn fresh() -> InferenceEngine {
+        InferenceEngine::new(BitnetDriver::new(MockMmio::with_csrs_zeroed()))
+    }
+
+    #[test]
+    fn configure_rejects_zero_layers() {
+        let mut e = fresh();
+        assert_eq!(e.configure(0, 1, 1, 1, 0), Err(DriverError::InvalidConfig));
+    }
+
+    #[test]
+    fn configure_rejects_zero_neurons() {
+        let mut e = fresh();
+        assert_eq!(e.configure(1, 0, 1, 1, 0), Err(DriverError::InvalidConfig));
+    }
+
+    #[test]
+    fn configure_rejects_zero_chunks() {
+        let mut e = fresh();
+        assert_eq!(e.configure(1, 1, 0, 1, 0), Err(DriverError::InvalidConfig));
+    }
+
+    #[test]
+    fn run_single_layer_succeeds() {
+        let mut e = fresh();
+        e.configure(1, 16, 4, 1, 0).unwrap();
+        let report = e.run(4).unwrap();
+        assert_eq!(report.total_layers, 1);
+        assert_eq!(report.layers_completed, 1);
+        assert_eq!(report.error_layer, None);
+    }
+
+    #[test]
+    fn run_two_layers_succeeds() {
+        let mut e = fresh();
+        e.configure(2, 16, 4, 1, 0).unwrap();
+        let report = e.run(4).unwrap();
+        assert_eq!(report.total_layers, 2);
+        assert_eq!(report.layers_completed, 2);
+    }
+
+    #[test]
+    fn run_reports_writes_and_reads() {
+        let mut e = fresh();
+        e.configure(1, 16, 4, 1, 0).unwrap();
+        let report = e.run(4).unwrap();
+        assert!(report.total_writes > 0);
+        assert!(report.total_reads > 0);
+    }
+
+    #[test]
+    fn run_increases_writes_with_more_layers() {
+        let mut e1 = fresh();
+        e1.configure(1, 16, 4, 1, 0).unwrap();
+        let r1 = e1.run(4).unwrap();
+
+        let mut e2 = fresh();
+        e2.configure(3, 16, 4, 1, 0).unwrap();
+        let r2 = e2.run(4).unwrap();
+
+        assert!(r2.total_writes > r1.total_writes);
+    }
+
+    #[test]
+    fn run_error_on_irq_error_stops_early() {
+        let mut e = fresh();
+        e.configure(3, 16, 4, 1, 0).unwrap();
+        e.driver_mut()
+            .handler_mut()
+            .driver_mut()
+            .mmio_mut()
+            .latch_irq(csr_map::IRQ_ERROR_MASK);
+        let report = e.run(4).unwrap();
+        assert!(report.layers_completed < report.total_layers);
+        assert!(report.error_layer.is_some());
+    }
+
+    #[test]
+    fn run_returns_error_on_zero_rounds() {
+        let mut e = fresh();
+        e.configure(1, 16, 4, 1, 0).unwrap();
+        let result = e.run(0);
+        assert_eq!(result, Err(DriverError::Timeout));
+    }
+
+    #[test]
+    fn five_layers_all_complete() {
+        let mut e = fresh();
+        e.configure(5, 4, 2, 1, 0).unwrap();
+        let report = e.run(4).unwrap();
+        assert_eq!(report.layers_completed, 5);
+        assert_eq!(report.error_layer, None);
+    }
+
+    #[test]
+    fn one_layer_one_neuron_one_chunk() {
+        let mut e = fresh();
+        e.configure(1, 1, 1, 0, 0).unwrap();
+        let report = e.run(4).unwrap();
+        assert_eq!(report.layers_completed, 1);
+    }
+
+    #[test]
+    fn threshold_zero_is_valid() {
+        let mut e = fresh();
+        e.configure(1, 4, 2, 0, 0).unwrap();
+        let report = e.run(4).unwrap();
+        assert_eq!(report.layers_completed, 1);
+    }
+
+    #[test]
+    fn large_weight_addr_wraps() {
+        let mut e = fresh();
+        e.configure(1, 4, 2, 1, 0xFFFF_FFFF_FFFF_FFFF).unwrap();
+        let report = e.run(4).unwrap();
+        assert_eq!(report.layers_completed, 1);
+    }
+
+    #[test]
+    fn read_count_positive_after_run() {
+        let mut e = fresh();
+        e.configure(1, 4, 4, 1, 0).unwrap();
+        let report = e.run(4).unwrap();
+        assert!(report.total_reads >= 1);
+    }
+
+    #[test]
+    fn writes_increase_monotonically_with_layers() {
+        let results: Vec<InferenceReport> = (1..=4)
+            .map(|n| {
+                let mut e = fresh();
+                e.configure(n, 4, 2, 1, 0).unwrap();
+                e.run(4).unwrap()
+            })
+            .collect();
+        for w in results.windows(2) {
+            assert!(w[1].total_writes > w[0].total_writes);
+        }
+    }
+
+    #[test]
+    fn configure_accepts_max_values() {
+        let mut e = fresh();
+        assert!(e.configure(u32::MAX, u32::MAX, u32::MAX, u32::MAX, u64::MAX).is_ok());
+    }
+}

--- a/bootstrap/src/host/irq.rs
+++ b/bootstrap/src/host/irq.rs
@@ -1,0 +1,251 @@
+use super::csr_map;
+use super::driver::{BitnetDriver, DriverError};
+use super::mmio::Mmio;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IrqSource {
+    InferenceDone,
+    DmaDone,
+    Error,
+}
+
+impl IrqSource {
+    pub fn mask(self) -> u32 {
+        match self {
+            IrqSource::InferenceDone => csr_map::IRQ_INFERENCE_DONE_MASK,
+            IrqSource::DmaDone => csr_map::IRQ_DMA_DONE_MASK,
+            IrqSource::Error => csr_map::IRQ_ERROR_MASK,
+        }
+    }
+
+    pub fn from_mask(mask: u32) -> Vec<IrqSource> {
+        let mut sources = Vec::new();
+        if mask & csr_map::IRQ_INFERENCE_DONE_MASK != 0 {
+            sources.push(IrqSource::InferenceDone);
+        }
+        if mask & csr_map::IRQ_DMA_DONE_MASK != 0 {
+            sources.push(IrqSource::DmaDone);
+        }
+        if mask & csr_map::IRQ_ERROR_MASK != 0 {
+            sources.push(IrqSource::Error);
+        }
+        sources
+    }
+}
+
+type IrqCallback = fn(IrqSource);
+
+pub struct IrqHandler<M: Mmio> {
+    driver: BitnetDriver<M>,
+    callbacks: [Option<IrqCallback>; 3],
+}
+
+impl<M: Mmio> IrqHandler<M> {
+    pub fn new(driver: BitnetDriver<M>) -> Self {
+        Self {
+            driver,
+            callbacks: [None, None, None],
+        }
+    }
+
+    pub fn register(&mut self, source: IrqSource, cb: IrqCallback) {
+        let idx = match source {
+            IrqSource::InferenceDone => 0,
+            IrqSource::DmaDone => 1,
+            IrqSource::Error => 2,
+        };
+        self.callbacks[idx] = Some(cb);
+    }
+
+    pub fn service(&mut self) -> u32 {
+        let stat = self.driver.read_irq_status();
+        if stat == 0 {
+            return 0;
+        }
+        let sources = IrqSource::from_mask(stat);
+        for src in sources {
+            let idx = match src {
+                IrqSource::InferenceDone => 0,
+                IrqSource::DmaDone => 1,
+                IrqSource::Error => 2,
+            };
+            if let Some(cb) = self.callbacks[idx] {
+                cb(src);
+            }
+        }
+        self.driver.clear_irq(stat);
+        stat
+    }
+
+    pub fn driver(&self) -> &BitnetDriver<M> {
+        &self.driver
+    }
+
+    pub fn driver_mut(&mut self) -> &mut BitnetDriver<M> {
+        &mut self.driver
+    }
+}
+
+pub struct IrqDrivenDriver<M: Mmio> {
+    handler: IrqHandler<M>,
+}
+
+impl<M: Mmio> IrqDrivenDriver<M> {
+    pub fn new(driver: BitnetDriver<M>) -> Self {
+        Self {
+            handler: IrqHandler::new(driver),
+        }
+    }
+
+    pub fn register(&mut self, source: IrqSource, cb: IrqCallback) {
+        self.handler.register(source, cb);
+    }
+
+    pub fn handler(&self) -> &IrqHandler<M> {
+        &self.handler
+    }
+
+    pub fn handler_mut(&mut self) -> &mut IrqHandler<M> {
+        &mut self.handler
+    }
+
+    pub fn wait_done_irq(&mut self, max_service_rounds: u32) -> Result<(), DriverError> {
+        for _ in 0..max_service_rounds {
+            let serviced = self.handler.service();
+            if serviced & csr_map::IRQ_ERROR_MASK != 0 {
+                return Err(DriverError::EngineError);
+            }
+            if serviced & csr_map::IRQ_INFERENCE_DONE_MASK != 0 {
+                return Ok(());
+            }
+            if self.handler.driver_mut().is_done() {
+                return Ok(());
+            }
+        }
+        Err(DriverError::Timeout)
+    }
+
+    pub fn into_handler(self) -> IrqHandler<M> {
+        self.handler
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::host::mmio::MockMmio;
+
+    thread_local! {
+        static FIRED: std::cell::RefCell<Vec<IrqSource>> = std::cell::RefCell::new(Vec::new());
+    }
+
+    fn record_cb(src: IrqSource) {
+        FIRED.with(|f| f.borrow_mut().push(src));
+    }
+
+    fn fired() -> Vec<IrqSource> {
+        FIRED.with(|f| f.borrow().clone())
+    }
+
+    fn clear_fired() {
+        FIRED.with(|f| f.borrow_mut().clear());
+    }
+
+    fn fresh_handler() -> IrqHandler<MockMmio> {
+        IrqHandler::new(BitnetDriver::new(MockMmio::with_csrs_zeroed()))
+    }
+
+    fn fresh_irq_driver() -> IrqDrivenDriver<MockMmio> {
+        IrqDrivenDriver::new(BitnetDriver::new(MockMmio::with_csrs_zeroed()))
+    }
+
+    #[test]
+    fn irq_source_mask_roundtrip() {
+        assert_eq!(IrqSource::InferenceDone.mask(), csr_map::IRQ_INFERENCE_DONE_MASK);
+        assert_eq!(IrqSource::DmaDone.mask(), csr_map::IRQ_DMA_DONE_MASK);
+        assert_eq!(IrqSource::Error.mask(), csr_map::IRQ_ERROR_MASK);
+    }
+
+    #[test]
+    fn from_mask_empty() {
+        assert!(IrqSource::from_mask(0).is_empty());
+    }
+
+    #[test]
+    fn from_mask_all_three() {
+        let sources = IrqSource::from_mask(csr_map::IRQ_ALL_MASK);
+        assert_eq!(sources.len(), 3);
+    }
+
+    #[test]
+    fn handler_service_no_irqs_returns_zero() {
+        let mut h = fresh_handler();
+        assert_eq!(h.service(), 0);
+    }
+
+    #[test]
+    fn handler_service_dispatches_callback() {
+        clear_fired();
+        let mut h = fresh_handler();
+        h.register(IrqSource::InferenceDone, record_cb);
+        h.driver_mut().mmio_mut().latch_irq(csr_map::IRQ_INFERENCE_DONE_MASK);
+        let serviced = h.service();
+        assert_eq!(serviced, csr_map::IRQ_INFERENCE_DONE_MASK);
+        assert_eq!(fired(), vec![IrqSource::InferenceDone]);
+    }
+
+    #[test]
+    fn handler_service_calls_clear_irq() {
+        let mut h = fresh_handler();
+        h.driver_mut().mmio_mut().latch_irq(csr_map::IRQ_INFERENCE_DONE_MASK);
+        h.service();
+        let log = h.driver().mmio().log();
+        let last = log.last().unwrap();
+        assert_eq!(last.op, super::super::mmio::MmioOp::Write);
+        assert_eq!(last.addr, csr_map::IRQ_STAT);
+        assert_eq!(last.value, csr_map::IRQ_INFERENCE_DONE_MASK);
+    }
+
+    #[test]
+    fn handler_multiple_sources() {
+        clear_fired();
+        let mut h = fresh_handler();
+        h.register(IrqSource::InferenceDone, record_cb);
+        h.register(IrqSource::DmaDone, record_cb);
+        h.driver_mut().mmio_mut().latch_irq(
+            csr_map::IRQ_INFERENCE_DONE_MASK | csr_map::IRQ_DMA_DONE_MASK,
+        );
+        let serviced = h.service();
+        assert_eq!(serviced, csr_map::IRQ_INFERENCE_DONE_MASK | csr_map::IRQ_DMA_DONE_MASK);
+        let f = fired();
+        assert!(f.contains(&IrqSource::InferenceDone));
+        assert!(f.contains(&IrqSource::DmaDone));
+    }
+
+    #[test]
+    fn irq_driver_wait_done_succeeds_on_inference_done() {
+        let mut d = fresh_irq_driver();
+        d.handler_mut().driver_mut().mmio_mut().latch_irq(csr_map::IRQ_INFERENCE_DONE_MASK);
+        assert_eq!(d.wait_done_irq(4), Ok(()));
+    }
+
+    #[test]
+    fn irq_driver_wait_done_returns_error_on_irq_error() {
+        let mut d = fresh_irq_driver();
+        d.handler_mut().driver_mut().mmio_mut().latch_irq(csr_map::IRQ_ERROR_MASK);
+        assert_eq!(d.wait_done_irq(4), Err(DriverError::EngineError));
+    }
+
+    #[test]
+    fn irq_driver_wait_done_times_out() {
+        let mut d = fresh_irq_driver();
+        assert_eq!(d.wait_done_irq(2), Err(DriverError::Timeout));
+    }
+
+    #[test]
+    fn irq_driver_wait_done_falls_back_to_done_bit() {
+        let mut d = fresh_irq_driver();
+        d.handler_mut().driver_mut().mmio_mut().set_done(true);
+        assert_eq!(d.wait_done_irq(4), Ok(()));
+    }
+}

--- a/bootstrap/src/host/irq.rs
+++ b/bootstrap/src/host/irq.rs
@@ -110,15 +110,21 @@ impl<M: Mmio> IrqDrivenDriver<M> {
     }
 
     pub fn wait_done_irq(&mut self, max_service_rounds: u32) -> Result<(), DriverError> {
+        self.wait_irq_mask(csr_map::IRQ_INFERENCE_DONE_MASK, max_service_rounds)
+    }
+
+    pub fn wait_irq_mask(&mut self, mask: u32, max_service_rounds: u32) -> Result<(), DriverError> {
         for _ in 0..max_service_rounds {
             let serviced = self.handler.service();
             if serviced & csr_map::IRQ_ERROR_MASK != 0 {
                 return Err(DriverError::EngineError);
             }
-            if serviced & csr_map::IRQ_INFERENCE_DONE_MASK != 0 {
+            if serviced & mask != 0 {
                 return Ok(());
             }
-            if self.handler.driver_mut().is_done() {
+            if mask == csr_map::IRQ_INFERENCE_DONE_MASK
+                && self.handler.driver_mut().is_done()
+            {
                 return Ok(());
             }
         }

--- a/bootstrap/src/host/mod.rs
+++ b/bootstrap/src/host/mod.rs
@@ -15,9 +15,11 @@
 
 pub mod csr_map;
 pub mod driver;
+pub mod engine;
 pub mod irq;
 pub mod mmio;
 
 pub use driver::{BitnetDriver, CsrSnapshot, DriverError};
+pub use engine::{InferenceEngine, InferenceReport};
 pub use irq::{IrqDrivenDriver, IrqHandler, IrqSource};
 pub use mmio::{MmioOp, MmioRecord, MockMmio};

--- a/bootstrap/src/host/mod.rs
+++ b/bootstrap/src/host/mod.rs
@@ -15,7 +15,9 @@
 
 pub mod csr_map;
 pub mod driver;
+pub mod irq;
 pub mod mmio;
 
 pub use driver::{BitnetDriver, CsrSnapshot, DriverError};
+pub use irq::{IrqDrivenDriver, IrqHandler, IrqSource};
 pub use mmio::{MmioOp, MmioRecord, MockMmio};

--- a/bootstrap/src/main.rs
+++ b/bootstrap/src/main.rs
@@ -349,6 +349,40 @@ enum Commands {
         max_polls: u32,
     },
 
+    /// Run a side-by-side poll-vs-IRQ comparison on MockMmio (Wave 40, R-HS-2).
+    ///
+    /// Executes the same configure -> start -> complete flow twice: once via
+    /// the poll-mode `wait_done` path (W39) and once via the interrupt-driven
+    /// `IrqDrivenDriver::wait_done_irq` path (W40). Prints a single comparison
+    /// line: `OK poll=Nw/Mr irq=Nw/Mr writes_match=<bool> irq_stat_poll=0x..
+    /// irq_stat_irq=0x..`.
+    #[command(name = "host-poll-vs-irq")]
+    HostPollVsIrq {
+        /// Number of layers to program (default: 2).
+        #[arg(long, default_value_t = 2)]
+        num_layers: u32,
+
+        /// Neurons per layer (default: 16).
+        #[arg(long, default_value_t = 16)]
+        neurons: u32,
+
+        /// Chunks per neuron (default: 4).
+        #[arg(long, default_value_t = 4)]
+        chunks: u32,
+
+        /// Signed threshold value (default: 1).
+        #[arg(long, default_value_t = 1)]
+        threshold: u32,
+
+        /// 64-bit weight base address as decimal (default: 0).
+        #[arg(long, default_value_t = 0)]
+        weight_addr: u64,
+
+        /// Maximum poll iterations before timeout (default: 16).
+        #[arg(long, default_value_t = 16)]
+        max_polls: u32,
+    },
+
     /// Emit a complete BitNet HLS bundle (Wave 38, R-SI-1).
     ///
     /// Composes all 9 BitNet HLS module emitters (W36a-f) plus the
@@ -3047,6 +3081,64 @@ fn run_host_smoke(
         snap.threshold,
         snap.weight_addr_64(),
         snap.irq_stat
+    );
+    Ok(())
+}
+
+fn run_host_poll_vs_irq(
+    num_layers: u32,
+    neurons: u32,
+    chunks: u32,
+    threshold: u32,
+    weight_addr: u64,
+    max_polls: u32,
+) -> anyhow::Result<()> {
+    use host::{BitnetDriver, IrqDrivenDriver, MockMmio};
+    let poll_writes;
+    let poll_reads;
+    let irq_stat_poll;
+    {
+        let mut driver = BitnetDriver::new(MockMmio::with_csrs_zeroed());
+        driver
+            .configure(num_layers, neurons, chunks, threshold, weight_addr)
+            .map_err(|e| anyhow::anyhow!("poll configure failed: {:?}", e))?;
+        driver.enable_irqs(host::csr_map::IRQ_ALL_MASK);
+        driver.start();
+        driver.mmio_mut().set_done(true);
+        driver.mmio_mut().latch_irq(host::csr_map::IRQ_INFERENCE_DONE_MASK);
+        driver
+            .wait_done(max_polls)
+            .map_err(|e| anyhow::anyhow!("poll wait_done failed: {:?}", e))?;
+        poll_writes = driver.mmio().write_count();
+        poll_reads = driver.mmio().read_count();
+        irq_stat_poll = driver.dump().irq_stat;
+    }
+    let irq_writes;
+    let irq_reads;
+    let irq_stat_irq;
+    {
+        let mut idd = IrqDrivenDriver::new(BitnetDriver::new(MockMmio::with_csrs_zeroed()));
+        idd.handler_mut()
+            .driver_mut()
+            .configure(num_layers, neurons, chunks, threshold, weight_addr)
+            .map_err(|e| anyhow::anyhow!("irq configure failed: {:?}", e))?;
+        idd.handler_mut().driver_mut().enable_irqs(host::csr_map::IRQ_ALL_MASK);
+        idd.handler_mut().driver_mut().start();
+        idd.handler_mut().driver_mut().mmio_mut().set_done(true);
+        idd.handler_mut()
+            .driver_mut()
+            .mmio_mut()
+            .latch_irq(host::csr_map::IRQ_INFERENCE_DONE_MASK);
+        idd.wait_done_irq(max_polls)
+            .map_err(|e| anyhow::anyhow!("irq wait_done_irq failed: {:?}", e))?;
+        irq_writes = idd.handler().driver().mmio().write_count();
+        irq_reads = idd.handler().driver().mmio().read_count();
+        irq_stat_irq = idd.handler_mut().driver_mut().dump().irq_stat;
+    }
+    let writes_match = poll_writes == irq_writes;
+    println!(
+        "OK poll={}w/{}r irq={}w/{}r writes_match={} irq_stat_poll=0x{:08x} irq_stat_irq=0x{:08x}",
+        poll_writes, poll_reads, irq_writes, irq_reads, writes_match, irq_stat_poll, irq_stat_irq
     );
     Ok(())
 }
@@ -7859,6 +7951,9 @@ async fn main() -> anyhow::Result<()> {
         Commands::HostSmoke { num_layers, neurons, chunks, threshold, weight_addr, max_polls } => {
             run_host_smoke(num_layers, neurons, chunks, threshold, weight_addr, max_polls)?
         }
+        Commands::HostPollVsIrq { num_layers, neurons, chunks, threshold, weight_addr, max_polls } => {
+            run_host_poll_vs_irq(num_layers, neurons, chunks, threshold, weight_addr, max_polls)?
+        }
         Commands::Asm { input, output, format } => run_asm(&input, output.as_deref(), &format)?,
         Commands::GenTestbench { input, period_ns, max_cycles, output } => {
             run_gen_testbench(&input, period_ns, max_cycles, output.as_deref())?
@@ -8096,6 +8191,9 @@ fn main() -> anyhow::Result<()> {
         }
         Commands::HostSmoke { num_layers, neurons, chunks, threshold, weight_addr, max_polls } => {
             run_host_smoke(num_layers, neurons, chunks, threshold, weight_addr, max_polls)?
+        }
+        Commands::HostPollVsIrq { num_layers, neurons, chunks, threshold, weight_addr, max_polls } => {
+            run_host_poll_vs_irq(num_layers, neurons, chunks, threshold, weight_addr, max_polls)?
         }
         Commands::Asm { input, output, format } => run_asm(&input, output.as_deref(), &format)?,
         Commands::GenTestbench { input, period_ns, max_cycles, output } => {

--- a/bootstrap/src/main.rs
+++ b/bootstrap/src/main.rs
@@ -383,6 +383,39 @@ enum Commands {
         max_polls: u32,
     },
 
+    /// Run a multi-layer DMA-driven BitNet inference flow on MockMmio
+    /// (Wave 41, R-HS-3).
+    ///
+    /// Exercises the full configure -> DMA prefetch -> inference ->
+    /// DMA drain cycle per layer, using IrqDrivenDriver from W40.
+    /// Prints `OK layers=N completed=M writes=W reads=R`.
+    #[command(name = "host-inference")]
+    HostInference {
+        /// Number of layers to program (default: 2).
+        #[arg(long, default_value_t = 2)]
+        num_layers: u32,
+
+        /// Neurons per layer (default: 16).
+        #[arg(long, default_value_t = 16)]
+        neurons: u32,
+
+        /// Chunks per neuron (default: 4).
+        #[arg(long, default_value_t = 4)]
+        chunks: u32,
+
+        /// Signed threshold value (default: 1).
+        #[arg(long, default_value_t = 1)]
+        threshold: u32,
+
+        /// 64-bit weight base address as decimal (default: 0).
+        #[arg(long, default_value_t = 0)]
+        weight_addr: u64,
+
+        /// Maximum IRQ-service rounds per stage (default: 16).
+        #[arg(long, default_value_t = 16)]
+        max_rounds: u32,
+    },
+
     /// Emit a complete BitNet HLS bundle (Wave 38, R-SI-1).
     ///
     /// Composes all 9 BitNet HLS module emitters (W36a-f) plus the
@@ -3139,6 +3172,28 @@ fn run_host_poll_vs_irq(
     println!(
         "OK poll={}w/{}r irq={}w/{}r writes_match={} irq_stat_poll=0x{:08x} irq_stat_irq=0x{:08x}",
         poll_writes, poll_reads, irq_writes, irq_reads, writes_match, irq_stat_poll, irq_stat_irq
+    );
+    Ok(())
+}
+
+fn run_host_inference(
+    num_layers: u32,
+    neurons: u32,
+    chunks: u32,
+    threshold: u32,
+    weight_addr: u64,
+    max_rounds: u32,
+) -> anyhow::Result<()> {
+    use host::{BitnetDriver, InferenceEngine, MockMmio};
+    let mut engine = InferenceEngine::new(BitnetDriver::new(MockMmio::with_csrs_zeroed()));    engine
+        .configure(num_layers, neurons, chunks, threshold, weight_addr)
+        .map_err(|e| anyhow::anyhow!("configure failed: {:?}", e))?;
+    let report = engine
+        .run(max_rounds)
+        .map_err(|e| anyhow::anyhow!("inference failed: {:?}", e))?;
+    println!(
+        "OK layers={} completed={} writes={} reads={}",
+        report.total_layers, report.layers_completed, report.total_writes, report.total_reads
     );
     Ok(())
 }
@@ -7954,6 +8009,9 @@ async fn main() -> anyhow::Result<()> {
         Commands::HostPollVsIrq { num_layers, neurons, chunks, threshold, weight_addr, max_polls } => {
             run_host_poll_vs_irq(num_layers, neurons, chunks, threshold, weight_addr, max_polls)?
         }
+        Commands::HostInference { num_layers, neurons, chunks, threshold, weight_addr, max_rounds } => {
+            run_host_inference(num_layers, neurons, chunks, threshold, weight_addr, max_rounds)?
+        }
         Commands::Asm { input, output, format } => run_asm(&input, output.as_deref(), &format)?,
         Commands::GenTestbench { input, period_ns, max_cycles, output } => {
             run_gen_testbench(&input, period_ns, max_cycles, output.as_deref())?
@@ -8194,6 +8252,9 @@ fn main() -> anyhow::Result<()> {
         }
         Commands::HostPollVsIrq { num_layers, neurons, chunks, threshold, weight_addr, max_polls } => {
             run_host_poll_vs_irq(num_layers, neurons, chunks, threshold, weight_addr, max_polls)?
+        }
+        Commands::HostInference { num_layers, neurons, chunks, threshold, weight_addr, max_rounds } => {
+            run_host_inference(num_layers, neurons, chunks, threshold, weight_addr, max_rounds)?
         }
         Commands::Asm { input, output, format } => run_asm(&input, output.as_deref(), &format)?,
         Commands::GenTestbench { input, period_ns, max_cycles, output } => {

--- a/bootstrap/tests/host_engine.rs
+++ b/bootstrap/tests/host_engine.rs
@@ -1,0 +1,162 @@
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_t27c")
+}
+
+fn run(args: &[&str]) -> (bool, String, String) {
+    let out = Command::new(bin())
+        .args(args)
+        .output()
+        .expect("failed to spawn t27c");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+#[test]
+fn inference_default_succeeds() {
+    let (ok, stdout, _) = run(&["host-inference"]);
+    assert!(ok, "default should succeed");
+    assert!(stdout.starts_with("OK "), "stdout = {stdout}");
+}
+
+#[test]
+fn inference_prints_layer_count() {
+    let (ok, stdout, _) = run(&["host-inference"]);
+    assert!(ok);
+    assert!(stdout.contains("layers=2"), "stdout = {stdout}");
+}
+
+#[test]
+fn inference_prints_completed_count() {
+    let (ok, stdout, _) = run(&["host-inference"]);
+    assert!(ok);
+    assert!(stdout.contains("completed=2"), "stdout = {stdout}");
+}
+
+#[test]
+fn inference_prints_writes() {
+    let (ok, stdout, _) = run(&["host-inference"]);
+    assert!(ok);
+    assert!(stdout.contains("writes="), "stdout = {stdout}");
+}
+
+#[test]
+fn inference_prints_reads() {
+    let (ok, stdout, _) = run(&["host-inference"]);
+    assert!(ok);
+    assert!(stdout.contains("reads="), "stdout = {stdout}");
+}
+
+#[test]
+fn inference_single_layer() {
+    let (ok, stdout, _) = run(&["host-inference", "--num-layers", "1"]);
+    assert!(ok);
+    assert!(stdout.contains("layers=1 completed=1"), "stdout = {stdout}");
+}
+
+#[test]
+fn inference_three_layers() {
+    let (ok, stdout, _) = run(&["host-inference", "--num-layers", "3"]);
+    assert!(ok);
+    assert!(stdout.contains("layers=3 completed=3"), "stdout = {stdout}");
+}
+
+#[test]
+fn inference_custom_neurons() {
+    let (ok, stdout, _) = run(&["host-inference", "--neurons", "128"]);
+    assert!(ok);
+}
+
+#[test]
+fn inference_custom_chunks() {
+    let (ok, stdout, _) = run(&["host-inference", "--chunks", "32"]);
+    assert!(ok);
+}
+
+#[test]
+fn inference_custom_threshold() {
+    let (ok, stdout, _) = run(&["host-inference", "--threshold", "42"]);
+    assert!(ok);
+}
+
+#[test]
+fn inference_custom_weight_addr() {
+    let (ok, stdout, _) = run(&["host-inference", "--weight-addr", "1099511627776"]);
+    assert!(ok);
+}
+
+#[test]
+fn inference_zero_layers_fails() {
+    let (ok, _, stderr) = run(&["host-inference", "--num-layers", "0"]);
+    assert!(!ok);
+    assert!(stderr.contains("configure") || stderr.contains("InvalidConfig"));
+}
+
+#[test]
+fn inference_zero_neurons_fails() {
+    let (ok, _, _stderr) = run(&["host-inference", "--neurons", "0"]);
+    assert!(!ok);
+}
+
+#[test]
+fn inference_zero_chunks_fails() {
+    let (ok, _, _stderr) = run(&["host-inference", "--chunks", "0"]);
+    assert!(!ok);
+}
+
+#[test]
+fn inference_deterministic() {
+    let (ok1, s1, _) = run(&["host-inference"]);
+    let (ok2, s2, _) = run(&["host-inference"]);
+    assert!(ok1 && ok2);
+    assert_eq!(s1, s2, "should be deterministic");
+}
+
+#[test]
+fn inference_single_line_output() {
+    let (ok, stdout, _) = run(&["host-inference"]);
+    assert!(ok);
+    let trimmed = stdout.trim_end_matches('\n');
+    assert!(!trimmed.contains('\n'), "expected single line, got {stdout}");
+}
+
+#[test]
+fn inference_no_stderr_on_success() {
+    let (ok, _, stderr) = run(&["host-inference"]);
+    assert!(ok);
+    assert!(stderr.trim().is_empty(), "stderr should be empty: {stderr}");
+}
+
+#[test]
+fn inference_combined_overrides() {
+    let (ok, stdout, _) = run(&[
+        "host-inference",
+        "--num-layers", "3",
+        "--neurons", "64",
+        "--chunks", "8",
+        "--threshold", "42",
+        "--weight-addr", "1024",
+    ]);
+    assert!(ok);
+    assert!(stdout.contains("layers=3 completed=3"));
+}
+
+#[test]
+fn inference_help_lists_all_flags() {
+    let (ok, stdout, _) = run(&["host-inference", "--help"]);
+    assert!(ok);
+    for flag in ["--num-layers", "--neurons", "--chunks", "--threshold", "--weight-addr", "--max-rounds"] {
+        assert!(stdout.contains(flag), "missing {flag} in help: {stdout}");
+    }
+}
+
+#[test]
+fn inference_help_mentions_wave_41() {
+    let (ok, stdout, _) = run(&["host-inference", "--help"]);
+    assert!(ok);
+    assert!(stdout.contains("Wave 41") || stdout.contains("R-HS-3"), "expected Wave 41 / R-HS-3: {stdout}");
+}

--- a/bootstrap/tests/host_irq.rs
+++ b/bootstrap/tests/host_irq.rs
@@ -1,0 +1,169 @@
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_t27c")
+}
+
+fn run(args: &[&str]) -> (bool, String, String) {
+    let out = Command::new(bin())
+        .args(args)
+        .output()
+        .expect("failed to spawn t27c");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+#[test]
+fn poll_vs_irq_default_succeeds() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq"]);
+    assert!(ok, "default should succeed");
+    assert!(stdout.starts_with("OK "), "stdout = {stdout}");
+}
+
+#[test]
+fn poll_vs_irq_prints_poll_metrics() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq"]);
+    assert!(ok);
+    assert!(stdout.contains("poll="), "stdout = {stdout}");
+}
+
+#[test]
+fn poll_vs_irq_prints_irq_metrics() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq"]);
+    assert!(ok);
+    assert!(stdout.contains("irq="), "stdout = {stdout}");
+}
+
+#[test]
+fn poll_vs_irq_writes_match_field_present() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq"]);
+    assert!(ok);
+    assert!(stdout.contains("writes_match="), "stdout = {stdout}");
+}
+
+#[test]
+fn poll_vs_irq_prints_irq_stat_poll() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq"]);
+    assert!(ok);
+    assert!(stdout.contains("irq_stat_poll=0x"), "stdout = {stdout}");
+}
+
+#[test]
+fn poll_vs_irq_prints_irq_stat_irq() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq"]);
+    assert!(ok);
+    assert!(stdout.contains("irq_stat_irq=0x"), "stdout = {stdout}");
+}
+
+#[test]
+fn poll_vs_irq_custom_layers() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq", "--num-layers", "5"]);
+    assert!(ok);
+    assert!(stdout.starts_with("OK "));
+}
+
+#[test]
+fn poll_vs_irq_custom_neurons() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq", "--neurons", "128"]);
+    assert!(ok);
+}
+
+#[test]
+fn poll_vs_irq_custom_chunks() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq", "--chunks", "32"]);
+    assert!(ok);
+}
+
+#[test]
+fn poll_vs_irq_custom_threshold() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq", "--threshold", "7"]);
+    assert!(ok);
+}
+
+#[test]
+fn poll_vs_irq_custom_weight_addr() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq", "--weight-addr", "1099511627776"]);
+    assert!(ok);
+}
+
+#[test]
+fn poll_vs_irq_zero_layers_fails() {
+    let (ok, _, stderr) = run(&["host-poll-vs-irq", "--num-layers", "0"]);
+    assert!(!ok);
+    assert!(stderr.contains("configure") || stderr.contains("InvalidConfig"));
+}
+
+#[test]
+fn poll_vs_irq_zero_neurons_fails() {
+    let (ok, _, _stderr) = run(&["host-poll-vs-irq", "--neurons", "0"]);
+    assert!(!ok);
+}
+
+#[test]
+fn poll_vs_irq_zero_chunks_fails() {
+    let (ok, _, _stderr) = run(&["host-poll-vs-irq", "--chunks", "0"]);
+    assert!(!ok);
+}
+
+#[test]
+fn poll_vs_irq_max_polls_one_succeeds() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq", "--max-polls", "1"]);
+    assert!(ok, "done is preset, 1 poll is enough");
+    assert!(stdout.starts_with("OK "));
+}
+
+#[test]
+fn poll_vs_irq_deterministic() {
+    let (ok1, s1, _) = run(&["host-poll-vs-irq"]);
+    let (ok2, s2, _) = run(&["host-poll-vs-irq"]);
+    assert!(ok1 && ok2);
+    assert_eq!(s1, s2, "should be deterministic");
+}
+
+#[test]
+fn poll_vs_irq_single_line_output() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq"]);
+    assert!(ok);
+    let trimmed = stdout.trim_end_matches('\n');
+    assert!(!trimmed.contains('\n'), "expected single line, got {stdout}");
+}
+
+#[test]
+fn poll_vs_irq_no_stderr_on_success() {
+    let (ok, _, stderr) = run(&["host-poll-vs-irq"]);
+    assert!(ok);
+    assert!(stderr.trim().is_empty(), "stderr should be empty: {stderr}");
+}
+
+#[test]
+fn poll_vs_irq_combined_overrides() {
+    let (ok, stdout, _) = run(&[
+        "host-poll-vs-irq",
+        "--num-layers", "3",
+        "--neurons", "64",
+        "--chunks", "8",
+        "--threshold", "42",
+        "--weight-addr", "1024",
+    ]);
+    assert!(ok);
+    assert!(stdout.contains("writes_match="));
+}
+
+#[test]
+fn poll_vs_irq_help_lists_all_flags() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq", "--help"]);
+    assert!(ok);
+    for flag in ["--num-layers", "--neurons", "--chunks", "--threshold", "--weight-addr", "--max-polls"] {
+        assert!(stdout.contains(flag), "missing {flag} in help: {stdout}");
+    }
+}
+
+#[test]
+fn poll_vs_irq_help_mentions_wave_40() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq", "--help"]);
+    assert!(ok);
+    assert!(stdout.contains("Wave 40") || stdout.contains("R-HS-2"), "expected Wave 40 / R-HS-2: {stdout}");
+}

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,12 @@
 
 Last updated: 2026-05-23
 
+## wave-41 -- t27c host-inference -- DMA-driven multi-layer BitNet inference flow (R-HS-3, Closes #789)
+
+- **WHERE** (bootstrap-only, additive): new file `bootstrap/src/host/engine.rs` (`InferenceEngine`, `InferenceReport`, per-layer DMA prefetch → inference → DMA drain cycle; 16 inline unit tests); updated `bootstrap/src/host/irq.rs` (`wait_irq_mask` generic IRQ wait, refactored from `wait_done_irq`); updated `bootstrap/src/host/mod.rs`; new CLI `Commands::HostInference` + `run_host_inference()`; new test file `bootstrap/tests/host_engine.rs` (20 integration tests).
+- **Why** (R-HS-3): W40 gave us IRQ-driven single-completion. W41 orchestrates the full multi-layer BitNet inference flow: for each layer, DMA prefetch weights (wait DmaDone IRQ), start inference (wait InferenceDone IRQ), DMA drain output (wait DmaDone IRQ). Uses `wait_irq_mask()` — a new generic IRQ-wait method on `IrqDrivenDriver` that waits for any mask, not just inference-done.
+- **Tests**: 36 new (16 inline + 20 integration). All pass. Zero regressions.
+
 ## wave-40 -- t27c host-poll-vs-irq -- IRQ-handler harness + poll-vs-IRQ comparison (R-HS-2, Closes #786)
 
 - **WHERE** (bootstrap-only, additive): new file `bootstrap/src/host/irq.rs` (`IrqSource` enum, `IrqHandler<M>` callback registry, `IrqDrivenDriver<M>` with `wait_done_irq`; 11 inline unit tests); updated `bootstrap/src/host/mod.rs`; new CLI `Commands::HostPollVsIrq` + `run_host_poll_vs_irq()`; new test file `bootstrap/tests/host_irq.rs` (21 integration tests).

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,12 @@
 
 Last updated: 2026-05-23
 
+## wave-40 -- t27c host-poll-vs-irq -- IRQ-handler harness + poll-vs-IRQ comparison (R-HS-2, Closes #786)
+
+- **WHERE** (bootstrap-only, additive): new file `bootstrap/src/host/irq.rs` (`IrqSource` enum, `IrqHandler<M>` callback registry, `IrqDrivenDriver<M>` with `wait_done_irq`; 11 inline unit tests); updated `bootstrap/src/host/mod.rs`; new CLI `Commands::HostPollVsIrq` + `run_host_poll_vs_irq()`; new test file `bootstrap/tests/host_irq.rs` (21 integration tests).
+- **Why** (R-HS-2): W39 added poll-mode driver. W40 adds interrupt-driven completion path with callback dispatch and side-by-side poll-vs-IRQ comparison on MockMmio.
+- **Tests**: 32 new (11 inline + 21 integration). All pass.
+
 ## wave-39 -- t27c host-side Rust driver module: BitNet AXI-Lite CSR aperture (R-HS-1, Closes #784)
 
 - **WHERE** (bootstrap-only, additive): new directory `bootstrap/src/host/` with four files -- `mod.rs` (re-exports), `csr_map.rs` (10 CSR offset constants + status/IRQ bit masks + 10 inline unit tests), `mmio.rs` (`Mmio` trait + `MockMmio` deterministic BTreeMap backend + transaction log + 10 inline unit tests), `driver.rs` (`BitnetDriver<M: Mmio>` orchestrator with configure / start / poll / IRQ / dump methods + `CsrSnapshot` struct + `DriverError` enum + 11 inline unit tests). One new `mod host;` declaration in `bootstrap/src/main.rs`. One new CLI subcommand `Commands::HostSmoke { num_layers, neurons, chunks, threshold, weight_addr, max_polls }` registered in the `Commands` enum and dispatched in both HTTP-server and CLI match arms via `run_host_smoke(...)`. **Zero** edits under `gen/`, `coq/`, `trios-coq/`, `proofs/`, `specs/`, `conformance/`, `architecture/`, `rings/`, root `Cargo.toml`. Doc-only update to this file. New test file `bootstrap/tests/host_driver.rs` (25 integration tests via `CARGO_BIN_EXE_t27c`).


### PR DESCRIPTION
## Wave 41 — R-HS-3: DMA-driven multi-layer BitNet inference flow

Closes #789

### What changed

- **New file** `bootstrap/src/host/engine.rs`:
  - `InferenceEngine` with per-layer: DMA prefetch (wait DmaDone) → inference (wait InferenceDone) → DMA drain (wait DmaDone)
  - `InferenceReport` (total_layers, layers_completed, error_layer, writes, reads)
  - 16 inline unit tests

- **Updated** `bootstrap/src/host/irq.rs`:
  - `wait_irq_mask(mask, max_rounds)` — generic IRQ wait for any mask
  - `wait_done_irq` refactored to delegate to `wait_irq_mask`

- **Updated** `bootstrap/src/host/mod.rs`: `pub mod engine` + re-exports

- **Updated** `bootstrap/src/main.rs`:
  - New CLI `Commands::HostInference` with `--max-rounds` flag
  - `run_host_inference()` prints `OK layers=N completed=M writes=W reads=R`

- **New file** `bootstrap/tests/host_engine.rs`: 20 integration tests

- **Updated** `docs/NOW.md`: wave-41 entry

### Test results

```
58/58 inline host tests pass
25/25 host_driver integration tests pass
21/21 host_irq integration tests pass
20/20 host_engine integration tests pass
= 36 new tests, zero regressions
```