### PR TITLE
feat(bootstrap): end-to-end host stack integration (Wave 46, R-HS-6)

### DIFF
--- a/bootstrap/src/host/e2e.rs
+++ b/bootstrap/src/host/e2e.rs
@@ -1,0 +1,221 @@
+use super::engine::InferenceReport;
+use super::perf::{EngineConfig, PerformanceEstimate};
+use super::weights::{WeightConfig, WeightPattern};
+
+#[derive(Debug, Clone)]
+pub struct E2eResult {
+    pub layers: u32,
+    pub neurons: u32,
+    pub chunks: u32,
+    pub pattern: String,
+    pub weight_words: usize,
+    pub inference: InferenceReport,
+    pub estimate: PerformanceEstimate,
+    pub weight_gen_ok: bool,
+}
+
+pub struct E2eConfig {
+    pub num_layers: u32,
+    pub neurons: u32,
+    pub chunks: u32,
+    pub threshold: u32,
+    pub weight_addr: u64,
+    pub pattern: WeightPattern,
+    pub max_rounds: u32,
+}
+
+impl E2eConfig {
+    pub fn perf_config(&self) -> Option<EngineConfig> {
+        EngineConfig::new(self.num_layers, self.neurons, self.chunks)
+    }
+}
+
+pub fn run_e2e(config: &E2eConfig) -> anyhow::Result<E2eResult> {
+    let weight_config = WeightConfig {
+        neurons: config.neurons,
+        chunks: config.chunks,
+        pattern: config.pattern,
+    };
+    let weight_words = super::weights::generate_weights(&weight_config);
+    let weight_gen_ok = !weight_words.is_empty();
+
+    let mut engine = super::engine::InferenceEngine::new(
+        super::driver::BitnetDriver::new(super::mmio::MockMmio::with_csrs_zeroed()),
+    );
+    engine
+        .configure(config.num_layers, config.neurons, config.chunks, config.threshold, config.weight_addr)
+        .map_err(|e| anyhow::anyhow!("configure: {:?}", e))?;
+    let inference = engine
+        .run(config.max_rounds)
+        .map_err(|e| anyhow::anyhow!("inference: {:?}", e))?;
+
+    let perf_config = config.perf_config()
+        .ok_or_else(|| anyhow::anyhow!("invalid perf config"))?;
+    let estimate = perf_config.estimate();
+
+    Ok(E2eResult {
+        layers: config.num_layers,
+        neurons: config.neurons,
+        chunks: config.chunks,
+        pattern: super::weights::pattern_name(config.pattern).to_string(),
+        weight_words: weight_words.len(),
+        inference,
+        estimate,
+        weight_gen_ok,
+    })
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct E2eJson {
+    pub ok: bool,
+    pub layers: u32,
+    pub neurons: u32,
+    pub chunks: u32,
+    pub pattern: String,
+    pub weight_words: usize,
+    pub layers_completed: u32,
+    pub total_writes: usize,
+    pub total_reads: usize,
+    pub estimated_cycles: u32,
+    pub estimated_dma_beats: u32,
+    pub bram_pct: f64,
+    pub weight_gen_ok: bool,
+}
+
+impl E2eJson {
+    pub fn from_result(r: &E2eResult) -> Self {
+        Self {
+            ok: r.inference.error_layer.is_none(),
+            layers: r.layers,
+            neurons: r.neurons,
+            chunks: r.chunks,
+            pattern: r.pattern.clone(),
+            weight_words: r.weight_words,
+            layers_completed: r.inference.layers_completed,
+            total_writes: r.inference.total_writes,
+            total_reads: r.inference.total_reads,
+            estimated_cycles: r.estimate.total_inference_cycles,
+            estimated_dma_beats: r.estimate.total_dma_beats,
+            bram_pct: r.estimate.bram_utilization_pct,
+            weight_gen_ok: r.weight_gen_ok,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_config() -> E2eConfig {
+        E2eConfig {
+            num_layers: 2,
+            neurons: 16,
+            chunks: 4,
+            threshold: 1,
+            weight_addr: 0,
+            pattern: WeightPattern::Alternating,
+            max_rounds: 4,
+        }
+    }
+
+    #[test]
+    fn e2e_default_succeeds() {
+        let result = run_e2e(&default_config()).unwrap();
+        assert!(result.weight_gen_ok);
+    }
+
+    #[test]
+    fn e2e_all_layers_complete() {
+        let result = run_e2e(&default_config()).unwrap();
+        assert_eq!(result.inference.layers_completed, result.layers);
+    }
+
+    #[test]
+    fn e2e_no_error_layer() {
+        let result = run_e2e(&default_config()).unwrap();
+        assert!(result.inference.error_layer.is_none());
+    }
+
+    #[test]
+    fn e2e_weight_words_match_config() {
+        let result = run_e2e(&default_config()).unwrap();
+        assert_eq!(result.weight_words, 16 * 4);
+    }
+
+    #[test]
+    fn e2e_has_mmio_transactions() {
+        let result = run_e2e(&default_config()).unwrap();
+        assert!(result.inference.total_writes > 0);
+        assert!(result.inference.total_reads > 0);
+    }
+
+    #[test]
+    fn e2e_estimate_has_cycles() {
+        let result = run_e2e(&default_config()).unwrap();
+        assert!(result.estimate.total_inference_cycles > 0);
+    }
+
+    #[test]
+    fn e2e_single_layer() {
+        let mut cfg = default_config();
+        cfg.num_layers = 1;
+        let result = run_e2e(&cfg).unwrap();
+        assert_eq!(result.inference.layers_completed, 1);
+    }
+
+    #[test]
+    fn e2e_five_layers() {
+        let mut cfg = default_config();
+        cfg.num_layers = 5;
+        let result = run_e2e(&cfg).unwrap();
+        assert_eq!(result.inference.layers_completed, 5);
+    }
+
+    #[test]
+    fn e2e_all_n_pattern() {
+        let mut cfg = default_config();
+        cfg.pattern = WeightPattern::AllN;
+        let result = run_e2e(&cfg).unwrap();
+        assert!(result.weight_gen_ok);
+    }
+
+    #[test]
+    fn e2e_seeded_random_pattern() {
+        let mut cfg = default_config();
+        cfg.pattern = WeightPattern::SeededRandom(123);
+        let result = run_e2e(&cfg).unwrap();
+        assert!(result.weight_gen_ok);
+    }
+
+    #[test]
+    fn e2e_json_serializable() {
+        let result = run_e2e(&default_config()).unwrap();
+        let json = E2eJson::from_result(&result);
+        let s = serde_json::to_string(&json).unwrap();
+        assert!(s.contains("\"ok\":true"));
+    }
+
+    #[test]
+    fn e2e_json_has_all_fields() {
+        let result = run_e2e(&default_config()).unwrap();
+        let json = E2eJson::from_result(&result);
+        let v: serde_json::Value = serde_json::to_string(&json).unwrap().parse().unwrap();
+        assert!(v["layers"].is_number());
+        assert!(v["weight_words"].is_number());
+        assert!(v["estimated_cycles"].is_number());
+        assert!(v["bram_pct"].is_number());
+    }
+
+    #[test]
+    fn e2e_writes_increase_with_layers() {
+        let mut cfg1 = default_config();
+        cfg1.num_layers = 1;
+        let r1 = run_e2e(&cfg1).unwrap();
+
+        let mut cfg2 = default_config();
+        cfg2.num_layers = 4;
+        let r2 = run_e2e(&cfg2).unwrap();
+
+        assert!(r2.inference.total_writes > r1.inference.total_writes);
+    }
+}

--- a/bootstrap/src/host/engine.rs
+++ b/bootstrap/src/host/engine.rs
@@ -1,0 +1,316 @@
+use super::csr_map;
+use super::driver::{BitnetDriver, DriverError};
+use super::irq::IrqDrivenDriver;
+use super::mmio::MockMmio;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InferenceReport {
+    pub total_layers: u32,
+    pub layers_completed: u32,
+    pub error_layer: Option<u32>,
+    pub total_writes: usize,
+    pub total_reads: usize,
+}
+
+pub struct InferenceEngine {
+    driver: IrqDrivenDriver<MockMmio>,
+    num_layers: u32,
+    neurons: u32,
+    chunks: u32,
+    threshold: u32,
+    weight_addr: u64,
+}
+
+impl InferenceEngine {
+    pub fn new(driver: BitnetDriver<MockMmio>) -> Self {
+        Self {
+            driver: IrqDrivenDriver::new(driver),
+            num_layers: 2,
+            neurons: 16,
+            chunks: 4,
+            threshold: 1,
+            weight_addr: 0,
+        }
+    }
+
+    pub fn configure(
+        &mut self,
+        num_layers: u32,
+        neurons: u32,
+        chunks: u32,
+        threshold: u32,
+        weight_addr: u64,
+    ) -> Result<(), DriverError> {
+        if num_layers == 0 || neurons == 0 || chunks == 0 {
+            return Err(DriverError::InvalidConfig);
+        }
+        self.num_layers = num_layers;
+        self.neurons = neurons;
+        self.chunks = chunks;
+        self.threshold = threshold;
+        self.weight_addr = weight_addr;
+        Ok(())
+    }
+
+    pub fn run(&mut self, max_rounds_per_stage: u32) -> Result<InferenceReport, DriverError> {
+        self.driver
+            .handler_mut()
+            .driver_mut()
+            .configure(
+                self.num_layers,
+                self.neurons,
+                self.chunks,
+                self.threshold,
+                self.weight_addr,
+            )?;
+        self.driver
+            .handler_mut()
+            .driver_mut()
+            .enable_irqs(csr_map::IRQ_ALL_MASK);
+
+        let mut layers_completed: u32 = 0;
+        let mut error_layer: Option<u32> = None;
+
+        for layer in 0..self.num_layers {
+            let layer_weight_addr = self.weight_addr.wrapping_add(
+                (layer as u64) * 0x1_0000 * (self.neurons as u64) * (self.chunks as u64),
+            );
+            self.driver
+                .handler_mut()
+                .driver_mut()
+                .mmio_mut()
+                .poke(csr_map::WEIGHT_ADDR_LO, layer_weight_addr as u32);
+            self.driver
+                .handler_mut()
+                .driver_mut()
+                .mmio_mut()
+                .poke(csr_map::WEIGHT_ADDR_HI, (layer_weight_addr >> 32) as u32);
+
+            self.driver
+                .handler_mut()
+                .driver_mut()
+                .mmio_mut()
+                .latch_irq(csr_map::IRQ_DMA_DONE_MASK);
+            if let Err(e) = self.wait_dma_done(max_rounds_per_stage) {
+                error_layer = Some(layer);
+                if e == DriverError::EngineError {
+                    break;
+                }
+                return Err(e);
+            }
+
+            self.driver.handler_mut().driver_mut().start();
+            self.driver
+                .handler_mut()
+                .driver_mut()
+                .mmio_mut()
+                .latch_irq(csr_map::IRQ_INFERENCE_DONE_MASK);
+            self.driver
+                .handler_mut()
+                .driver_mut()
+                .mmio_mut()
+                .set_done(true);
+            if let Err(e) = self.wait_inference_done(max_rounds_per_stage) {
+                error_layer = Some(layer);
+                if e == DriverError::EngineError {
+                    break;
+                }
+                return Err(e);
+            }
+
+            self.driver
+                .handler_mut()
+                .driver_mut()
+                .mmio_mut()
+                .latch_irq(csr_map::IRQ_DMA_DONE_MASK);
+            if let Err(e) = self.wait_dma_done(max_rounds_per_stage) {
+                error_layer = Some(layer);
+                if e == DriverError::EngineError {
+                    break;
+                }
+                return Err(e);
+            }
+
+            layers_completed += 1;
+        }
+
+        let total_writes = self.driver.handler().driver().mmio().write_count();
+        let total_reads = self.driver.handler().driver().mmio().read_count();
+
+        Ok(InferenceReport {
+            total_layers: self.num_layers,
+            layers_completed,
+            error_layer,
+            total_writes,
+            total_reads,
+        })
+    }
+
+    fn wait_dma_done(&mut self, max_rounds: u32) -> Result<(), DriverError> {
+        self.driver.wait_irq_mask(csr_map::IRQ_DMA_DONE_MASK, max_rounds)
+    }
+
+    fn wait_inference_done(&mut self, max_rounds: u32) -> Result<(), DriverError> {
+        self.driver.wait_irq_mask(csr_map::IRQ_INFERENCE_DONE_MASK, max_rounds)
+    }
+
+    pub fn driver(&self) -> &IrqDrivenDriver<MockMmio> {
+        &self.driver
+    }
+
+    pub fn driver_mut(&mut self) -> &mut IrqDrivenDriver<MockMmio> {
+        &mut self.driver
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::host::mmio::MockMmio;
+
+    fn fresh() -> InferenceEngine {
+        InferenceEngine::new(BitnetDriver::new(MockMmio::with_csrs_zeroed()))
+    }
+
+    #[test]
+    fn configure_rejects_zero_layers() {
+        let mut e = fresh();
+        assert_eq!(e.configure(0, 1, 1, 1, 0), Err(DriverError::InvalidConfig));
+    }
+
+    #[test]
+    fn configure_rejects_zero_neurons() {
+        let mut e = fresh();
+        assert_eq!(e.configure(1, 0, 1, 1, 0), Err(DriverError::InvalidConfig));
+    }
+
+    #[test]
+    fn configure_rejects_zero_chunks() {
+        let mut e = fresh();
+        assert_eq!(e.configure(1, 1, 0, 1, 0), Err(DriverError::InvalidConfig));
+    }
+
+    #[test]
+    fn run_single_layer_succeeds() {
+        let mut e = fresh();
+        e.configure(1, 16, 4, 1, 0).unwrap();
+        let report = e.run(4).unwrap();
+        assert_eq!(report.total_layers, 1);
+        assert_eq!(report.layers_completed, 1);
+        assert_eq!(report.error_layer, None);
+    }
+
+    #[test]
+    fn run_two_layers_succeeds() {
+        let mut e = fresh();
+        e.configure(2, 16, 4, 1, 0).unwrap();
+        let report = e.run(4).unwrap();
+        assert_eq!(report.total_layers, 2);
+        assert_eq!(report.layers_completed, 2);
+    }
+
+    #[test]
+    fn run_reports_writes_and_reads() {
+        let mut e = fresh();
+        e.configure(1, 16, 4, 1, 0).unwrap();
+        let report = e.run(4).unwrap();
+        assert!(report.total_writes > 0);
+        assert!(report.total_reads > 0);
+    }
+
+    #[test]
+    fn run_increases_writes_with_more_layers() {
+        let mut e1 = fresh();
+        e1.configure(1, 16, 4, 1, 0).unwrap();
+        let r1 = e1.run(4).unwrap();
+
+        let mut e2 = fresh();
+        e2.configure(3, 16, 4, 1, 0).unwrap();
+        let r2 = e2.run(4).unwrap();
+
+        assert!(r2.total_writes > r1.total_writes);
+    }
+
+    #[test]
+    fn run_error_on_irq_error_stops_early() {
+        let mut e = fresh();
+        e.configure(3, 16, 4, 1, 0).unwrap();
+        e.driver_mut()
+            .handler_mut()
+            .driver_mut()
+            .mmio_mut()
+            .latch_irq(csr_map::IRQ_ERROR_MASK);
+        let report = e.run(4).unwrap();
+        assert!(report.layers_completed < report.total_layers);
+        assert!(report.error_layer.is_some());
+    }
+
+    #[test]
+    fn run_returns_error_on_zero_rounds() {
+        let mut e = fresh();
+        e.configure(1, 16, 4, 1, 0).unwrap();
+        let result = e.run(0);
+        assert_eq!(result, Err(DriverError::Timeout));
+    }
+
+    #[test]
+    fn five_layers_all_complete() {
+        let mut e = fresh();
+        e.configure(5, 4, 2, 1, 0).unwrap();
+        let report = e.run(4).unwrap();
+        assert_eq!(report.layers_completed, 5);
+        assert_eq!(report.error_layer, None);
+    }
+
+    #[test]
+    fn one_layer_one_neuron_one_chunk() {
+        let mut e = fresh();
+        e.configure(1, 1, 1, 0, 0).unwrap();
+        let report = e.run(4).unwrap();
+        assert_eq!(report.layers_completed, 1);
+    }
+
+    #[test]
+    fn threshold_zero_is_valid() {
+        let mut e = fresh();
+        e.configure(1, 4, 2, 0, 0).unwrap();
+        let report = e.run(4).unwrap();
+        assert_eq!(report.layers_completed, 1);
+    }
+
+    #[test]
+    fn large_weight_addr_wraps() {
+        let mut e = fresh();
+        e.configure(1, 4, 2, 1, 0xFFFF_FFFF_FFFF_FFFF).unwrap();
+        let report = e.run(4).unwrap();
+        assert_eq!(report.layers_completed, 1);
+    }
+
+    #[test]
+    fn read_count_positive_after_run() {
+        let mut e = fresh();
+        e.configure(1, 4, 4, 1, 0).unwrap();
+        let report = e.run(4).unwrap();
+        assert!(report.total_reads >= 1);
+    }
+
+    #[test]
+    fn writes_increase_monotonically_with_layers() {
+        let results: Vec<InferenceReport> = (1..=4)
+            .map(|n| {
+                let mut e = fresh();
+                e.configure(n, 4, 2, 1, 0).unwrap();
+                e.run(4).unwrap()
+            })
+            .collect();
+        for w in results.windows(2) {
+            assert!(w[1].total_writes > w[0].total_writes);
+        }
+    }
+
+    #[test]
+    fn configure_accepts_max_values() {
+        let mut e = fresh();
+        assert!(e.configure(u32::MAX, u32::MAX, u32::MAX, u32::MAX, u64::MAX).is_ok());
+    }
+}

--- a/bootstrap/src/host/irq.rs
+++ b/bootstrap/src/host/irq.rs
@@ -1,0 +1,251 @@
+use super::csr_map;
+use super::driver::{BitnetDriver, DriverError};
+use super::mmio::Mmio;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IrqSource {
+    InferenceDone,
+    DmaDone,
+    Error,
+}
+
+impl IrqSource {
+    pub fn mask(self) -> u32 {
+        match self {
+            IrqSource::InferenceDone => csr_map::IRQ_INFERENCE_DONE_MASK,
+            IrqSource::DmaDone => csr_map::IRQ_DMA_DONE_MASK,
+            IrqSource::Error => csr_map::IRQ_ERROR_MASK,
+        }
+    }
+
+    pub fn from_mask(mask: u32) -> Vec<IrqSource> {
+        let mut sources = Vec::new();
+        if mask & csr_map::IRQ_INFERENCE_DONE_MASK != 0 {
+            sources.push(IrqSource::InferenceDone);
+        }
+        if mask & csr_map::IRQ_DMA_DONE_MASK != 0 {
+            sources.push(IrqSource::DmaDone);
+        }
+        if mask & csr_map::IRQ_ERROR_MASK != 0 {
+            sources.push(IrqSource::Error);
+        }
+        sources
+    }
+}
+
+type IrqCallback = fn(IrqSource);
+
+pub struct IrqHandler<M: Mmio> {
+    driver: BitnetDriver<M>,
+    callbacks: [Option<IrqCallback>; 3],
+}
+
+impl<M: Mmio> IrqHandler<M> {
+    pub fn new(driver: BitnetDriver<M>) -> Self {
+        Self {
+            driver,
+            callbacks: [None, None, None],
+        }
+    }
+
+    pub fn register(&mut self, source: IrqSource, cb: IrqCallback) {
+        let idx = match source {
+            IrqSource::InferenceDone => 0,
+            IrqSource::DmaDone => 1,
+            IrqSource::Error => 2,
+        };
+        self.callbacks[idx] = Some(cb);
+    }
+
+    pub fn service(&mut self) -> u32 {
+        let stat = self.driver.read_irq_status();
+        if stat == 0 {
+            return 0;
+        }
+        let sources = IrqSource::from_mask(stat);
+        for src in sources {
+            let idx = match src {
+                IrqSource::InferenceDone => 0,
+                IrqSource::DmaDone => 1,
+                IrqSource::Error => 2,
+            };
+            if let Some(cb) = self.callbacks[idx] {
+                cb(src);
+            }
+        }
+        self.driver.clear_irq(stat);
+        stat
+    }
+
+    pub fn driver(&self) -> &BitnetDriver<M> {
+        &self.driver
+    }
+
+    pub fn driver_mut(&mut self) -> &mut BitnetDriver<M> {
+        &mut self.driver
+    }
+}
+
+pub struct IrqDrivenDriver<M: Mmio> {
+    handler: IrqHandler<M>,
+}
+
+impl<M: Mmio> IrqDrivenDriver<M> {
+    pub fn new(driver: BitnetDriver<M>) -> Self {
+        Self {
+            handler: IrqHandler::new(driver),
+        }
+    }
+
+    pub fn register(&mut self, source: IrqSource, cb: IrqCallback) {
+        self.handler.register(source, cb);
+    }
+
+    pub fn handler(&self) -> &IrqHandler<M> {
+        &self.handler
+    }
+
+    pub fn handler_mut(&mut self) -> &mut IrqHandler<M> {
+        &mut self.handler
+    }
+
+    pub fn wait_done_irq(&mut self, max_service_rounds: u32) -> Result<(), DriverError> {
+        for _ in 0..max_service_rounds {
+            let serviced = self.handler.service();
+            if serviced & csr_map::IRQ_ERROR_MASK != 0 {
+                return Err(DriverError::EngineError);
+            }
+            if serviced & csr_map::IRQ_INFERENCE_DONE_MASK != 0 {
+                return Ok(());
+            }
+            if self.handler.driver_mut().is_done() {
+                return Ok(());
+            }
+        }
+        Err(DriverError::Timeout)
+    }
+
+    pub fn into_handler(self) -> IrqHandler<M> {
+        self.handler
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::host::mmio::MockMmio;
+
+    thread_local! {
+        static FIRED: std::cell::RefCell<Vec<IrqSource>> = std::cell::RefCell::new(Vec::new());
+    }
+
+    fn record_cb(src: IrqSource) {
+        FIRED.with(|f| f.borrow_mut().push(src));
+    }
+
+    fn fired() -> Vec<IrqSource> {
+        FIRED.with(|f| f.borrow().clone())
+    }
+
+    fn clear_fired() {
+        FIRED.with(|f| f.borrow_mut().clear());
+    }
+
+    fn fresh_handler() -> IrqHandler<MockMmio> {
+        IrqHandler::new(BitnetDriver::new(MockMmio::with_csrs_zeroed()))
+    }
+
+    fn fresh_irq_driver() -> IrqDrivenDriver<MockMmio> {
+        IrqDrivenDriver::new(BitnetDriver::new(MockMmio::with_csrs_zeroed()))
+    }
+
+    #[test]
+    fn irq_source_mask_roundtrip() {
+        assert_eq!(IrqSource::InferenceDone.mask(), csr_map::IRQ_INFERENCE_DONE_MASK);
+        assert_eq!(IrqSource::DmaDone.mask(), csr_map::IRQ_DMA_DONE_MASK);
+        assert_eq!(IrqSource::Error.mask(), csr_map::IRQ_ERROR_MASK);
+    }
+
+    #[test]
+    fn from_mask_empty() {
+        assert!(IrqSource::from_mask(0).is_empty());
+    }
+
+    #[test]
+    fn from_mask_all_three() {
+        let sources = IrqSource::from_mask(csr_map::IRQ_ALL_MASK);
+        assert_eq!(sources.len(), 3);
+    }
+
+    #[test]
+    fn handler_service_no_irqs_returns_zero() {
+        let mut h = fresh_handler();
+        assert_eq!(h.service(), 0);
+    }
+
+    #[test]
+    fn handler_service_dispatches_callback() {
+        clear_fired();
+        let mut h = fresh_handler();
+        h.register(IrqSource::InferenceDone, record_cb);
+        h.driver_mut().mmio_mut().latch_irq(csr_map::IRQ_INFERENCE_DONE_MASK);
+        let serviced = h.service();
+        assert_eq!(serviced, csr_map::IRQ_INFERENCE_DONE_MASK);
+        assert_eq!(fired(), vec![IrqSource::InferenceDone]);
+    }
+
+    #[test]
+    fn handler_service_calls_clear_irq() {
+        let mut h = fresh_handler();
+        h.driver_mut().mmio_mut().latch_irq(csr_map::IRQ_INFERENCE_DONE_MASK);
+        h.service();
+        let log = h.driver().mmio().log();
+        let last = log.last().unwrap();
+        assert_eq!(last.op, super::super::mmio::MmioOp::Write);
+        assert_eq!(last.addr, csr_map::IRQ_STAT);
+        assert_eq!(last.value, csr_map::IRQ_INFERENCE_DONE_MASK);
+    }
+
+    #[test]
+    fn handler_multiple_sources() {
+        clear_fired();
+        let mut h = fresh_handler();
+        h.register(IrqSource::InferenceDone, record_cb);
+        h.register(IrqSource::DmaDone, record_cb);
+        h.driver_mut().mmio_mut().latch_irq(
+            csr_map::IRQ_INFERENCE_DONE_MASK | csr_map::IRQ_DMA_DONE_MASK,
+        );
+        let serviced = h.service();
+        assert_eq!(serviced, csr_map::IRQ_INFERENCE_DONE_MASK | csr_map::IRQ_DMA_DONE_MASK);
+        let f = fired();
+        assert!(f.contains(&IrqSource::InferenceDone));
+        assert!(f.contains(&IrqSource::DmaDone));
+    }
+
+    #[test]
+    fn irq_driver_wait_done_succeeds_on_inference_done() {
+        let mut d = fresh_irq_driver();
+        d.handler_mut().driver_mut().mmio_mut().latch_irq(csr_map::IRQ_INFERENCE_DONE_MASK);
+        assert_eq!(d.wait_done_irq(4), Ok(()));
+    }
+
+    #[test]
+    fn irq_driver_wait_done_returns_error_on_irq_error() {
+        let mut d = fresh_irq_driver();
+        d.handler_mut().driver_mut().mmio_mut().latch_irq(csr_map::IRQ_ERROR_MASK);
+        assert_eq!(d.wait_done_irq(4), Err(DriverError::EngineError));
+    }
+
+    #[test]
+    fn irq_driver_wait_done_times_out() {
+        let mut d = fresh_irq_driver();
+        assert_eq!(d.wait_done_irq(2), Err(DriverError::Timeout));
+    }
+
+    #[test]
+    fn irq_driver_wait_done_falls_back_to_done_bit() {
+        let mut d = fresh_irq_driver();
+        d.handler_mut().driver_mut().mmio_mut().set_done(true);
+        assert_eq!(d.wait_done_irq(4), Ok(()));
+    }
+}

--- a/bootstrap/src/host/irq.rs
+++ b/bootstrap/src/host/irq.rs
@@ -110,15 +110,21 @@ impl<M: Mmio> IrqDrivenDriver<M> {
     }
 
     pub fn wait_done_irq(&mut self, max_service_rounds: u32) -> Result<(), DriverError> {
+        self.wait_irq_mask(csr_map::IRQ_INFERENCE_DONE_MASK, max_service_rounds)
+    }
+
+    pub fn wait_irq_mask(&mut self, mask: u32, max_service_rounds: u32) -> Result<(), DriverError> {
         for _ in 0..max_service_rounds {
             let serviced = self.handler.service();
             if serviced & csr_map::IRQ_ERROR_MASK != 0 {
                 return Err(DriverError::EngineError);
             }
-            if serviced & csr_map::IRQ_INFERENCE_DONE_MASK != 0 {
+            if serviced & mask != 0 {
                 return Ok(());
             }
-            if self.handler.driver_mut().is_done() {
+            if mask == csr_map::IRQ_INFERENCE_DONE_MASK
+                && self.handler.driver_mut().is_done()
+            {
                 return Ok(());
             }
         }

--- a/bootstrap/src/host/json_output.rs
+++ b/bootstrap/src/host/json_output.rs
@@ -1,0 +1,58 @@
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HostSmokeJson {
+    pub ok: bool,
+    pub writes: usize,
+    pub reads: usize,
+    pub layers: u32,
+    pub neurons: u32,
+    pub chunks: u32,
+    pub threshold: u32,
+    pub weight_addr: String,
+    pub irq_stat: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HostPollVsIrqJson {
+    pub ok: bool,
+    pub poll_writes: usize,
+    pub poll_reads: usize,
+    pub irq_writes: usize,
+    pub irq_reads: usize,
+    pub writes_match: bool,
+    pub irq_stat_poll: String,
+    pub irq_stat_irq: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HostInferenceJson {
+    pub ok: bool,
+    pub total_layers: u32,
+    pub layers_completed: u32,
+    pub error_layer: Option<u32>,
+    pub total_writes: usize,
+    pub total_reads: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HostPerfJson {
+    pub ok: bool,
+    pub layers: u32,
+    pub neurons: u32,
+    pub chunks: u32,
+    pub total_cycles: u32,
+    pub total_weight_words: u32,
+    pub total_weight_bytes: u32,
+    pub bram_utilization_pct: f64,
+    pub total_dma_beats: u32,
+    pub throughput_inf_per_sec: f64,
+    pub clock_mhz: f64,
+}
+
+pub fn print_json<T: Serialize>(value: &T) -> anyhow::Result<()> {
+    let s = serde_json::to_string(value)
+        .map_err(|e| anyhow::anyhow!("JSON serialization failed: {}", e))?;
+    println!("{}", s);
+    Ok(())
+}

--- a/bootstrap/src/host/mod.rs
+++ b/bootstrap/src/host/mod.rs
@@ -15,9 +15,11 @@
 
 pub mod csr_map;
 pub mod driver;
+pub mod engine;
 pub mod irq;
 pub mod mmio;
 
 pub use driver::{BitnetDriver, CsrSnapshot, DriverError};
+pub use engine::{InferenceEngine, InferenceReport};
 pub use irq::{IrqDrivenDriver, IrqHandler, IrqSource};
 pub use mmio::{MmioOp, MmioRecord, MockMmio};

--- a/bootstrap/src/host/mod.rs
+++ b/bootstrap/src/host/mod.rs
@@ -15,7 +15,9 @@
 
 pub mod csr_map;
 pub mod driver;
+pub mod irq;
 pub mod mmio;
 
 pub use driver::{BitnetDriver, CsrSnapshot, DriverError};
+pub use irq::{IrqDrivenDriver, IrqHandler, IrqSource};
 pub use mmio::{MmioOp, MmioRecord, MockMmio};

--- a/bootstrap/src/host/mod.rs
+++ b/bootstrap/src/host/mod.rs
@@ -15,6 +15,7 @@
 
 pub mod csr_map;
 pub mod driver;
+pub mod e2e;
 pub mod engine;
 pub mod irq;
 pub mod json_output;
@@ -24,6 +25,7 @@ pub mod ternary;
 pub mod weights;
 
 pub use driver::{BitnetDriver, CsrSnapshot, DriverError};
+pub use e2e::{E2eConfig, E2eResult, E2eJson};
 pub use engine::{InferenceEngine, InferenceReport};
 pub use irq::{IrqDrivenDriver, IrqHandler, IrqSource};
 pub use json_output::{HostSmokeJson, HostPollVsIrqJson, HostInferenceJson, HostPerfJson};

--- a/bootstrap/src/host/mod.rs
+++ b/bootstrap/src/host/mod.rs
@@ -17,11 +17,13 @@ pub mod csr_map;
 pub mod driver;
 pub mod engine;
 pub mod irq;
+pub mod json_output;
 pub mod mmio;
 pub mod perf;
 
 pub use driver::{BitnetDriver, CsrSnapshot, DriverError};
 pub use engine::{InferenceEngine, InferenceReport};
 pub use irq::{IrqDrivenDriver, IrqHandler, IrqSource};
+pub use json_output::{HostSmokeJson, HostPollVsIrqJson, HostInferenceJson, HostPerfJson};
 pub use mmio::{MmioOp, MmioRecord, MockMmio};
 pub use perf::{EngineConfig, PerformanceEstimate};

--- a/bootstrap/src/host/mod.rs
+++ b/bootstrap/src/host/mod.rs
@@ -20,6 +20,7 @@ pub mod irq;
 pub mod json_output;
 pub mod mmio;
 pub mod perf;
+pub mod ternary;
 
 pub use driver::{BitnetDriver, CsrSnapshot, DriverError};
 pub use engine::{InferenceEngine, InferenceReport};
@@ -27,3 +28,4 @@ pub use irq::{IrqDrivenDriver, IrqHandler, IrqSource};
 pub use json_output::{HostSmokeJson, HostPollVsIrqJson, HostInferenceJson, HostPerfJson};
 pub use mmio::{MmioOp, MmioRecord, MockMmio};
 pub use perf::{EngineConfig, PerformanceEstimate};
+pub use ternary::{Trit, pack_word, unpack_word, pack_words, unpack_words, parse_trit_string, format_trits};

--- a/bootstrap/src/host/mod.rs
+++ b/bootstrap/src/host/mod.rs
@@ -21,6 +21,7 @@ pub mod json_output;
 pub mod mmio;
 pub mod perf;
 pub mod ternary;
+pub mod weights;
 
 pub use driver::{BitnetDriver, CsrSnapshot, DriverError};
 pub use engine::{InferenceEngine, InferenceReport};
@@ -29,3 +30,4 @@ pub use json_output::{HostSmokeJson, HostPollVsIrqJson, HostInferenceJson, HostP
 pub use mmio::{MmioOp, MmioRecord, MockMmio};
 pub use perf::{EngineConfig, PerformanceEstimate};
 pub use ternary::{Trit, pack_word, unpack_word, pack_words, unpack_words, parse_trit_string, format_trits};
+pub use weights::{WeightPattern, WeightConfig, generate_pattern, generate_weights, pattern_name, parse_pattern};

--- a/bootstrap/src/host/mod.rs
+++ b/bootstrap/src/host/mod.rs
@@ -18,8 +18,10 @@ pub mod driver;
 pub mod engine;
 pub mod irq;
 pub mod mmio;
+pub mod perf;
 
 pub use driver::{BitnetDriver, CsrSnapshot, DriverError};
 pub use engine::{InferenceEngine, InferenceReport};
 pub use irq::{IrqDrivenDriver, IrqHandler, IrqSource};
 pub use mmio::{MmioOp, MmioRecord, MockMmio};
+pub use perf::{EngineConfig, PerformanceEstimate};

--- a/bootstrap/src/host/perf.rs
+++ b/bootstrap/src/host/perf.rs
@@ -1,0 +1,252 @@
+pub const TRITS_PER_WORD: u32 = 27;
+pub const BITS_PER_TRIT: u32 = 2;
+pub const DATA_WIDTH: u32 = TRITS_PER_WORD * BITS_PER_TRIT;
+pub const BRAM_DEPTH: u32 = 4096;
+pub const DDR_BEAT_BITS: u32 = 64;
+pub const DDR_BEAT_BYTES: u32 = DDR_BEAT_BITS / 8;
+pub const WORDS_PER_DDR_BEAT: u32 = DDR_BEAT_BITS / DATA_WIDTH;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EngineConfig {
+    pub num_layers: u32,
+    pub neurons: u32,
+    pub chunks: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LayerEstimate {
+    pub layer_index: u32,
+    pub weight_words: u32,
+    pub weight_bytes: u32,
+    pub dma_prefetch_beats: u32,
+    pub compute_cycles: u32,
+    pub dma_drain_beats: u32,
+    pub total_cycles: u32,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PerformanceEstimate {
+    pub config: EngineConfig,
+    pub total_weight_words: u32,
+    pub total_weight_bytes: u32,
+    pub bram_utilization_pct: f64,
+    pub total_dma_beats: u32,
+    pub total_inference_cycles: u32,
+    pub layers: Vec<LayerEstimate>,
+}
+
+impl EngineConfig {
+    pub fn new(num_layers: u32, neurons: u32, chunks: u32) -> Option<Self> {
+        if num_layers == 0 || neurons == 0 || chunks == 0 {
+            return None;
+        }
+        Some(Self {
+            num_layers,
+            neurons,
+            chunks,
+        })
+    }
+
+    pub fn weight_words_per_layer(&self) -> u32 {
+        self.neurons * self.chunks
+    }
+
+    pub fn total_weight_words(&self) -> u32 {
+        self.weight_words_per_layer() * self.num_layers
+    }
+
+    pub fn weight_bytes_per_layer(&self) -> u32 {
+        self.weight_words_per_layer() * (DATA_WIDTH / 8)
+    }
+
+    pub fn total_weight_bytes(&self) -> u32 {
+        self.total_weight_words() * (DATA_WIDTH / 8)
+    }
+
+    pub fn bram_utilization_pct(&self) -> f64 {
+        let words = self.weight_words_per_layer() as f64;
+        (words / BRAM_DEPTH as f64) * 100.0
+    }
+
+    pub fn dma_beats_per_layer(&self) -> u32 {
+        let words = self.weight_words_per_layer();
+        (words + WORDS_PER_DDR_BEAT - 1) / WORDS_PER_DDR_BEAT
+    }
+
+    pub fn compute_cycles_per_layer(&self) -> u32 {
+        self.neurons * self.chunks
+    }
+
+    pub fn cycles_per_layer(&self) -> u32 {
+        let dma_beats = self.dma_beats_per_layer();
+        let compute = self.compute_cycles_per_layer();
+        dma_beats + compute + dma_beats
+    }
+
+    pub fn total_inference_cycles(&self) -> u32 {
+        self.cycles_per_layer() * self.num_layers
+    }
+
+    pub fn throughput_inf_per_sec(&self, clock_mhz: f64) -> f64 {
+        if clock_mhz <= 0.0 {
+            return 0.0;
+        }
+        let cycles_per_sec = clock_mhz * 1e6;
+        let cycles_per_inf = self.total_inference_cycles() as f64;
+        if cycles_per_inf == 0.0 {
+            return 0.0;
+        }
+        cycles_per_sec / cycles_per_inf
+    }
+
+    pub fn estimate(&self) -> PerformanceEstimate {
+        let layers: Vec<LayerEstimate> = (0..self.num_layers)
+            .map(|i| {
+                let weight_words = self.weight_words_per_layer();
+                let dma_beats = self.dma_beats_per_layer();
+                let compute = self.compute_cycles_per_layer();
+                LayerEstimate {
+                    layer_index: i,
+                    weight_words,
+                    weight_bytes: self.weight_bytes_per_layer(),
+                    dma_prefetch_beats: dma_beats,
+                    compute_cycles: compute,
+                    dma_drain_beats: dma_beats,
+                    total_cycles: dma_beats + compute + dma_beats,
+                }
+            })
+            .collect();
+
+        PerformanceEstimate {
+            config: *self,
+            total_weight_words: self.total_weight_words(),
+            total_weight_bytes: self.total_weight_bytes(),
+            bram_utilization_pct: self.bram_utilization_pct(),
+            total_dma_beats: layers.iter().map(|l| l.dma_prefetch_beats + l.dma_drain_beats).sum(),
+            total_inference_cycles: self.total_inference_cycles(),
+            layers,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> EngineConfig {
+        EngineConfig::new(2, 16, 4).unwrap()
+    }
+
+    #[test]
+    fn rejects_zero_layers() {
+        assert!(EngineConfig::new(0, 1, 1).is_none());
+    }
+
+    #[test]
+    fn rejects_zero_neurons() {
+        assert!(EngineConfig::new(1, 0, 1).is_none());
+    }
+
+    #[test]
+    fn rejects_zero_chunks() {
+        assert!(EngineConfig::new(1, 1, 0).is_none());
+    }
+
+    #[test]
+    fn weight_words_per_layer() {
+        assert_eq!(cfg().weight_words_per_layer(), 64);
+    }
+
+    #[test]
+    fn total_weight_words() {
+        assert_eq!(cfg().total_weight_words(), 128);
+    }
+
+    #[test]
+    fn weight_bytes_per_layer() {
+        assert_eq!(cfg().weight_bytes_per_layer(), 64 * (DATA_WIDTH / 8));
+    }
+
+    #[test]
+    fn bram_utilization_under_100() {
+        assert!(cfg().bram_utilization_pct() < 100.0);
+    }
+
+    #[test]
+    fn bram_utilization_exact() {
+        let c = cfg();
+        let expected = (c.weight_words_per_layer() as f64 / BRAM_DEPTH as f64) * 100.0;
+        assert!((c.bram_utilization_pct() - expected).abs() < 0.001);
+    }
+
+    #[test]
+    fn compute_cycles_per_layer() {
+        assert_eq!(cfg().compute_cycles_per_layer(), 64);
+    }
+
+    #[test]
+    fn cycles_per_layer_is_three_stages() {
+        let c = cfg();
+        let dma = c.dma_beats_per_layer();
+        let compute = c.compute_cycles_per_layer();
+        assert_eq!(c.cycles_per_layer(), dma + compute + dma);
+    }
+
+    #[test]
+    fn total_inference_cycles_scales_linearly() {
+        let c = cfg();
+        assert_eq!(
+            c.total_inference_cycles(),
+            c.cycles_per_layer() * c.num_layers
+        );
+    }
+
+    #[test]
+    fn throughput_at_66_mhz() {
+        let t = cfg().throughput_inf_per_sec(66.0);
+        assert!(t > 0.0, "throughput should be positive: {t}");
+    }
+
+    #[test]
+    fn throughput_zero_clock_is_zero() {
+        assert_eq!(cfg().throughput_inf_per_sec(0.0), 0.0);
+    }
+
+    #[test]
+    fn estimate_has_correct_layer_count() {
+        let e = cfg().estimate();
+        assert_eq!(e.layers.len(), 2);
+    }
+
+    #[test]
+    fn estimate_layer_indices_sequential() {
+        let e = cfg().estimate();
+        for (i, l) in e.layers.iter().enumerate() {
+            assert_eq!(l.layer_index, i as u32);
+        }
+    }
+
+    #[test]
+    fn estimate_total_weight_words_matches() {
+        let e = cfg().estimate();
+        assert_eq!(e.total_weight_words, cfg().total_weight_words());
+    }
+
+    #[test]
+    fn large_config_does_not_overflow() {
+        let c = EngineConfig::new(100, 4096, 64).unwrap();
+        let e = c.estimate();
+        assert!(e.total_weight_words > 0);
+        assert!(e.total_inference_cycles > 0);
+    }
+
+    #[test]
+    fn data_width_is_54() {
+        assert_eq!(DATA_WIDTH, 54);
+    }
+
+    #[test]
+    fn bram_depth_is_4096() {
+        assert_eq!(BRAM_DEPTH, 4096);
+    }
+}

--- a/bootstrap/src/host/ternary.rs
+++ b/bootstrap/src/host/ternary.rs
@@ -1,0 +1,199 @@
+pub const TRITS_PER_WORD: usize = 27;
+pub const BITS_PER_TRIT: usize = 2;
+pub const WORD_BITS: usize = TRITS_PER_WORD * BITS_PER_TRIT;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Trit {
+    N = -1,
+    Z = 0,
+    P = 1,
+}
+
+impl Trit {
+    pub fn from_i8(v: i8) -> Option<Self> {
+        match v {
+            -1 => Some(Trit::N),
+            0 => Some(Trit::Z),
+            1 => Some(Trit::P),
+            _ => None,
+        }
+    }
+
+    pub fn to_i8(self) -> i8 {
+        self as i8
+    }
+
+    fn encode(self) -> u8 {
+        match self {
+            Trit::N => 0b00,
+            Trit::Z => 0b01,
+            Trit::P => 0b10,
+        }
+    }
+
+    fn decode(bits: u8) -> Option<Self> {
+        match bits & 0b11 {
+            0b00 => Some(Trit::N),
+            0b01 => Some(Trit::Z),
+            0b10 => Some(Trit::P),
+            _ => None,
+        }
+    }
+}
+
+pub fn pack_word(trits: &[Trit]) -> u64 {
+    assert!(trits.len() <= TRITS_PER_WORD, "word overflow: {} trits", trits.len());
+    let mut word: u64 = 0;
+    for (i, t) in trits.iter().enumerate() {
+        word |= (t.encode() as u64) << (i * BITS_PER_TRIT);
+    }
+    word
+}
+
+pub fn unpack_word(word: u64) -> Vec<Trit> {
+    let mut trits = Vec::with_capacity(TRITS_PER_WORD);
+    for i in 0..TRITS_PER_WORD {
+        let bits = ((word >> (i * BITS_PER_TRIT)) & 0b11) as u8;
+        trits.push(Trit::decode(bits).unwrap_or(Trit::Z));
+    }
+    trits
+}
+
+pub fn pack_words(all_trits: &[Trit]) -> Vec<u64> {
+    all_trits.chunks(TRITS_PER_WORD).map(|chunk| pack_word(chunk)).collect()
+}
+
+pub fn unpack_words(words: &[u64]) -> Vec<Trit> {
+    words.iter().flat_map(|w| unpack_word(*w)).collect()
+}
+
+pub fn parse_trit_string(s: &str) -> Option<Vec<Trit>> {
+    s.split(',')
+        .map(|tok| tok.trim().parse::<i8>().ok().and_then(Trit::from_i8))
+        .collect()
+}
+
+pub fn format_trits(trits: &[Trit]) -> String {
+    trits.iter().map(|t| t.to_i8().to_string()).collect::<Vec<_>>().join(",")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trit_from_i8_roundtrip() {
+        for v in [-1i8, 0, 1] {
+            assert_eq!(Trit::from_i8(v).unwrap().to_i8(), v);
+        }
+    }
+
+    #[test]
+    fn trit_from_i8_rejects_invalid() {
+        assert!(Trit::from_i8(2).is_none());
+        assert!(Trit::from_i8(-2).is_none());
+        assert!(Trit::from_i8(127).is_none());
+    }
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        for t in [Trit::N, Trit::Z, Trit::P] {
+            assert_eq!(Trit::decode(t.encode()).unwrap(), t);
+        }
+    }
+
+    #[test]
+    fn pack_single_trit_n() {
+        assert_eq!(pack_word(&[Trit::N]), 0b00);
+    }
+
+    #[test]
+    fn pack_single_trit_z() {
+        assert_eq!(pack_word(&[Trit::Z]), 0b01);
+    }
+
+    #[test]
+    fn pack_single_trit_p() {
+        assert_eq!(pack_word(&[Trit::P]), 0b10);
+    }
+
+    #[test]
+    fn pack_two_trits() {
+        let w = pack_word(&[Trit::P, Trit::N]);
+        assert_eq!(w, 0b00_10);
+    }
+
+    #[test]
+    fn unpack_two_trits() {
+        let trits = unpack_word(0b00_10);
+        assert_eq!(trits[0], Trit::P);
+        assert_eq!(trits[1], Trit::N);
+    }
+
+    #[test]
+    fn pack_unpack_roundtrip_full_word() {
+        let original: Vec<Trit> = (0..TRITS_PER_WORD)
+            .map(|i| Trit::from_i8((i % 3) as i8 - 1).unwrap())
+            .collect();
+        let packed = pack_word(&original);
+        let unpacked = unpack_word(packed);
+        assert_eq!(original, unpacked);
+    }
+
+    #[test]
+    fn pack_words_chunks_correctly() {
+        let trits: Vec<Trit> = (0..TRITS_PER_WORD * 2 + 5)
+            .map(|i| Trit::from_i8((i % 3) as i8 - 1).unwrap())
+            .collect();
+        let words = pack_words(&trits);
+        assert_eq!(words.len(), 3);
+    }
+
+    #[test]
+    fn pack_unpack_words_roundtrip() {
+        let trits: Vec<Trit> = (0..TRITS_PER_WORD * 3)
+            .map(|i| Trit::from_i8((i % 3) as i8 - 1).unwrap())
+            .collect();
+        let words = pack_words(&trits);
+        let back = unpack_words(&words);
+        assert_eq!(trits, back);
+    }
+
+    #[test]
+    fn parse_trit_string_valid() {
+        let trits = parse_trit_string("-1,0,1,0,-1").unwrap();
+        assert_eq!(trits, vec![Trit::N, Trit::Z, Trit::P, Trit::Z, Trit::N]);
+    }
+
+    #[test]
+    fn parse_trit_string_rejects_invalid() {
+        assert!(parse_trit_string("1,2,3").is_none());
+    }
+
+    #[test]
+    fn format_trits_matches_parse() {
+        let original = vec![Trit::N, Trit::Z, Trit::P];
+        let s = format_trits(&original);
+        let parsed = parse_trit_string(&s).unwrap();
+        assert_eq!(original, parsed);
+    }
+
+    #[test]
+    fn empty_pack_words() {
+        let words = pack_words(&[]);
+        assert!(words.is_empty());
+    }
+
+    #[test]
+    fn unpack_reserved_bits_defaults_to_z() {
+        let trits = unpack_word(0b11);
+        assert_eq!(trits[0], Trit::Z);
+    }
+
+    #[test]
+    fn trit_constants() {
+        assert_eq!(TRITS_PER_WORD, 27);
+        assert_eq!(BITS_PER_TRIT, 2);
+        assert_eq!(WORD_BITS, 54);
+    }
+}

--- a/bootstrap/src/host/weights.rs
+++ b/bootstrap/src/host/weights.rs
@@ -1,0 +1,198 @@
+use super::ternary::{Trit, pack_words};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WeightPattern {
+    AllN,
+    AllZ,
+    AllP,
+    Alternating,
+    PhiSequence,
+    SeededRandom(u64),
+}
+
+pub struct WeightConfig {
+    pub neurons: u32,
+    pub chunks: u32,
+    pub pattern: WeightPattern,
+}
+
+impl WeightConfig {
+    pub fn total_trits(&self) -> usize {
+        (self.neurons as usize) * (self.chunks as usize) * super::ternary::TRITS_PER_WORD
+    }
+
+    pub fn total_words(&self) -> usize {
+        (self.neurons as usize) * (self.chunks as usize)
+    }
+}
+
+pub fn generate_pattern(pattern: WeightPattern, count: usize) -> Vec<Trit> {
+    match pattern {
+        WeightPattern::AllN => vec![Trit::N; count],
+        WeightPattern::AllZ => vec![Trit::Z; count],
+        WeightPattern::AllP => vec![Trit::P; count],
+        WeightPattern::Alternating => (0..count).map(|i| match i % 3 {
+            0 => Trit::N,
+            1 => Trit::Z,
+            _ => Trit::P,
+        }).collect(),
+        WeightPattern::PhiSequence => {
+            let phi_trits = [Trit::N, Trit::Z, Trit::P, Trit::P, Trit::Z, Trit::N, Trit::P, Trit::Z, Trit::N];
+            (0..count).map(|i| phi_trits[i % phi_trits.len()]).collect()
+        },
+        WeightPattern::SeededRandom(seed) => {
+            let mut state = seed;
+            (0..count).map(|_| {
+                state = state.wrapping_mul(0x9E3779B97F4A7C15).wrapping_add(0x1);
+                match (state >> 62) & 3 {
+                    0 => Trit::N,
+                    1 => Trit::Z,
+                    _ => Trit::P,
+                }
+            }).collect()
+        },
+    }
+}
+
+pub fn generate_weights(config: &WeightConfig) -> Vec<u64> {
+    let total = config.total_trits();
+    let trits = generate_pattern(config.pattern, total);
+    pack_words(&trits)
+}
+
+pub fn pattern_name(pattern: WeightPattern) -> &'static str {
+    match pattern {
+        WeightPattern::AllN => "all-n",
+        WeightPattern::AllZ => "all-z",
+        WeightPattern::AllP => "all-p",
+        WeightPattern::Alternating => "alternating",
+        WeightPattern::PhiSequence => "phi-sequence",
+        WeightPattern::SeededRandom(_) => "seeded-random",
+    }
+}
+
+pub fn parse_pattern(s: &str) -> Option<WeightPattern> {
+    match s {
+        "all-n" => Some(WeightPattern::AllN),
+        "all-z" => Some(WeightPattern::AllZ),
+        "all-p" => Some(WeightPattern::AllP),
+        "alternating" => Some(WeightPattern::Alternating),
+        "phi-sequence" => Some(WeightPattern::PhiSequence),
+        other if other.starts_with("seeded-random") => {
+            let seed_str = other.strip_prefix("seeded-random:")?;
+            let seed = seed_str.parse::<u64>().ok()?;
+            Some(WeightPattern::SeededRandom(seed))
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::host::ternary::TRITS_PER_WORD;
+
+    #[test]
+    fn all_n_pattern() {
+        let trits = generate_pattern(WeightPattern::AllN, 10);
+        assert!(trits.iter().all(|t| *t == Trit::N));
+    }
+
+    #[test]
+    fn all_z_pattern() {
+        let trits = generate_pattern(WeightPattern::AllZ, 10);
+        assert!(trits.iter().all(|t| *t == Trit::Z));
+    }
+
+    #[test]
+    fn all_p_pattern() {
+        let trits = generate_pattern(WeightPattern::AllP, 10);
+        assert!(trits.iter().all(|t| *t == Trit::P));
+    }
+
+    #[test]
+    fn alternating_pattern_cycle() {
+        let trits = generate_pattern(WeightPattern::Alternating, 6);
+        assert_eq!(trits, vec![Trit::N, Trit::Z, Trit::P, Trit::N, Trit::Z, Trit::P]);
+    }
+
+    #[test]
+    fn phi_sequence_repeats() {
+        let trits = generate_pattern(WeightPattern::PhiSequence, 18);
+        assert_eq!(&trits[0..9], &trits[9..18]);
+    }
+
+    #[test]
+    fn seeded_random_deterministic() {
+        let t1 = generate_pattern(WeightPattern::SeededRandom(42), 100);
+        let t2 = generate_pattern(WeightPattern::SeededRandom(42), 100);
+        assert_eq!(t1, t2);
+    }
+
+    #[test]
+    fn seeded_random_different_seeds_differ() {
+        let t1 = generate_pattern(WeightPattern::SeededRandom(1), 100);
+        let t2 = generate_pattern(WeightPattern::SeededRandom(2), 100);
+        assert_ne!(t1, t2);
+    }
+
+    #[test]
+    fn generate_weights_word_count() {
+        let config = WeightConfig { neurons: 2, chunks: 4, pattern: WeightPattern::AllP };
+        assert_eq!(generate_weights(&config).len(), 8);
+    }
+
+    #[test]
+    fn generate_weights_total_trits() {
+        let config = WeightConfig { neurons: 3, chunks: 2, pattern: WeightPattern::AllZ };
+        assert_eq!(config.total_trits(), 3 * 2 * TRITS_PER_WORD);
+    }
+
+    #[test]
+    fn pattern_name_roundtrip() {
+        assert_eq!(pattern_name(WeightPattern::AllN), "all-n");
+        assert_eq!(pattern_name(WeightPattern::AllZ), "all-z");
+        assert_eq!(pattern_name(WeightPattern::AllP), "all-p");
+        assert_eq!(pattern_name(WeightPattern::Alternating), "alternating");
+        assert_eq!(pattern_name(WeightPattern::PhiSequence), "phi-sequence");
+    }
+
+    #[test]
+    fn parse_pattern_valid() {
+        assert_eq!(parse_pattern("all-n"), Some(WeightPattern::AllN));
+        assert_eq!(parse_pattern("all-z"), Some(WeightPattern::AllZ));
+        assert_eq!(parse_pattern("alternating"), Some(WeightPattern::Alternating));
+    }
+
+    #[test]
+    fn parse_pattern_invalid() {
+        assert_eq!(parse_pattern("bogus"), None);
+    }
+
+    #[test]
+    fn parse_pattern_seeded() {
+        assert_eq!(parse_pattern("seeded-random:12345"), Some(WeightPattern::SeededRandom(12345)));
+    }
+
+    #[test]
+    fn all_n_packs_to_zero() {
+        let config = WeightConfig { neurons: 1, chunks: 1, pattern: WeightPattern::AllN };
+        let words = generate_weights(&config);
+        assert_eq!(words[0], 0u64);
+    }
+
+    #[test]
+    fn all_z_packs_to_known() {
+        let config = WeightConfig { neurons: 1, chunks: 1, pattern: WeightPattern::AllZ };
+        let words = generate_weights(&config);
+        let expected: u64 = (0..27).fold(0u64, |acc, i| acc | (0b01u64 << (i * 2)));
+        assert_eq!(words[0], expected);
+    }
+
+    #[test]
+    fn empty_config() {
+        let config = WeightConfig { neurons: 0, chunks: 0, pattern: WeightPattern::AllN };
+        assert_eq!(config.total_trits(), 0);
+        assert_eq!(generate_weights(&config).len(), 0);
+    }
+}

--- a/bootstrap/src/main.rs
+++ b/bootstrap/src/main.rs
@@ -347,6 +347,10 @@ enum Commands {
         /// Maximum poll iterations before timeout (default: 16).
         #[arg(long, default_value_t = 16)]
         max_polls: u32,
+
+        /// Emit structured JSON instead of human-readable output.
+        #[arg(long)]
+        json: bool,
     },
 
     /// Run a side-by-side poll-vs-IRQ comparison on MockMmio (Wave 40, R-HS-2).
@@ -381,6 +385,10 @@ enum Commands {
         /// Maximum poll iterations before timeout (default: 16).
         #[arg(long, default_value_t = 16)]
         max_polls: u32,
+
+        /// Emit structured JSON instead of human-readable output.
+        #[arg(long)]
+        json: bool,
     },
 
     /// Run a multi-layer DMA-driven BitNet inference flow on MockMmio
@@ -414,6 +422,10 @@ enum Commands {
         /// Maximum IRQ-service rounds per stage (default: 16).
         #[arg(long, default_value_t = 16)]
         max_rounds: u32,
+
+        /// Emit structured JSON instead of human-readable output.
+        #[arg(long)]
+        json: bool,
     },
 
     /// Estimate BitNet inference performance from engine configuration
@@ -439,6 +451,10 @@ enum Commands {
         /// matching STARTUPE2.CFGMCLK on Wukong V1).
         #[arg(long, default_value_t = 66.0)]
         clock_mhz: f64,
+
+        /// Emit structured JSON instead of human-readable output.
+        #[arg(long)]
+        json: bool,
     },
 
     /// Emit a complete BitNet HLS bundle (Wave 38, R-SI-1).
@@ -3111,6 +3127,7 @@ fn run_host_smoke(
     threshold: u32,
     weight_addr: u64,
     max_polls: u32,
+    json: bool,
 ) -> anyhow::Result<()> {
     use host::{BitnetDriver, MockMmio};
     let mut driver = BitnetDriver::new(MockMmio::with_csrs_zeroed());
@@ -3119,8 +3136,6 @@ fn run_host_smoke(
         .map_err(|e| anyhow::anyhow!("configure failed: {:?}", e))?;
     driver.enable_irqs(host::csr_map::IRQ_ALL_MASK);
     driver.start();
-    // Simulate hardware completing the inference immediately for the smoke
-    // test: latch `done` and the inference_done IRQ before polling.
     driver.mmio_mut().set_done(true);
     driver.mmio_mut().latch_irq(host::csr_map::IRQ_INFERENCE_DONE_MASK);
     driver
@@ -3129,17 +3144,24 @@ fn run_host_smoke(
     let snap = driver.dump();
     let w = driver.mmio().write_count();
     let r = driver.mmio().read_count();
-    println!(
-        "OK {}w/{}r layers={} neurons={} chunks={} threshold={} weight_addr=0x{:016x} irq_stat=0x{:08x}",
-        w,
-        r,
-        snap.num_layers,
-        snap.neurons,
-        snap.chunks,
-        snap.threshold,
-        snap.weight_addr_64(),
-        snap.irq_stat
-    );
+    if json {
+        host::json_output::print_json(&host::json_output::HostSmokeJson {
+            ok: true,
+            writes: w,
+            reads: r,
+            layers: snap.num_layers,
+            neurons: snap.neurons,
+            chunks: snap.chunks,
+            threshold: snap.threshold,
+            weight_addr: format!("0x{:016x}", snap.weight_addr_64()),
+            irq_stat: format!("0x{:08x}", snap.irq_stat),
+        })?;
+    } else {
+        println!(
+            "OK {}w/{}r layers={} neurons={} chunks={} threshold={} weight_addr=0x{:016x} irq_stat=0x{:08x}",
+            w, r, snap.num_layers, snap.neurons, snap.chunks, snap.threshold, snap.weight_addr_64(), snap.irq_stat
+        );
+    }
     Ok(())
 }
 
@@ -3150,6 +3172,7 @@ fn run_host_poll_vs_irq(
     threshold: u32,
     weight_addr: u64,
     max_polls: u32,
+    json: bool,
 ) -> anyhow::Result<()> {
     use host::{BitnetDriver, IrqDrivenDriver, MockMmio};
     let poll_writes;
@@ -3194,10 +3217,23 @@ fn run_host_poll_vs_irq(
         irq_stat_irq = idd.handler_mut().driver_mut().dump().irq_stat;
     }
     let writes_match = poll_writes == irq_writes;
-    println!(
-        "OK poll={}w/{}r irq={}w/{}r writes_match={} irq_stat_poll=0x{:08x} irq_stat_irq=0x{:08x}",
-        poll_writes, poll_reads, irq_writes, irq_reads, writes_match, irq_stat_poll, irq_stat_irq
-    );
+    if json {
+        host::json_output::print_json(&host::json_output::HostPollVsIrqJson {
+            ok: true,
+            poll_writes,
+            poll_reads,
+            irq_writes,
+            irq_reads,
+            writes_match,
+            irq_stat_poll: format!("0x{:08x}", irq_stat_poll),
+            irq_stat_irq: format!("0x{:08x}", irq_stat_irq),
+        })?;
+    } else {
+        println!(
+            "OK poll={}w/{}r irq={}w/{}r writes_match={} irq_stat_poll=0x{:08x} irq_stat_irq=0x{:08x}",
+            poll_writes, poll_reads, irq_writes, irq_reads, writes_match, irq_stat_poll, irq_stat_irq
+        );
+    }
     Ok(())
 }
 
@@ -3208,18 +3244,31 @@ fn run_host_inference(
     threshold: u32,
     weight_addr: u64,
     max_rounds: u32,
+    json: bool,
 ) -> anyhow::Result<()> {
     use host::{BitnetDriver, InferenceEngine, MockMmio};
-    let mut engine = InferenceEngine::new(BitnetDriver::new(MockMmio::with_csrs_zeroed()));    engine
+    let mut engine = InferenceEngine::new(BitnetDriver::new(MockMmio::with_csrs_zeroed()));
+    engine
         .configure(num_layers, neurons, chunks, threshold, weight_addr)
         .map_err(|e| anyhow::anyhow!("configure failed: {:?}", e))?;
     let report = engine
         .run(max_rounds)
         .map_err(|e| anyhow::anyhow!("inference failed: {:?}", e))?;
-    println!(
-        "OK layers={} completed={} writes={} reads={}",
-        report.total_layers, report.layers_completed, report.total_writes, report.total_reads
-    );
+    if json {
+        host::json_output::print_json(&host::json_output::HostInferenceJson {
+            ok: true,
+            total_layers: report.total_layers,
+            layers_completed: report.layers_completed,
+            error_layer: report.error_layer,
+            total_writes: report.total_writes,
+            total_reads: report.total_reads,
+        })?;
+    } else {
+        println!(
+            "OK layers={} completed={} writes={} reads={}",
+            report.total_layers, report.layers_completed, report.total_writes, report.total_reads
+        );
+    }
     Ok(())
 }
 
@@ -3228,24 +3277,41 @@ fn run_host_perf(
     neurons: u32,
     chunks: u32,
     clock_mhz: f64,
+    json: bool,
 ) -> anyhow::Result<()> {
     use host::perf::EngineConfig;
     let cfg = EngineConfig::new(num_layers, neurons, chunks)
         .ok_or_else(|| anyhow::anyhow!("invalid config: layers, neurons, and chunks must be > 0"))?;
     let est = cfg.estimate();
     let throughput = cfg.throughput_inf_per_sec(clock_mhz);
-    println!(
-        "OK layers={} neurons={} chunks={} total_cycles={} total_weight_words={} bram_pct={:.1}% dma_beats={} throughput={:.1} inf/s @ {:.1} MHz",
-        est.config.num_layers,
-        est.config.neurons,
-        est.config.chunks,
-        est.total_inference_cycles,
-        est.total_weight_words,
-        est.bram_utilization_pct,
-        est.total_dma_beats,
-        throughput,
-        clock_mhz,
-    );
+    if json {
+        host::json_output::print_json(&host::json_output::HostPerfJson {
+            ok: true,
+            layers: est.config.num_layers,
+            neurons: est.config.neurons,
+            chunks: est.config.chunks,
+            total_cycles: est.total_inference_cycles,
+            total_weight_words: est.total_weight_words,
+            total_weight_bytes: est.total_weight_bytes,
+            bram_utilization_pct: est.bram_utilization_pct,
+            total_dma_beats: est.total_dma_beats,
+            throughput_inf_per_sec: throughput,
+            clock_mhz,
+        })?;
+    } else {
+        println!(
+            "OK layers={} neurons={} chunks={} total_cycles={} total_weight_words={} bram_pct={:.1}% dma_beats={} throughput={:.1} inf/s @ {:.1} MHz",
+            est.config.num_layers,
+            est.config.neurons,
+            est.config.chunks,
+            est.total_inference_cycles,
+            est.total_weight_words,
+            est.bram_utilization_pct,
+            est.total_dma_beats,
+            throughput,
+            clock_mhz,
+        );
+    }
     Ok(())
 }
 
@@ -8054,17 +8120,17 @@ async fn main() -> anyhow::Result<()> {
         Commands::GenBitnetBundle { top_name, axi_addr_width, axi_data_width, output_dir } => {
             run_gen_bitnet_bundle(&top_name, axi_addr_width, axi_data_width, &output_dir)?
         }
-        Commands::HostSmoke { num_layers, neurons, chunks, threshold, weight_addr, max_polls } => {
-            run_host_smoke(num_layers, neurons, chunks, threshold, weight_addr, max_polls)?
+        Commands::HostSmoke { num_layers, neurons, chunks, threshold, weight_addr, max_polls, json } => {
+            run_host_smoke(num_layers, neurons, chunks, threshold, weight_addr, max_polls, json)?
         }
-        Commands::HostPollVsIrq { num_layers, neurons, chunks, threshold, weight_addr, max_polls } => {
-            run_host_poll_vs_irq(num_layers, neurons, chunks, threshold, weight_addr, max_polls)?
+        Commands::HostPollVsIrq { num_layers, neurons, chunks, threshold, weight_addr, max_polls, json } => {
+            run_host_poll_vs_irq(num_layers, neurons, chunks, threshold, weight_addr, max_polls, json)?
         }
-        Commands::HostInference { num_layers, neurons, chunks, threshold, weight_addr, max_rounds } => {
-            run_host_inference(num_layers, neurons, chunks, threshold, weight_addr, max_rounds)?
+        Commands::HostInference { num_layers, neurons, chunks, threshold, weight_addr, max_rounds, json } => {
+            run_host_inference(num_layers, neurons, chunks, threshold, weight_addr, max_rounds, json)?
         }
-        Commands::HostPerf { num_layers, neurons, chunks, clock_mhz } => {
-            run_host_perf(num_layers, neurons, chunks, clock_mhz)?
+        Commands::HostPerf { num_layers, neurons, chunks, clock_mhz, json } => {
+            run_host_perf(num_layers, neurons, chunks, clock_mhz, json)?
         }
         Commands::Asm { input, output, format } => run_asm(&input, output.as_deref(), &format)?,
         Commands::GenTestbench { input, period_ns, max_cycles, output } => {
@@ -8301,17 +8367,17 @@ fn main() -> anyhow::Result<()> {
         Commands::GenBitnetBundle { top_name, axi_addr_width, axi_data_width, output_dir } => {
             run_gen_bitnet_bundle(&top_name, axi_addr_width, axi_data_width, &output_dir)?
         }
-        Commands::HostSmoke { num_layers, neurons, chunks, threshold, weight_addr, max_polls } => {
-            run_host_smoke(num_layers, neurons, chunks, threshold, weight_addr, max_polls)?
+        Commands::HostSmoke { num_layers, neurons, chunks, threshold, weight_addr, max_polls, json } => {
+            run_host_smoke(num_layers, neurons, chunks, threshold, weight_addr, max_polls, json)?
         }
-        Commands::HostPollVsIrq { num_layers, neurons, chunks, threshold, weight_addr, max_polls } => {
-            run_host_poll_vs_irq(num_layers, neurons, chunks, threshold, weight_addr, max_polls)?
+        Commands::HostPollVsIrq { num_layers, neurons, chunks, threshold, weight_addr, max_polls, json } => {
+            run_host_poll_vs_irq(num_layers, neurons, chunks, threshold, weight_addr, max_polls, json)?
         }
-        Commands::HostInference { num_layers, neurons, chunks, threshold, weight_addr, max_rounds } => {
-            run_host_inference(num_layers, neurons, chunks, threshold, weight_addr, max_rounds)?
+        Commands::HostInference { num_layers, neurons, chunks, threshold, weight_addr, max_rounds, json } => {
+            run_host_inference(num_layers, neurons, chunks, threshold, weight_addr, max_rounds, json)?
         }
-        Commands::HostPerf { num_layers, neurons, chunks, clock_mhz } => {
-            run_host_perf(num_layers, neurons, chunks, clock_mhz)?
+        Commands::HostPerf { num_layers, neurons, chunks, clock_mhz, json } => {
+            run_host_perf(num_layers, neurons, chunks, clock_mhz, json)?
         }
         Commands::Asm { input, output, format } => run_asm(&input, output.as_deref(), &format)?,
         Commands::GenTestbench { input, period_ns, max_cycles, output } => {

--- a/bootstrap/src/main.rs
+++ b/bootstrap/src/main.rs
@@ -416,6 +416,31 @@ enum Commands {
         max_rounds: u32,
     },
 
+    /// Estimate BitNet inference performance from engine configuration
+    /// (Wave 42, R-HS-4).
+    ///
+    /// Prints cycle counts, DMA beats, BRAM utilization, and throughput
+    /// estimates. No hardware required — pure arithmetic model.
+    #[command(name = "host-perf")]
+    HostPerf {
+        /// Number of layers (default: 2).
+        #[arg(long, default_value_t = 2)]
+        num_layers: u32,
+
+        /// Neurons per layer (default: 16).
+        #[arg(long, default_value_t = 16)]
+        neurons: u32,
+
+        /// Chunks per neuron (default: 4).
+        #[arg(long, default_value_t = 4)]
+        chunks: u32,
+
+        /// Clock frequency in MHz for throughput estimate (default: 66.0,
+        /// matching STARTUPE2.CFGMCLK on Wukong V1).
+        #[arg(long, default_value_t = 66.0)]
+        clock_mhz: f64,
+    },
+
     /// Emit a complete BitNet HLS bundle (Wave 38, R-SI-1).
     ///
     /// Composes all 9 BitNet HLS module emitters (W36a-f) plus the
@@ -3194,6 +3219,32 @@ fn run_host_inference(
     println!(
         "OK layers={} completed={} writes={} reads={}",
         report.total_layers, report.layers_completed, report.total_writes, report.total_reads
+    );
+    Ok(())
+}
+
+fn run_host_perf(
+    num_layers: u32,
+    neurons: u32,
+    chunks: u32,
+    clock_mhz: f64,
+) -> anyhow::Result<()> {
+    use host::perf::EngineConfig;
+    let cfg = EngineConfig::new(num_layers, neurons, chunks)
+        .ok_or_else(|| anyhow::anyhow!("invalid config: layers, neurons, and chunks must be > 0"))?;
+    let est = cfg.estimate();
+    let throughput = cfg.throughput_inf_per_sec(clock_mhz);
+    println!(
+        "OK layers={} neurons={} chunks={} total_cycles={} total_weight_words={} bram_pct={:.1}% dma_beats={} throughput={:.1} inf/s @ {:.1} MHz",
+        est.config.num_layers,
+        est.config.neurons,
+        est.config.chunks,
+        est.total_inference_cycles,
+        est.total_weight_words,
+        est.bram_utilization_pct,
+        est.total_dma_beats,
+        throughput,
+        clock_mhz,
     );
     Ok(())
 }
@@ -8012,6 +8063,9 @@ async fn main() -> anyhow::Result<()> {
         Commands::HostInference { num_layers, neurons, chunks, threshold, weight_addr, max_rounds } => {
             run_host_inference(num_layers, neurons, chunks, threshold, weight_addr, max_rounds)?
         }
+        Commands::HostPerf { num_layers, neurons, chunks, clock_mhz } => {
+            run_host_perf(num_layers, neurons, chunks, clock_mhz)?
+        }
         Commands::Asm { input, output, format } => run_asm(&input, output.as_deref(), &format)?,
         Commands::GenTestbench { input, period_ns, max_cycles, output } => {
             run_gen_testbench(&input, period_ns, max_cycles, output.as_deref())?
@@ -8255,6 +8309,9 @@ fn main() -> anyhow::Result<()> {
         }
         Commands::HostInference { num_layers, neurons, chunks, threshold, weight_addr, max_rounds } => {
             run_host_inference(num_layers, neurons, chunks, threshold, weight_addr, max_rounds)?
+        }
+        Commands::HostPerf { num_layers, neurons, chunks, clock_mhz } => {
+            run_host_perf(num_layers, neurons, chunks, clock_mhz)?
         }
         Commands::Asm { input, output, format } => run_asm(&input, output.as_deref(), &format)?,
         Commands::GenTestbench { input, period_ns, max_cycles, output } => {

--- a/bootstrap/src/main.rs
+++ b/bootstrap/src/main.rs
@@ -349,6 +349,40 @@ enum Commands {
         max_polls: u32,
     },
 
+    /// Run a side-by-side poll-vs-IRQ comparison on MockMmio (Wave 40, R-HS-2).
+    ///
+    /// Executes the same configure -> start -> complete flow twice: once via
+    /// the poll-mode `wait_done` path (W39) and once via the interrupt-driven
+    /// `IrqDrivenDriver::wait_done_irq` path (W40). Prints a single comparison
+    /// line: `OK poll=Nw/Mr irq=Nw/Mr writes_match=<bool> irq_stat_poll=0x..
+    /// irq_stat_irq=0x..`.
+    #[command(name = "host-poll-vs-irq")]
+    HostPollVsIrq {
+        /// Number of layers to program (default: 2).
+        #[arg(long, default_value_t = 2)]
+        num_layers: u32,
+
+        /// Neurons per layer (default: 16).
+        #[arg(long, default_value_t = 16)]
+        neurons: u32,
+
+        /// Chunks per neuron (default: 4).
+        #[arg(long, default_value_t = 4)]
+        chunks: u32,
+
+        /// Signed threshold value (default: 1).
+        #[arg(long, default_value_t = 1)]
+        threshold: u32,
+
+        /// 64-bit weight base address as decimal (default: 0).
+        #[arg(long, default_value_t = 0)]
+        weight_addr: u64,
+
+        /// Maximum poll iterations before timeout (default: 16).
+        #[arg(long, default_value_t = 16)]
+        max_polls: u32,
+    },
+
     /// Emit a complete BitNet HLS bundle (Wave 38, R-SI-1).
     ///
     /// Composes all 9 BitNet HLS module emitters (W36a-f) plus the
@@ -3047,6 +3081,64 @@ fn run_host_smoke(
         snap.threshold,
         snap.weight_addr_64(),
         snap.irq_stat
+    );
+    Ok(())
+}
+
+fn run_host_poll_vs_irq(
+    num_layers: u32,
+    neurons: u32,
+    chunks: u32,
+    threshold: u32,
+    weight_addr: u64,
+    max_polls: u32,
+) -> anyhow::Result<()> {
+    use host::{BitnetDriver, IrqDrivenDriver, MockMmio};
+    let poll_writes;
+    let poll_reads;
+    let irq_stat_poll;
+    {
+        let mut driver = BitnetDriver::new(MockMmio::with_csrs_zeroed());
+        driver
+            .configure(num_layers, neurons, chunks, threshold, weight_addr)
+            .map_err(|e| anyhow::anyhow!("poll configure failed: {:?}", e))?;
+        driver.enable_irqs(host::csr_map::IRQ_ALL_MASK);
+        driver.start();
+        driver.mmio_mut().set_done(true);
+        driver.mmio_mut().latch_irq(host::csr_map::IRQ_INFERENCE_DONE_MASK);
+        driver
+            .wait_done(max_polls)
+            .map_err(|e| anyhow::anyhow!("poll wait_done failed: {:?}", e))?;
+        poll_writes = driver.mmio().write_count();
+        poll_reads = driver.mmio().read_count();
+        irq_stat_poll = driver.dump().irq_stat;
+    }
+    let irq_writes;
+    let irq_reads;
+    let irq_stat_irq;
+    {
+        let mut idd = IrqDrivenDriver::new(BitnetDriver::new(MockMmio::with_csrs_zeroed()));
+        idd.handler_mut()
+            .driver_mut()
+            .configure(num_layers, neurons, chunks, threshold, weight_addr)
+            .map_err(|e| anyhow::anyhow!("irq configure failed: {:?}", e))?;
+        idd.handler_mut().driver_mut().enable_irqs(host::csr_map::IRQ_ALL_MASK);
+        idd.handler_mut().driver_mut().start();
+        idd.handler_mut().driver_mut().mmio_mut().set_done(true);
+        idd.handler_mut()
+            .driver_mut()
+            .mmio_mut()
+            .latch_irq(host::csr_map::IRQ_INFERENCE_DONE_MASK);
+        idd.wait_done_irq(max_polls)
+            .map_err(|e| anyhow::anyhow!("irq wait_done_irq failed: {:?}", e))?;
+        irq_writes = idd.handler().driver().mmio().write_count();
+        irq_reads = idd.handler().driver().mmio().read_count();
+        irq_stat_irq = idd.handler_mut().driver_mut().dump().irq_stat;
+    }
+    let writes_match = poll_writes == irq_writes;
+    println!(
+        "OK poll={}w/{}r irq={}w/{}r writes_match={} irq_stat_poll=0x{:08x} irq_stat_irq=0x{:08x}",
+        poll_writes, poll_reads, irq_writes, irq_reads, writes_match, irq_stat_poll, irq_stat_irq
     );
     Ok(())
 }
@@ -7859,6 +7951,9 @@ async fn main() -> anyhow::Result<()> {
         Commands::HostSmoke { num_layers, neurons, chunks, threshold, weight_addr, max_polls } => {
             run_host_smoke(num_layers, neurons, chunks, threshold, weight_addr, max_polls)?
         }
+        Commands::HostPollVsIrq { num_layers, neurons, chunks, threshold, weight_addr, max_polls } => {
+            run_host_poll_vs_irq(num_layers, neurons, chunks, threshold, weight_addr, max_polls)?
+        }
         Commands::Asm { input, output, format } => run_asm(&input, output.as_deref(), &format)?,
         Commands::GenTestbench { input, period_ns, max_cycles, output } => {
             run_gen_testbench(&input, period_ns, max_cycles, output.as_deref())?
@@ -8096,6 +8191,9 @@ fn main() -> anyhow::Result<()> {
         }
         Commands::HostSmoke { num_layers, neurons, chunks, threshold, weight_addr, max_polls } => {
             run_host_smoke(num_layers, neurons, chunks, threshold, weight_addr, max_polls)?
+        }
+        Commands::HostPollVsIrq { num_layers, neurons, chunks, threshold, weight_addr, max_polls } => {
+            run_host_poll_vs_irq(num_layers, neurons, chunks, threshold, weight_addr, max_polls)?
         }
         Commands::Asm { input, output, format } => run_asm(&input, output.as_deref(), &format)?,
         Commands::GenTestbench { input, period_ns, max_cycles, output } => {

--- a/bootstrap/src/main.rs
+++ b/bootstrap/src/main.rs
@@ -479,6 +479,27 @@ enum Commands {
         words: String,
     },
 
+    /// Generate deterministic packed-trit weight patterns (Wave 45, R-HT-2).
+    ///
+    /// Generates weight words in packed-trit format (54 bits/word) for a
+    /// given (neurons, chunks) configuration. Patterns: all-n, all-z,
+    /// all-p, alternating, phi-sequence, seeded-random:SEED.
+    #[command(name = "host-weight-gen")]
+    HostWeightGen {
+        /// Number of neurons (default: 16).
+        #[arg(long, default_value_t = 16)]
+        neurons: u32,
+
+        /// Chunks per neuron (default: 4).
+        #[arg(long, default_value_t = 4)]
+        chunks: u32,
+
+        /// Weight pattern: all-n, all-z, all-p, alternating, phi-sequence,
+        /// seeded-random:SEED (default: alternating).
+        #[arg(long, default_value = "alternating")]
+        pattern: String,
+    },
+
     /// Emit a complete BitNet HLS bundle (Wave 38, R-SI-1).
     ///
     /// Composes all 9 BitNet HLS module emitters (W36a-f) plus the
@@ -3364,6 +3385,20 @@ fn run_host_unpack(words_str: &str) -> anyhow::Result<()> {
     }
     let trits = host::ternary::unpack_words(&words);
     println!("{}", host::ternary::format_trits(&trits));
+    Ok(())
+}
+
+fn run_host_weight_gen(neurons: u32, chunks: u32, pattern_str: &str) -> anyhow::Result<()> {
+    let pattern = host::weights::parse_pattern(pattern_str)
+        .ok_or_else(|| anyhow::anyhow!("invalid pattern '{}': expected all-n, all-z, all-p, alternating, phi-sequence, or seeded-random:SEED", pattern_str))?;
+    let config = host::weights::WeightConfig { neurons, chunks, pattern };
+    let words = host::weights::generate_weights(&config);
+    if words.is_empty() {
+        anyhow::bail!("no words generated: neurons and chunks must be > 0");
+    }
+    for w in &words {
+        println!("0x{:016x}", w);
+    }
     Ok(())
 }
 
@@ -8190,6 +8225,9 @@ async fn main() -> anyhow::Result<()> {
         Commands::HostUnpack { words } => {
             run_host_unpack(&words)?
         }
+        Commands::HostWeightGen { neurons, chunks, pattern } => {
+            run_host_weight_gen(neurons, chunks, &pattern)?
+        }
         Commands::Asm { input, output, format } => run_asm(&input, output.as_deref(), &format)?,
         Commands::GenTestbench { input, period_ns, max_cycles, output } => {
             run_gen_testbench(&input, period_ns, max_cycles, output.as_deref())?
@@ -8442,6 +8480,9 @@ fn main() -> anyhow::Result<()> {
         }
         Commands::HostUnpack { words } => {
             run_host_unpack(&words)?
+        }
+        Commands::HostWeightGen { neurons, chunks, pattern } => {
+            run_host_weight_gen(neurons, chunks, &pattern)?
         }
         Commands::Asm { input, output, format } => run_asm(&input, output.as_deref(), &format)?,
         Commands::GenTestbench { input, period_ns, max_cycles, output } => {

--- a/bootstrap/src/main.rs
+++ b/bootstrap/src/main.rs
@@ -500,6 +500,38 @@ enum Commands {
         pattern: String,
     },
 
+    /// Run full end-to-end host stack: weight-gen + inference + perf estimate
+    /// (Wave 46, R-HS-6).
+    ///
+    /// Generates weights, runs InferenceEngine, estimates performance, and
+    /// prints a comparison summary. Capstone for the host driver stack.
+    #[command(name = "host-e2e")]
+    HostE2e {
+        /// Number of layers (default: 2).
+        #[arg(long, default_value_t = 2)]
+        num_layers: u32,
+
+        /// Neurons per layer (default: 16).
+        #[arg(long, default_value_t = 16)]
+        neurons: u32,
+
+        /// Chunks per neuron (default: 4).
+        #[arg(long, default_value_t = 4)]
+        chunks: u32,
+
+        /// Threshold (default: 1).
+        #[arg(long, default_value_t = 1)]
+        threshold: u32,
+
+        /// Weight pattern (default: alternating).
+        #[arg(long, default_value = "alternating")]
+        pattern: String,
+
+        /// Emit structured JSON.
+        #[arg(long)]
+        json: bool,
+    },
+
     /// Emit a complete BitNet HLS bundle (Wave 38, R-SI-1).
     ///
     /// Composes all 9 BitNet HLS module emitters (W36a-f) plus the
@@ -3398,6 +3430,43 @@ fn run_host_weight_gen(neurons: u32, chunks: u32, pattern_str: &str) -> anyhow::
     }
     for w in &words {
         println!("0x{:016x}", w);
+    }
+    Ok(())
+}
+
+fn run_host_e2e(
+    num_layers: u32,
+    neurons: u32,
+    chunks: u32,
+    threshold: u32,
+    pattern_str: &str,
+    json: bool,
+) -> anyhow::Result<()> {
+    let pattern = host::weights::parse_pattern(pattern_str)
+        .ok_or_else(|| anyhow::anyhow!("invalid pattern '{}'", pattern_str))?;
+    let config = host::e2e::E2eConfig {
+        num_layers, neurons, chunks, threshold,
+        weight_addr: 0,
+        pattern,
+        max_rounds: 16,
+    };
+    let result = host::e2e::run_e2e(&config)?;
+    if json {
+        let j = host::e2e::E2eJson::from_result(&result);
+        host::json_output::print_json(&j)?;
+    } else {
+        println!(
+            "OK layers={} completed={} pattern={} weight_words={} writes={} reads={} est_cycles={} est_dma={} bram={:.1}%",
+            result.layers,
+            result.inference.layers_completed,
+            result.pattern,
+            result.weight_words,
+            result.inference.total_writes,
+            result.inference.total_reads,
+            result.estimate.total_inference_cycles,
+            result.estimate.total_dma_beats,
+            result.estimate.bram_utilization_pct,
+        );
     }
     Ok(())
 }
@@ -8228,6 +8297,9 @@ async fn main() -> anyhow::Result<()> {
         Commands::HostWeightGen { neurons, chunks, pattern } => {
             run_host_weight_gen(neurons, chunks, &pattern)?
         }
+        Commands::HostE2e { num_layers, neurons, chunks, threshold, pattern, json } => {
+            run_host_e2e(num_layers, neurons, chunks, threshold, &pattern, json)?
+        }
         Commands::Asm { input, output, format } => run_asm(&input, output.as_deref(), &format)?,
         Commands::GenTestbench { input, period_ns, max_cycles, output } => {
             run_gen_testbench(&input, period_ns, max_cycles, output.as_deref())?
@@ -8483,6 +8555,9 @@ fn main() -> anyhow::Result<()> {
         }
         Commands::HostWeightGen { neurons, chunks, pattern } => {
             run_host_weight_gen(neurons, chunks, &pattern)?
+        }
+        Commands::HostE2e { num_layers, neurons, chunks, threshold, pattern, json } => {
+            run_host_e2e(num_layers, neurons, chunks, threshold, &pattern, json)?
         }
         Commands::Asm { input, output, format } => run_asm(&input, output.as_deref(), &format)?,
         Commands::GenTestbench { input, period_ns, max_cycles, output } => {

--- a/bootstrap/src/main.rs
+++ b/bootstrap/src/main.rs
@@ -457,6 +457,28 @@ enum Commands {
         json: bool,
     },
 
+    /// Pack comma-separated trit values into 54-bit words (Wave 44, R-HT-1).
+    ///
+    /// Reads trit values from --trits (e.g., "-1,0,1,0,-1") and prints
+    /// one hex word per line. Encoding: 2'b00=-1, 2'b01=0, 2'b10=+1,
+    /// LSB-first, 27 trits per 54-bit word.
+    #[command(name = "host-pack")]
+    HostPack {
+        /// Comma-separated trit values (-1, 0, +1).
+        #[arg(long)]
+        trits: String,
+    },
+
+    /// Unpack hex words into comma-separated trit values (Wave 44, R-HT-1).
+    ///
+    /// Reads hex words from --words (comma-separated) and prints trit values.
+    #[command(name = "host-unpack")]
+    HostUnpack {
+        /// Comma-separated hex words (e.g., "0x3,0x0").
+        #[arg(long)]
+        words: String,
+    },
+
     /// Emit a complete BitNet HLS bundle (Wave 38, R-SI-1).
     ///
     /// Composes all 9 BitNet HLS module emitters (W36a-f) plus the
@@ -3312,6 +3334,36 @@ fn run_host_perf(
             clock_mhz,
         );
     }
+    Ok(())
+}
+
+fn run_host_pack(trits_str: &str) -> anyhow::Result<()> {
+    let trits = host::ternary::parse_trit_string(trits_str)
+        .ok_or_else(|| anyhow::anyhow!("invalid trit string: expected comma-separated -1, 0, +1"))?;
+    if trits.is_empty() {
+        anyhow::bail!("no trits provided");
+    }
+    let words = host::ternary::pack_words(&trits);
+    for w in &words {
+        println!("0x{:016x}", w);
+    }
+    Ok(())
+}
+
+fn run_host_unpack(words_str: &str) -> anyhow::Result<()> {
+    let words: Vec<u64> = words_str
+        .split(',')
+        .map(|tok| {
+            let tok = tok.trim().trim_start_matches("0x").trim_start_matches("0X");
+            u64::from_str_radix(tok, 16)
+                .map_err(|e| anyhow::anyhow!("invalid hex word '{}': {}", tok.trim(), e))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    if words.is_empty() {
+        anyhow::bail!("no words provided");
+    }
+    let trits = host::ternary::unpack_words(&words);
+    println!("{}", host::ternary::format_trits(&trits));
     Ok(())
 }
 
@@ -8132,6 +8184,12 @@ async fn main() -> anyhow::Result<()> {
         Commands::HostPerf { num_layers, neurons, chunks, clock_mhz, json } => {
             run_host_perf(num_layers, neurons, chunks, clock_mhz, json)?
         }
+        Commands::HostPack { trits } => {
+            run_host_pack(&trits)?
+        }
+        Commands::HostUnpack { words } => {
+            run_host_unpack(&words)?
+        }
         Commands::Asm { input, output, format } => run_asm(&input, output.as_deref(), &format)?,
         Commands::GenTestbench { input, period_ns, max_cycles, output } => {
             run_gen_testbench(&input, period_ns, max_cycles, output.as_deref())?
@@ -8378,6 +8436,12 @@ fn main() -> anyhow::Result<()> {
         }
         Commands::HostPerf { num_layers, neurons, chunks, clock_mhz, json } => {
             run_host_perf(num_layers, neurons, chunks, clock_mhz, json)?
+        }
+        Commands::HostPack { trits } => {
+            run_host_pack(&trits)?
+        }
+        Commands::HostUnpack { words } => {
+            run_host_unpack(&words)?
         }
         Commands::Asm { input, output, format } => run_asm(&input, output.as_deref(), &format)?,
         Commands::GenTestbench { input, period_ns, max_cycles, output } => {

--- a/bootstrap/src/main.rs
+++ b/bootstrap/src/main.rs
@@ -383,6 +383,39 @@ enum Commands {
         max_polls: u32,
     },
 
+    /// Run a multi-layer DMA-driven BitNet inference flow on MockMmio
+    /// (Wave 41, R-HS-3).
+    ///
+    /// Exercises the full configure -> DMA prefetch -> inference ->
+    /// DMA drain cycle per layer, using IrqDrivenDriver from W40.
+    /// Prints `OK layers=N completed=M writes=W reads=R`.
+    #[command(name = "host-inference")]
+    HostInference {
+        /// Number of layers to program (default: 2).
+        #[arg(long, default_value_t = 2)]
+        num_layers: u32,
+
+        /// Neurons per layer (default: 16).
+        #[arg(long, default_value_t = 16)]
+        neurons: u32,
+
+        /// Chunks per neuron (default: 4).
+        #[arg(long, default_value_t = 4)]
+        chunks: u32,
+
+        /// Signed threshold value (default: 1).
+        #[arg(long, default_value_t = 1)]
+        threshold: u32,
+
+        /// 64-bit weight base address as decimal (default: 0).
+        #[arg(long, default_value_t = 0)]
+        weight_addr: u64,
+
+        /// Maximum IRQ-service rounds per stage (default: 16).
+        #[arg(long, default_value_t = 16)]
+        max_rounds: u32,
+    },
+
     /// Emit a complete BitNet HLS bundle (Wave 38, R-SI-1).
     ///
     /// Composes all 9 BitNet HLS module emitters (W36a-f) plus the
@@ -3139,6 +3172,28 @@ fn run_host_poll_vs_irq(
     println!(
         "OK poll={}w/{}r irq={}w/{}r writes_match={} irq_stat_poll=0x{:08x} irq_stat_irq=0x{:08x}",
         poll_writes, poll_reads, irq_writes, irq_reads, writes_match, irq_stat_poll, irq_stat_irq
+    );
+    Ok(())
+}
+
+fn run_host_inference(
+    num_layers: u32,
+    neurons: u32,
+    chunks: u32,
+    threshold: u32,
+    weight_addr: u64,
+    max_rounds: u32,
+) -> anyhow::Result<()> {
+    use host::{BitnetDriver, InferenceEngine, MockMmio};
+    let mut engine = InferenceEngine::new(BitnetDriver::new(MockMmio::with_csrs_zeroed()));    engine
+        .configure(num_layers, neurons, chunks, threshold, weight_addr)
+        .map_err(|e| anyhow::anyhow!("configure failed: {:?}", e))?;
+    let report = engine
+        .run(max_rounds)
+        .map_err(|e| anyhow::anyhow!("inference failed: {:?}", e))?;
+    println!(
+        "OK layers={} completed={} writes={} reads={}",
+        report.total_layers, report.layers_completed, report.total_writes, report.total_reads
     );
     Ok(())
 }
@@ -7954,6 +8009,9 @@ async fn main() -> anyhow::Result<()> {
         Commands::HostPollVsIrq { num_layers, neurons, chunks, threshold, weight_addr, max_polls } => {
             run_host_poll_vs_irq(num_layers, neurons, chunks, threshold, weight_addr, max_polls)?
         }
+        Commands::HostInference { num_layers, neurons, chunks, threshold, weight_addr, max_rounds } => {
+            run_host_inference(num_layers, neurons, chunks, threshold, weight_addr, max_rounds)?
+        }
         Commands::Asm { input, output, format } => run_asm(&input, output.as_deref(), &format)?,
         Commands::GenTestbench { input, period_ns, max_cycles, output } => {
             run_gen_testbench(&input, period_ns, max_cycles, output.as_deref())?
@@ -8194,6 +8252,9 @@ fn main() -> anyhow::Result<()> {
         }
         Commands::HostPollVsIrq { num_layers, neurons, chunks, threshold, weight_addr, max_polls } => {
             run_host_poll_vs_irq(num_layers, neurons, chunks, threshold, weight_addr, max_polls)?
+        }
+        Commands::HostInference { num_layers, neurons, chunks, threshold, weight_addr, max_rounds } => {
+            run_host_inference(num_layers, neurons, chunks, threshold, weight_addr, max_rounds)?
         }
         Commands::Asm { input, output, format } => run_asm(&input, output.as_deref(), &format)?,
         Commands::GenTestbench { input, period_ns, max_cycles, output } => {

--- a/bootstrap/tests/host_e2e.rs
+++ b/bootstrap/tests/host_e2e.rs
@@ -1,0 +1,174 @@
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_t27c")
+}
+
+fn run(args: &[&str]) -> (bool, String, String) {
+    let out = Command::new(bin())
+        .args(args)
+        .output()
+        .expect("failed to spawn t27c");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+fn run_e2e(extra: &[&str]) -> (bool, String, String) {
+    let mut args = vec!["host-e2e"];
+    args.extend(extra);
+    run(&args)
+}
+
+#[test]
+fn e2e_default_succeeds() {
+    let (ok, stdout, _) = run_e2e(&[]);
+    assert!(ok);
+    assert!(stdout.starts_with("OK "), "stdout = {stdout}");
+}
+
+#[test]
+fn e2e_prints_layers() {
+    let (ok, stdout, _) = run_e2e(&[]);
+    assert!(ok);
+    assert!(stdout.contains("layers=2"), "stdout = {stdout}");
+}
+
+#[test]
+fn e2e_prints_completed() {
+    let (ok, stdout, _) = run_e2e(&[]);
+    assert!(ok);
+    assert!(stdout.contains("completed=2"), "stdout = {stdout}");
+}
+
+#[test]
+fn e2e_prints_pattern() {
+    let (ok, stdout, _) = run_e2e(&[]);
+    assert!(ok);
+    assert!(stdout.contains("pattern=alternating"), "stdout = {stdout}");
+}
+
+#[test]
+fn e2e_prints_weight_words() {
+    let (ok, stdout, _) = run_e2e(&[]);
+    assert!(ok);
+    assert!(stdout.contains("weight_words="), "stdout = {stdout}");
+}
+
+#[test]
+fn e2e_prints_writes_reads() {
+    let (ok, stdout, _) = run_e2e(&[]);
+    assert!(ok);
+    assert!(stdout.contains("writes="), "stdout = {stdout}");
+    assert!(stdout.contains("reads="), "stdout = {stdout}");
+}
+
+#[test]
+fn e2e_prints_estimated_metrics() {
+    let (ok, stdout, _) = run_e2e(&[]);
+    assert!(ok);
+    assert!(stdout.contains("est_cycles="), "stdout = {stdout}");
+    assert!(stdout.contains("est_dma="), "stdout = {stdout}");
+    assert!(stdout.contains("bram="), "stdout = {stdout}");
+}
+
+#[test]
+fn e2e_single_layer() {
+    let (ok, stdout, _) = run_e2e(&["--num-layers=1"]);
+    assert!(ok);
+    assert!(stdout.contains("layers=1 completed=1"));
+}
+
+#[test]
+fn e2e_custom_neurons() {
+    let (ok, stdout, _) = run_e2e(&["--neurons=32"]);
+    assert!(ok);
+    assert!(stdout.contains("weight_words=128"), "32*4=128: {stdout}");
+}
+
+#[test]
+fn e2e_all_n_pattern() {
+    let (ok, stdout, _) = run_e2e(&["--pattern=all-n"]);
+    assert!(ok);
+    assert!(stdout.contains("pattern=all-n"));
+}
+
+#[test]
+fn e2e_seeded_pattern() {
+    let (ok, stdout, _) = run_e2e(&["--pattern=seeded-random:42"]);
+    assert!(ok);
+}
+
+#[test]
+fn e2e_invalid_pattern_fails() {
+    let (ok, _, stderr) = run_e2e(&["--pattern=bogus"]);
+    assert!(!ok);
+    assert!(stderr.contains("invalid pattern"));
+}
+
+#[test]
+fn e2e_json_valid() {
+    let (ok, stdout, _) = run_e2e(&["--json"]);
+    assert!(ok);
+    let v: serde_json::Value = stdout.trim().parse().unwrap();
+    assert_eq!(v["ok"], true);
+}
+
+#[test]
+fn e2e_json_has_all_fields() {
+    let (ok, stdout, _) = run_e2e(&["--json"]);
+    assert!(ok);
+    let v: serde_json::Value = stdout.trim().parse().unwrap();
+    for key in ["layers", "neurons", "chunks", "pattern", "weight_words", "layers_completed", "total_writes", "total_reads", "estimated_cycles", "estimated_dma_beats", "bram_pct", "weight_gen_ok"] {
+        assert!(v.get(key).is_some(), "missing field {key}");
+    }
+}
+
+#[test]
+fn e2e_deterministic() {
+    let (ok1, s1, _) = run_e2e(&[]);
+    let (ok2, s2, _) = run_e2e(&[]);
+    assert!(ok1 && ok2);
+    assert_eq!(s1, s2);
+}
+
+#[test]
+fn e2e_single_line_output() {
+    let (ok, stdout, _) = run_e2e(&[]);
+    assert!(ok);
+    let trimmed = stdout.trim_end_matches('\n');
+    assert!(!trimmed.contains('\n'));
+}
+
+#[test]
+fn e2e_no_stderr_on_success() {
+    let (ok, _, stderr) = run_e2e(&[]);
+    assert!(ok);
+    assert!(stderr.trim().is_empty());
+}
+
+#[test]
+fn e2e_help_lists_flags() {
+    let (ok, stdout, _) = run_e2e(&["--help"]);
+    assert!(ok);
+    for flag in ["--num-layers", "--neurons", "--chunks", "--threshold", "--pattern", "--json"] {
+        assert!(stdout.contains(flag), "missing {flag}");
+    }
+}
+
+#[test]
+fn e2e_help_mentions_wave_46() {
+    let (ok, stdout, _) = run_e2e(&["--help"]);
+    assert!(ok);
+    assert!(stdout.contains("Wave 46") || stdout.contains("R-HS-6"), "expected Wave 46: {stdout}");
+}
+
+#[test]
+fn e2e_json_deterministic() {
+    let (ok1, s1, _) = run_e2e(&["--json"]);
+    let (ok2, s2, _) = run_e2e(&["--json"]);
+    assert!(ok1 && ok2);
+    assert_eq!(s1, s2);
+}

--- a/bootstrap/tests/host_engine.rs
+++ b/bootstrap/tests/host_engine.rs
@@ -1,0 +1,162 @@
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_t27c")
+}
+
+fn run(args: &[&str]) -> (bool, String, String) {
+    let out = Command::new(bin())
+        .args(args)
+        .output()
+        .expect("failed to spawn t27c");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+#[test]
+fn inference_default_succeeds() {
+    let (ok, stdout, _) = run(&["host-inference"]);
+    assert!(ok, "default should succeed");
+    assert!(stdout.starts_with("OK "), "stdout = {stdout}");
+}
+
+#[test]
+fn inference_prints_layer_count() {
+    let (ok, stdout, _) = run(&["host-inference"]);
+    assert!(ok);
+    assert!(stdout.contains("layers=2"), "stdout = {stdout}");
+}
+
+#[test]
+fn inference_prints_completed_count() {
+    let (ok, stdout, _) = run(&["host-inference"]);
+    assert!(ok);
+    assert!(stdout.contains("completed=2"), "stdout = {stdout}");
+}
+
+#[test]
+fn inference_prints_writes() {
+    let (ok, stdout, _) = run(&["host-inference"]);
+    assert!(ok);
+    assert!(stdout.contains("writes="), "stdout = {stdout}");
+}
+
+#[test]
+fn inference_prints_reads() {
+    let (ok, stdout, _) = run(&["host-inference"]);
+    assert!(ok);
+    assert!(stdout.contains("reads="), "stdout = {stdout}");
+}
+
+#[test]
+fn inference_single_layer() {
+    let (ok, stdout, _) = run(&["host-inference", "--num-layers", "1"]);
+    assert!(ok);
+    assert!(stdout.contains("layers=1 completed=1"), "stdout = {stdout}");
+}
+
+#[test]
+fn inference_three_layers() {
+    let (ok, stdout, _) = run(&["host-inference", "--num-layers", "3"]);
+    assert!(ok);
+    assert!(stdout.contains("layers=3 completed=3"), "stdout = {stdout}");
+}
+
+#[test]
+fn inference_custom_neurons() {
+    let (ok, stdout, _) = run(&["host-inference", "--neurons", "128"]);
+    assert!(ok);
+}
+
+#[test]
+fn inference_custom_chunks() {
+    let (ok, stdout, _) = run(&["host-inference", "--chunks", "32"]);
+    assert!(ok);
+}
+
+#[test]
+fn inference_custom_threshold() {
+    let (ok, stdout, _) = run(&["host-inference", "--threshold", "42"]);
+    assert!(ok);
+}
+
+#[test]
+fn inference_custom_weight_addr() {
+    let (ok, stdout, _) = run(&["host-inference", "--weight-addr", "1099511627776"]);
+    assert!(ok);
+}
+
+#[test]
+fn inference_zero_layers_fails() {
+    let (ok, _, stderr) = run(&["host-inference", "--num-layers", "0"]);
+    assert!(!ok);
+    assert!(stderr.contains("configure") || stderr.contains("InvalidConfig"));
+}
+
+#[test]
+fn inference_zero_neurons_fails() {
+    let (ok, _, _stderr) = run(&["host-inference", "--neurons", "0"]);
+    assert!(!ok);
+}
+
+#[test]
+fn inference_zero_chunks_fails() {
+    let (ok, _, _stderr) = run(&["host-inference", "--chunks", "0"]);
+    assert!(!ok);
+}
+
+#[test]
+fn inference_deterministic() {
+    let (ok1, s1, _) = run(&["host-inference"]);
+    let (ok2, s2, _) = run(&["host-inference"]);
+    assert!(ok1 && ok2);
+    assert_eq!(s1, s2, "should be deterministic");
+}
+
+#[test]
+fn inference_single_line_output() {
+    let (ok, stdout, _) = run(&["host-inference"]);
+    assert!(ok);
+    let trimmed = stdout.trim_end_matches('\n');
+    assert!(!trimmed.contains('\n'), "expected single line, got {stdout}");
+}
+
+#[test]
+fn inference_no_stderr_on_success() {
+    let (ok, _, stderr) = run(&["host-inference"]);
+    assert!(ok);
+    assert!(stderr.trim().is_empty(), "stderr should be empty: {stderr}");
+}
+
+#[test]
+fn inference_combined_overrides() {
+    let (ok, stdout, _) = run(&[
+        "host-inference",
+        "--num-layers", "3",
+        "--neurons", "64",
+        "--chunks", "8",
+        "--threshold", "42",
+        "--weight-addr", "1024",
+    ]);
+    assert!(ok);
+    assert!(stdout.contains("layers=3 completed=3"));
+}
+
+#[test]
+fn inference_help_lists_all_flags() {
+    let (ok, stdout, _) = run(&["host-inference", "--help"]);
+    assert!(ok);
+    for flag in ["--num-layers", "--neurons", "--chunks", "--threshold", "--weight-addr", "--max-rounds"] {
+        assert!(stdout.contains(flag), "missing {flag} in help: {stdout}");
+    }
+}
+
+#[test]
+fn inference_help_mentions_wave_41() {
+    let (ok, stdout, _) = run(&["host-inference", "--help"]);
+    assert!(ok);
+    assert!(stdout.contains("Wave 41") || stdout.contains("R-HS-3"), "expected Wave 41 / R-HS-3: {stdout}");
+}

--- a/bootstrap/tests/host_irq.rs
+++ b/bootstrap/tests/host_irq.rs
@@ -1,0 +1,169 @@
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_t27c")
+}
+
+fn run(args: &[&str]) -> (bool, String, String) {
+    let out = Command::new(bin())
+        .args(args)
+        .output()
+        .expect("failed to spawn t27c");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+#[test]
+fn poll_vs_irq_default_succeeds() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq"]);
+    assert!(ok, "default should succeed");
+    assert!(stdout.starts_with("OK "), "stdout = {stdout}");
+}
+
+#[test]
+fn poll_vs_irq_prints_poll_metrics() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq"]);
+    assert!(ok);
+    assert!(stdout.contains("poll="), "stdout = {stdout}");
+}
+
+#[test]
+fn poll_vs_irq_prints_irq_metrics() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq"]);
+    assert!(ok);
+    assert!(stdout.contains("irq="), "stdout = {stdout}");
+}
+
+#[test]
+fn poll_vs_irq_writes_match_field_present() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq"]);
+    assert!(ok);
+    assert!(stdout.contains("writes_match="), "stdout = {stdout}");
+}
+
+#[test]
+fn poll_vs_irq_prints_irq_stat_poll() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq"]);
+    assert!(ok);
+    assert!(stdout.contains("irq_stat_poll=0x"), "stdout = {stdout}");
+}
+
+#[test]
+fn poll_vs_irq_prints_irq_stat_irq() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq"]);
+    assert!(ok);
+    assert!(stdout.contains("irq_stat_irq=0x"), "stdout = {stdout}");
+}
+
+#[test]
+fn poll_vs_irq_custom_layers() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq", "--num-layers", "5"]);
+    assert!(ok);
+    assert!(stdout.starts_with("OK "));
+}
+
+#[test]
+fn poll_vs_irq_custom_neurons() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq", "--neurons", "128"]);
+    assert!(ok);
+}
+
+#[test]
+fn poll_vs_irq_custom_chunks() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq", "--chunks", "32"]);
+    assert!(ok);
+}
+
+#[test]
+fn poll_vs_irq_custom_threshold() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq", "--threshold", "7"]);
+    assert!(ok);
+}
+
+#[test]
+fn poll_vs_irq_custom_weight_addr() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq", "--weight-addr", "1099511627776"]);
+    assert!(ok);
+}
+
+#[test]
+fn poll_vs_irq_zero_layers_fails() {
+    let (ok, _, stderr) = run(&["host-poll-vs-irq", "--num-layers", "0"]);
+    assert!(!ok);
+    assert!(stderr.contains("configure") || stderr.contains("InvalidConfig"));
+}
+
+#[test]
+fn poll_vs_irq_zero_neurons_fails() {
+    let (ok, _, _stderr) = run(&["host-poll-vs-irq", "--neurons", "0"]);
+    assert!(!ok);
+}
+
+#[test]
+fn poll_vs_irq_zero_chunks_fails() {
+    let (ok, _, _stderr) = run(&["host-poll-vs-irq", "--chunks", "0"]);
+    assert!(!ok);
+}
+
+#[test]
+fn poll_vs_irq_max_polls_one_succeeds() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq", "--max-polls", "1"]);
+    assert!(ok, "done is preset, 1 poll is enough");
+    assert!(stdout.starts_with("OK "));
+}
+
+#[test]
+fn poll_vs_irq_deterministic() {
+    let (ok1, s1, _) = run(&["host-poll-vs-irq"]);
+    let (ok2, s2, _) = run(&["host-poll-vs-irq"]);
+    assert!(ok1 && ok2);
+    assert_eq!(s1, s2, "should be deterministic");
+}
+
+#[test]
+fn poll_vs_irq_single_line_output() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq"]);
+    assert!(ok);
+    let trimmed = stdout.trim_end_matches('\n');
+    assert!(!trimmed.contains('\n'), "expected single line, got {stdout}");
+}
+
+#[test]
+fn poll_vs_irq_no_stderr_on_success() {
+    let (ok, _, stderr) = run(&["host-poll-vs-irq"]);
+    assert!(ok);
+    assert!(stderr.trim().is_empty(), "stderr should be empty: {stderr}");
+}
+
+#[test]
+fn poll_vs_irq_combined_overrides() {
+    let (ok, stdout, _) = run(&[
+        "host-poll-vs-irq",
+        "--num-layers", "3",
+        "--neurons", "64",
+        "--chunks", "8",
+        "--threshold", "42",
+        "--weight-addr", "1024",
+    ]);
+    assert!(ok);
+    assert!(stdout.contains("writes_match="));
+}
+
+#[test]
+fn poll_vs_irq_help_lists_all_flags() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq", "--help"]);
+    assert!(ok);
+    for flag in ["--num-layers", "--neurons", "--chunks", "--threshold", "--weight-addr", "--max-polls"] {
+        assert!(stdout.contains(flag), "missing {flag} in help: {stdout}");
+    }
+}
+
+#[test]
+fn poll_vs_irq_help_mentions_wave_40() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq", "--help"]);
+    assert!(ok);
+    assert!(stdout.contains("Wave 40") || stdout.contains("R-HS-2"), "expected Wave 40 / R-HS-2: {stdout}");
+}

--- a/bootstrap/tests/host_json.rs
+++ b/bootstrap/tests/host_json.rs
@@ -1,0 +1,235 @@
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_t27c")
+}
+
+fn run(args: &[&str]) -> (bool, String, String) {
+    let out = Command::new(bin())
+        .args(args)
+        .output()
+        .expect("failed to spawn t27c");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+fn parse_json(s: &str) -> serde_json::Value {
+    let trimmed = s.trim();
+    serde_json::from_str(trimmed).unwrap_or_else(|e| panic!("invalid JSON: {e}\ninput: {trimmed}"))
+}
+
+// -- host-smoke --json --
+
+#[test]
+fn smoke_json_is_valid() {
+    let (ok, stdout, _) = run(&["host-smoke", "--json"]);
+    assert!(ok);
+    let v = parse_json(&stdout);
+    assert_eq!(v["ok"], true);
+}
+
+#[test]
+fn smoke_json_has_writes_reads() {
+    let (ok, stdout, _) = run(&["host-smoke", "--json"]);
+    assert!(ok);
+    let v = parse_json(&stdout);
+    assert!(v["writes"].is_number());
+    assert!(v["reads"].is_number());
+}
+
+#[test]
+fn smoke_json_has_config_fields() {
+    let (ok, stdout, _) = run(&["host-smoke", "--json"]);
+    assert!(ok);
+    let v = parse_json(&stdout);
+    assert_eq!(v["layers"], 2);
+    assert_eq!(v["neurons"], 16);
+    assert_eq!(v["chunks"], 4);
+    assert_eq!(v["threshold"], 1);
+}
+
+#[test]
+fn smoke_json_weight_addr_is_string() {
+    let (ok, stdout, _) = run(&["host-smoke", "--json"]);
+    assert!(ok);
+    let v = parse_json(&stdout);
+    assert!(v["weight_addr"].is_string());
+    assert!(v["weight_addr"].as_str().unwrap().starts_with("0x"));
+}
+
+#[test]
+fn smoke_json_irq_stat_is_string() {
+    let (ok, stdout, _) = run(&["host-smoke", "--json"]);
+    assert!(ok);
+    let v = parse_json(&stdout);
+    assert!(v["irq_stat"].is_string());
+}
+
+// -- host-poll-vs-irq --json --
+
+#[test]
+fn poll_vs_irq_json_is_valid() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq", "--json"]);
+    assert!(ok);
+    let v = parse_json(&stdout);
+    assert_eq!(v["ok"], true);
+}
+
+#[test]
+fn poll_vs_irq_json_has_poll_and_irq_counts() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq", "--json"]);
+    assert!(ok);
+    let v = parse_json(&stdout);
+    assert!(v["poll_writes"].is_number());
+    assert!(v["poll_reads"].is_number());
+    assert!(v["irq_writes"].is_number());
+    assert!(v["irq_reads"].is_number());
+}
+
+#[test]
+fn poll_vs_irq_json_writes_match_is_bool() {
+    let (ok, stdout, _) = run(&["host-poll-vs-irq", "--json"]);
+    assert!(ok);
+    let v = parse_json(&stdout);
+    assert!(v["writes_match"].is_boolean());
+}
+
+// -- host-inference --json --
+
+#[test]
+fn inference_json_is_valid() {
+    let (ok, stdout, _) = run(&["host-inference", "--json"]);
+    assert!(ok);
+    let v = parse_json(&stdout);
+    assert_eq!(v["ok"], true);
+}
+
+#[test]
+fn inference_json_has_layers_completed() {
+    let (ok, stdout, _) = run(&["host-inference", "--json"]);
+    assert!(ok);
+    let v = parse_json(&stdout);
+    assert_eq!(v["total_layers"], 2);
+    assert_eq!(v["layers_completed"], 2);
+}
+
+#[test]
+fn inference_json_has_writes_reads() {
+    let (ok, stdout, _) = run(&["host-inference", "--json"]);
+    assert!(ok);
+    let v = parse_json(&stdout);
+    assert!(v["total_writes"].is_number());
+    assert!(v["total_reads"].is_number());
+}
+
+#[test]
+fn inference_json_error_layer_is_null_on_success() {
+    let (ok, stdout, _) = run(&["host-inference", "--json"]);
+    assert!(ok);
+    let v = parse_json(&stdout);
+    assert!(v["error_layer"].is_null());
+}
+
+#[test]
+fn inference_json_single_layer() {
+    let (ok, stdout, _) = run(&["host-inference", "--json", "--num-layers", "1"]);
+    assert!(ok);
+    let v = parse_json(&stdout);
+    assert_eq!(v["total_layers"], 1);
+    assert_eq!(v["layers_completed"], 1);
+}
+
+// -- host-perf --json --
+
+#[test]
+fn perf_json_is_valid() {
+    let (ok, stdout, _) = run(&["host-perf", "--json"]);
+    assert!(ok);
+    let v = parse_json(&stdout);
+    assert_eq!(v["ok"], true);
+}
+
+#[test]
+fn perf_json_has_config() {
+    let (ok, stdout, _) = run(&["host-perf", "--json"]);
+    assert!(ok);
+    let v = parse_json(&stdout);
+    assert_eq!(v["layers"], 2);
+    assert_eq!(v["neurons"], 16);
+    assert_eq!(v["chunks"], 4);
+}
+
+#[test]
+fn perf_json_has_cycles_and_dma() {
+    let (ok, stdout, _) = run(&["host-perf", "--json"]);
+    assert!(ok);
+    let v = parse_json(&stdout);
+    assert!(v["total_cycles"].is_number());
+    assert!(v["total_dma_beats"].is_number());
+    assert!(v["total_weight_words"].is_number());
+}
+
+#[test]
+fn perf_json_has_bram_pct() {
+    let (ok, stdout, _) = run(&["host-perf", "--json"]);
+    assert!(ok);
+    let v = parse_json(&stdout);
+    assert!(v["bram_utilization_pct"].is_number());
+}
+
+#[test]
+fn perf_json_has_throughput() {
+    let (ok, stdout, _) = run(&["host-perf", "--json"]);
+    assert!(ok);
+    let v = parse_json(&stdout);
+    assert!(v["throughput_inf_per_sec"].is_number());
+    assert!(v["clock_mhz"].is_number());
+}
+
+#[test]
+fn perf_json_custom_clock() {
+    let (ok, stdout, _) = run(&["host-perf", "--json", "--clock-mhz", "100.0"]);
+    assert!(ok);
+    let v = parse_json(&stdout);
+    assert_eq!(v["clock_mhz"], 100.0);
+}
+
+// -- cross-command: without --json, output is NOT JSON --
+
+#[test]
+fn smoke_without_json_is_not_json_object() {
+    let (ok, stdout, _) = run(&["host-smoke"]);
+    assert!(ok);
+    let trimmed = stdout.trim();
+    assert!(trimmed.starts_with("OK "), "expected human-readable: {trimmed}");
+    assert!(!trimmed.starts_with("{"), "should not be JSON: {trimmed}");
+}
+
+#[test]
+fn perf_without_json_is_not_json_object() {
+    let (ok, stdout, _) = run(&["host-perf"]);
+    assert!(ok);
+    let trimmed = stdout.trim();
+    assert!(trimmed.starts_with("OK "), "expected human-readable: {trimmed}");
+}
+
+// -- determinism --
+
+#[test]
+fn smoke_json_deterministic() {
+    let (ok1, s1, _) = run(&["host-smoke", "--json"]);
+    let (ok2, s2, _) = run(&["host-smoke", "--json"]);
+    assert!(ok1 && ok2);
+    assert_eq!(s1, s2);
+}
+
+#[test]
+fn perf_json_deterministic() {
+    let (ok1, s1, _) = run(&["host-perf", "--json"]);
+    let (ok2, s2, _) = run(&["host-perf", "--json"]);
+    assert!(ok1 && ok2);
+    assert_eq!(s1, s2);
+}

--- a/bootstrap/tests/host_perf.rs
+++ b/bootstrap/tests/host_perf.rs
@@ -1,0 +1,189 @@
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_t27c")
+}
+
+fn run(args: &[&str]) -> (bool, String, String) {
+    let out = Command::new(bin())
+        .args(args)
+        .output()
+        .expect("failed to spawn t27c");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+#[test]
+fn perf_default_succeeds() {
+    let (ok, stdout, _) = run(&["host-perf"]);
+    assert!(ok, "default should succeed");
+    assert!(stdout.starts_with("OK "), "stdout = {stdout}");
+}
+
+#[test]
+fn perf_prints_layer_count() {
+    let (ok, stdout, _) = run(&["host-perf"]);
+    assert!(ok);
+    assert!(stdout.contains("layers=2"), "stdout = {stdout}");
+}
+
+#[test]
+fn perf_prints_neuron_count() {
+    let (ok, stdout, _) = run(&["host-perf"]);
+    assert!(ok);
+    assert!(stdout.contains("neurons=16"), "stdout = {stdout}");
+}
+
+#[test]
+fn perf_prints_chunk_count() {
+    let (ok, stdout, _) = run(&["host-perf"]);
+    assert!(ok);
+    assert!(stdout.contains("chunks=4"), "stdout = {stdout}");
+}
+
+#[test]
+fn perf_prints_total_cycles() {
+    let (ok, stdout, _) = run(&["host-perf"]);
+    assert!(ok);
+    assert!(stdout.contains("total_cycles="), "stdout = {stdout}");
+}
+
+#[test]
+fn perf_prints_weight_words() {
+    let (ok, stdout, _) = run(&["host-perf"]);
+    assert!(ok);
+    assert!(stdout.contains("total_weight_words="), "stdout = {stdout}");
+}
+
+#[test]
+fn perf_prints_bram_pct() {
+    let (ok, stdout, _) = run(&["host-perf"]);
+    assert!(ok);
+    assert!(stdout.contains("bram_pct="), "stdout = {stdout}");
+}
+
+#[test]
+fn perf_prints_dma_beats() {
+    let (ok, stdout, _) = run(&["host-perf"]);
+    assert!(ok);
+    assert!(stdout.contains("dma_beats="), "stdout = {stdout}");
+}
+
+#[test]
+fn perf_prints_throughput() {
+    let (ok, stdout, _) = run(&["host-perf"]);
+    assert!(ok);
+    assert!(stdout.contains("throughput="), "stdout = {stdout}");
+    assert!(stdout.contains("inf/s"), "stdout = {stdout}");
+}
+
+#[test]
+fn perf_prints_clock_freq() {
+    let (ok, stdout, _) = run(&["host-perf"]);
+    assert!(ok);
+    assert!(stdout.contains("MHz"), "stdout = {stdout}");
+}
+
+#[test]
+fn perf_custom_layers() {
+    let (ok, stdout, _) = run(&["host-perf", "--num-layers", "5"]);
+    assert!(ok);
+    assert!(stdout.contains("layers=5"), "stdout = {stdout}");
+}
+
+#[test]
+fn perf_custom_neurons() {
+    let (ok, stdout, _) = run(&["host-perf", "--neurons", "128"]);
+    assert!(ok);
+    assert!(stdout.contains("neurons=128"), "stdout = {stdout}");
+}
+
+#[test]
+fn perf_custom_chunks() {
+    let (ok, stdout, _) = run(&["host-perf", "--chunks", "32"]);
+    assert!(ok);
+    assert!(stdout.contains("chunks=32"), "stdout = {stdout}");
+}
+
+#[test]
+fn perf_custom_clock() {
+    let (ok, stdout, _) = run(&["host-perf", "--clock-mhz", "100.0"]);
+    assert!(ok);
+    assert!(stdout.contains("@ 100.0 MHz"), "stdout = {stdout}");
+}
+
+#[test]
+fn perf_zero_layers_fails() {
+    let (ok, _, stderr) = run(&["host-perf", "--num-layers", "0"]);
+    assert!(!ok);
+    assert!(stderr.contains("invalid config"), "stderr = {stderr}");
+}
+
+#[test]
+fn perf_zero_neurons_fails() {
+    let (ok, _, _stderr) = run(&["host-perf", "--neurons", "0"]);
+    assert!(!ok);
+}
+
+#[test]
+fn perf_zero_chunks_fails() {
+    let (ok, _, _stderr) = run(&["host-perf", "--chunks", "0"]);
+    assert!(!ok);
+}
+
+#[test]
+fn perf_deterministic() {
+    let (ok1, s1, _) = run(&["host-perf"]);
+    let (ok2, s2, _) = run(&["host-perf"]);
+    assert!(ok1 && ok2);
+    assert_eq!(s1, s2, "should be deterministic");
+}
+
+#[test]
+fn perf_single_line_output() {
+    let (ok, stdout, _) = run(&["host-perf"]);
+    assert!(ok);
+    let trimmed = stdout.trim_end_matches('\n');
+    assert!(!trimmed.contains('\n'), "expected single line, got {stdout}");
+}
+
+#[test]
+fn perf_no_stderr_on_success() {
+    let (ok, _, stderr) = run(&["host-perf"]);
+    assert!(ok);
+    assert!(stderr.trim().is_empty(), "stderr should be empty: {stderr}");
+}
+
+#[test]
+fn perf_help_lists_all_flags() {
+    let (ok, stdout, _) = run(&["host-perf", "--help"]);
+    assert!(ok);
+    for flag in ["--num-layers", "--neurons", "--chunks", "--clock-mhz"] {
+        assert!(stdout.contains(flag), "missing {flag} in help: {stdout}");
+    }
+}
+
+#[test]
+fn perf_help_mentions_wave_42() {
+    let (ok, stdout, _) = run(&["host-perf", "--help"]);
+    assert!(ok);
+    assert!(stdout.contains("Wave 42") || stdout.contains("R-HS-4"), "expected Wave 42 / R-HS-4: {stdout}");
+}
+
+#[test]
+fn perf_cycles_increase_with_layers() {
+    let (ok1, s1, _) = run(&["host-perf", "--num-layers", "1"]);
+    let (ok2, s2, _) = run(&["host-perf", "--num-layers", "4"]);
+    assert!(ok1 && ok2);
+    let c1: u64 = extract_total_cycles(&s1);
+    let c2: u64 = extract_total_cycles(&s2);
+    assert!(c2 > c1, "4-layer cycles ({c2}) should exceed 1-layer ({c1})");
+}
+
+fn extract_total_cycles(s: &str) -> u64 {
+    let part = s.split("total_cycles=").nth(1).unwrap_or("");
+    part.split_whitespace().next().unwrap_or("0").parse().unwrap_or(0)
+}

--- a/bootstrap/tests/host_ternary.rs
+++ b/bootstrap/tests/host_ternary.rs
@@ -1,0 +1,192 @@
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_t27c")
+}
+
+fn run(args: &[&str]) -> (bool, String, String) {
+    let out = Command::new(bin())
+        .args(args)
+        .output()
+        .expect("failed to spawn t27c");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+fn run_pack(trits: &str) -> (bool, String, String) {
+    run(&["host-pack", &format!("--trits={}", trits)])
+}
+
+// -- host-pack --
+
+#[test]
+fn pack_single_n() {
+    let (ok, stdout, _) = run_pack("-1");
+    assert!(ok);
+    assert!(stdout.contains("0x0000000000000000"), "stdout = {stdout}");
+}
+
+#[test]
+fn pack_single_z() {
+    let (ok, stdout, _) = run_pack("0");
+    assert!(ok);
+    assert!(stdout.contains("0x0000000000000001"), "stdout = {stdout}");
+}
+
+#[test]
+fn pack_single_p() {
+    let (ok, stdout, _) = run_pack("1");
+    assert!(ok);
+    assert!(stdout.contains("0x0000000000000002"), "stdout = {stdout}");
+}
+
+#[test]
+fn pack_pn_pair() {
+    let (ok, stdout, _) = run_pack("1,-1");
+    assert!(ok);
+    assert!(stdout.contains("0x0000000000000002"), "stdout = {stdout}");
+}
+
+#[test]
+fn pack_27_trits_one_word() {
+    let trits: Vec<String> = (0..27).map(|i| format!("{}", (i % 3) as i8 - 1)).collect();
+    let (ok, stdout, _) = run_pack(&trits.join(","));
+    assert!(ok);
+    let lines: Vec<&str> = stdout.trim().lines().collect();
+    assert_eq!(lines.len(), 1, "27 trits should produce 1 word");
+}
+
+#[test]
+fn pack_54_trits_two_words() {
+    let trits: Vec<String> = (0..54).map(|i| format!("{}", (i % 3) as i8 - 1)).collect();
+    let (ok, stdout, _) = run_pack(&trits.join(","));
+    assert!(ok);
+    let lines: Vec<&str> = stdout.trim().lines().collect();
+    assert_eq!(lines.len(), 2, "54 trits should produce 2 words");
+}
+
+#[test]
+fn pack_invalid_trit_fails() {
+    let (ok, _, stderr) = run_pack("1,2,3");
+    assert!(!ok);
+    assert!(stderr.contains("invalid trit"));
+}
+
+#[test]
+fn pack_empty_fails() {
+    let (ok, _, _stderr) = run_pack("");
+    assert!(!ok);
+}
+
+#[test]
+fn pack_output_is_hex_words() {
+    let (ok, stdout, _) = run_pack("1,0,-1");
+    assert!(ok);
+    for line in stdout.trim().lines() {
+        assert!(line.starts_with("0x"), "expected hex word: {line}");
+    }
+}
+
+fn run_unpack(words: &str) -> (bool, String, String) {
+    run(&["host-unpack", &format!("--words={}", words)])
+}
+
+// -- host-unpack --
+
+#[test]
+fn unpack_single_n() {
+    let (ok, stdout, _) = run_unpack("0x0");
+    assert!(ok);
+    assert!(stdout.trim().starts_with("-1"), "stdout = {stdout}");
+}
+
+#[test]
+fn unpack_single_z() {
+    let (ok, stdout, _) = run_unpack("0x1");
+    assert!(ok);
+    let trits: Vec<&str> = stdout.trim().split(',').collect();
+    assert_eq!(trits[0], "0");
+}
+
+#[test]
+fn unpack_single_p() {
+    let (ok, stdout, _) = run_unpack("0x2");
+    assert!(ok);
+    let trits: Vec<&str> = stdout.trim().split(',').collect();
+    assert_eq!(trits[0], "1");
+}
+
+#[test]
+fn unpack_produces_27_trits_per_word() {
+    let (ok, stdout, _) = run_unpack("0x0");
+    assert!(ok);
+    let count = stdout.trim().split(',').count();
+    assert_eq!(count, 27);
+}
+
+#[test]
+fn unpack_two_words_produces_54_trits() {
+    let (ok, stdout, _) = run_unpack("0x0,0x0");
+    assert!(ok);
+    let count = stdout.trim().split(',').count();
+    assert_eq!(count, 54);
+}
+
+#[test]
+fn unpack_invalid_hex_fails() {
+    let (ok, _, stderr) = run_unpack("zzzz");
+    assert!(!ok);
+    assert!(stderr.contains("invalid hex"));
+}
+
+#[test]
+fn unpack_empty_fails() {
+    let (ok, _, _stderr) = run_unpack("");
+    assert!(!ok);
+}
+
+// -- round-trip: pack then unpack --
+
+#[test]
+fn roundtrip_pack_unpack() {
+    let trits = "-1,0,1,0,-1,1,1,-1,0";
+    let (ok1, packed, _) = run_pack(trits);
+    assert!(ok1);
+    let hex_words = packed.trim().lines().collect::<Vec<_>>().join(",");
+    let (ok2, unpacked, _) = run_unpack(&hex_words);
+    assert!(ok2);
+    let original: Vec<&str> = trits.split(',').collect();
+    let result: Vec<&str> = unpacked.trim().split(',').collect();
+    for (i, o) in original.iter().zip(result.iter()) {
+        assert_eq!(i, o, "mismatch: original={i} result={o}");
+    }
+}
+
+#[test]
+fn roundtrip_full_27_trits() {
+    let trits: Vec<String> = (0..27).map(|i| format!("{}", (i % 3) as i8 - 1)).collect();
+    let trits_str = trits.join(",");
+    let (ok1, packed, _) = run_pack(&trits_str);
+    assert!(ok1);
+    let hex = packed.trim();
+    let (ok2, unpacked, _) = run_unpack(hex);
+    assert!(ok2);
+    let result: Vec<&str> = unpacked.trim().split(',').collect();
+    assert_eq!(result.len(), 27);
+    for (i, (o, r)) in trits.iter().zip(result.iter()).enumerate() {
+        assert_eq!(o.as_str(), *r, "trit {i} mismatch");
+    }
+}
+
+// -- determinism --
+
+#[test]
+fn pack_deterministic() {
+    let (ok1, s1, _) = run_pack("1,0,-1,1,0");
+    let (ok2, s2, _) = run_pack("1,0,-1,1,0");
+    assert!(ok1 && ok2);
+    assert_eq!(s1, s2);
+}

--- a/bootstrap/tests/host_weights.rs
+++ b/bootstrap/tests/host_weights.rs
@@ -1,0 +1,169 @@
+use std::process::Command;
+
+fn bin() -> &'static str {
+    env!("CARGO_BIN_EXE_t27c")
+}
+
+fn run(args: &[&str]) -> (bool, String, String) {
+    let out = Command::new(bin())
+        .args(args)
+        .output()
+        .expect("failed to spawn t27c");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stdout).to_string(),
+        String::from_utf8_lossy(&out.stderr).to_string(),
+    )
+}
+
+fn run_gen(extra: &[&str]) -> (bool, String, String) {
+    let mut args = vec!["host-weight-gen"];
+    args.extend(extra);
+    run(&args)
+}
+
+#[test]
+fn weight_gen_default_succeeds() {
+    let (ok, stdout, _) = run_gen(&[]);
+    assert!(ok, "should succeed with defaults");
+    assert!(!stdout.trim().is_empty());
+}
+
+#[test]
+fn weight_gen_all_n() {
+    let (ok, stdout, _) = run_gen(&["--pattern=all-n"]);
+    assert!(ok);
+    for line in stdout.trim().lines() {
+        assert_eq!(line, "0x0000000000000000", "all-n should be zero: {line}");
+    }
+}
+
+#[test]
+fn weight_gen_all_p() {
+    let (ok, stdout, _) = run_gen(&["--pattern=all-p"]);
+    assert!(ok);
+    for line in stdout.trim().lines() {
+        assert!(line.starts_with("0x"), "expected hex: {line}");
+    }
+}
+
+#[test]
+fn weight_gen_all_z() {
+    let (ok, stdout, _) = run_gen(&["--pattern=all-z"]);
+    assert!(ok);
+    assert!(!stdout.trim().is_empty());
+}
+
+#[test]
+fn weight_gen_alternating() {
+    let (ok, stdout, _) = run_gen(&["--pattern=alternating"]);
+    assert!(ok);
+    assert!(!stdout.trim().is_empty());
+}
+
+#[test]
+fn weight_gen_phi_sequence() {
+    let (ok, stdout, _) = run_gen(&["--pattern=phi-sequence"]);
+    assert!(ok);
+    assert!(!stdout.trim().is_empty());
+}
+
+#[test]
+fn weight_gen_seeded_random() {
+    let (ok, stdout, _) = run_gen(&["--pattern=seeded-random:42"]);
+    assert!(ok);
+    assert!(!stdout.trim().is_empty());
+}
+
+#[test]
+fn weight_gen_custom_neurons() {
+    let (ok, stdout, _) = run_gen(&["--neurons=8"]);
+    assert!(ok);
+    let lines = stdout.trim().lines().count();
+    assert_eq!(lines, 8 * 4, "8 neurons x 4 chunks = 32 words");
+}
+
+#[test]
+fn weight_gen_custom_chunks() {
+    let (ok, stdout, _) = run_gen(&["--chunks=2", "--neurons=3"]);
+    assert!(ok);
+    let lines = stdout.trim().lines().count();
+    assert_eq!(lines, 6, "3 neurons x 2 chunks = 6 words");
+}
+
+#[test]
+fn weight_gen_invalid_pattern_fails() {
+    let (ok, _, stderr) = run_gen(&["--pattern=bogus"]);
+    assert!(!ok);
+    assert!(stderr.contains("invalid pattern"), "stderr = {stderr}");
+}
+
+#[test]
+fn weight_gen_zero_neurons_fails() {
+    let (ok, _, _stderr) = run_gen(&["--neurons=0"]);
+    assert!(!ok);
+}
+
+#[test]
+fn weight_gen_deterministic_default() {
+    let (ok1, s1, _) = run_gen(&[]);
+    let (ok2, s2, _) = run_gen(&[]);
+    assert!(ok1 && ok2);
+    assert_eq!(s1, s2);
+}
+
+#[test]
+fn weight_gen_seeded_deterministic() {
+    let (ok1, s1, _) = run_gen(&["--pattern=seeded-random:99"]);
+    let (ok2, s2, _) = run_gen(&["--pattern=seeded-random:99"]);
+    assert!(ok1 && ok2);
+    assert_eq!(s1, s2);
+}
+
+#[test]
+fn weight_gen_seeded_different_seeds_differ() {
+    let (ok1, s1, _) = run_gen(&["--pattern=seeded-random:1"]);
+    let (ok2, s2, _) = run_gen(&["--pattern=seeded-random:2"]);
+    assert!(ok1 && ok2);
+    assert_ne!(s1, s2);
+}
+
+#[test]
+fn weight_gen_output_is_hex_words() {
+    let (ok, stdout, _) = run_gen(&[]);
+    assert!(ok);
+    for line in stdout.trim().lines() {
+        assert!(line.starts_with("0x") && line.len() == 18, "expected 0x + 16 hex: {line}");
+    }
+}
+
+#[test]
+fn weight_gen_single_line_per_word() {
+    let (ok, stdout, _) = run_gen(&["--neurons=1", "--chunks=1"]);
+    assert!(ok);
+    let lines: Vec<&str> = stdout.trim().lines().collect();
+    assert_eq!(lines.len(), 1);
+}
+
+#[test]
+fn weight_gen_no_stderr_on_success() {
+    let (ok, _, stderr) = run_gen(&[]);
+    assert!(ok);
+    assert!(stderr.trim().is_empty(), "stderr = {stderr}");
+}
+
+#[test]
+fn weight_gen_help_lists_flags() {
+    let (ok, stdout, _) = run_gen(&["--help"]);
+    assert!(ok);
+    for flag in ["--neurons", "--chunks", "--pattern"] {
+        assert!(stdout.contains(flag), "missing {flag}");
+    }
+}
+
+#[test]
+fn weight_gen_help_mentions_wave_45() {
+    let (ok, stdout, _) = run_gen(&["--help"]);
+    assert!(ok);
+    assert!(stdout.contains("Wave 45") || stdout.contains("R-HT-2"), "expected Wave 45: {stdout}");
+}

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,12 @@
 
 Last updated: 2026-05-23
 
+## wave-43 -- t27c --json flag for host CLI commands (R-HS-5, Closes #795)
+
+- **WHERE** (bootstrap-only, additive): new file `bootstrap/src/host/json_output.rs` (`HostSmokeJson`, `HostPollVsIrqJson`, `HostInferenceJson`, `HostPerfJson` structs, `print_json` helper); updated `bootstrap/src/host/mod.rs`; added `--json` flag to all 4 host commands in `main.rs`; new test file `bootstrap/tests/host_json.rs` (23 integration tests).
+- **Why** (R-HS-5): host commands emit human-readable single-line output by default. `--json` enables structured JSON for CI pipelines, trios-bridge, and downstream tooling. Additive — default output unchanged.
+- **Tests**: 23 new integration tests. All pass. Zero regressions.
+
 ## wave-42 -- t27c host-perf -- performance model and cycle estimator (R-HS-4, Closes #791)
 
 - **WHERE** (bootstrap-only, additive): new file `bootstrap/src/host/perf.rs` (`EngineConfig`, `PerformanceEstimate`, `LayerEstimate`; cycle/DMA/BRAM/throughput estimation; 19 inline unit tests); updated `bootstrap/src/host/mod.rs`; new CLI `Commands::HostPerf` + `run_host_perf()`; new test file `bootstrap/tests/host_perf.rs` (23 integration tests).

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,12 @@
 
 Last updated: 2026-05-23
 
+## wave-41 -- t27c host-inference -- DMA-driven multi-layer BitNet inference flow (R-HS-3, Closes #789)
+
+- **WHERE** (bootstrap-only, additive): new file `bootstrap/src/host/engine.rs` (`InferenceEngine`, `InferenceReport`, per-layer DMA prefetch → inference → DMA drain cycle; 16 inline unit tests); updated `bootstrap/src/host/irq.rs` (`wait_irq_mask` generic IRQ wait, refactored from `wait_done_irq`); updated `bootstrap/src/host/mod.rs`; new CLI `Commands::HostInference` + `run_host_inference()`; new test file `bootstrap/tests/host_engine.rs` (20 integration tests).
+- **Why** (R-HS-3): W40 gave us IRQ-driven single-completion. W41 orchestrates the full multi-layer BitNet inference flow: for each layer, DMA prefetch weights (wait DmaDone IRQ), start inference (wait InferenceDone IRQ), DMA drain output (wait DmaDone IRQ). Uses `wait_irq_mask()` — a new generic IRQ-wait method on `IrqDrivenDriver` that waits for any mask, not just inference-done.
+- **Tests**: 36 new (16 inline + 20 integration). All pass. Zero regressions.
+
 ## wave-40 -- t27c host-poll-vs-irq -- IRQ-handler harness + poll-vs-IRQ comparison (R-HS-2, Closes #786)
 
 - **WHERE** (bootstrap-only, additive): new file `bootstrap/src/host/irq.rs` (`IrqSource` enum, `IrqHandler<M>` callback registry, `IrqDrivenDriver<M>` with `wait_done_irq`; 11 inline unit tests); updated `bootstrap/src/host/mod.rs`; new CLI `Commands::HostPollVsIrq` + `run_host_poll_vs_irq()`; new test file `bootstrap/tests/host_irq.rs` (21 integration tests).

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,12 @@
 
 Last updated: 2026-05-23
 
+## wave-42 -- t27c host-perf -- performance model and cycle estimator (R-HS-4, Closes #791)
+
+- **WHERE** (bootstrap-only, additive): new file `bootstrap/src/host/perf.rs` (`EngineConfig`, `PerformanceEstimate`, `LayerEstimate`; cycle/DMA/BRAM/throughput estimation; 19 inline unit tests); updated `bootstrap/src/host/mod.rs`; new CLI `Commands::HostPerf` + `run_host_perf()`; new test file `bootstrap/tests/host_perf.rs` (23 integration tests).
+- **Why** (R-HS-4): W41 gave us the full inference engine. W42 adds the analytical performance model: given engine config (layers, neurons, chunks), compute per-layer DMA beats, compute cycles, BRAM utilization, total inference cycles, and throughput at a given clock frequency. Pure arithmetic, no hardware dependency. Essential for FPGA bringup (compare estimated vs actual CYCLES counter from W36f).
+- **Tests**: 42 new (19 inline + 23 integration). All pass. Zero regressions.
+
 ## wave-41 -- t27c host-inference -- DMA-driven multi-layer BitNet inference flow (R-HS-3, Closes #789)
 
 - **WHERE** (bootstrap-only, additive): new file `bootstrap/src/host/engine.rs` (`InferenceEngine`, `InferenceReport`, per-layer DMA prefetch → inference → DMA drain cycle; 16 inline unit tests); updated `bootstrap/src/host/irq.rs` (`wait_irq_mask` generic IRQ wait, refactored from `wait_done_irq`); updated `bootstrap/src/host/mod.rs`; new CLI `Commands::HostInference` + `run_host_inference()`; new test file `bootstrap/tests/host_engine.rs` (20 integration tests).

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,12 @@
 
 Last updated: 2026-05-23
 
+## wave-45 -- t27c host-weight-gen -- deterministic weight pattern generator (R-HT-2, Closes #799)
+
+- **WHERE** (bootstrap-only, additive): new file `bootstrap/src/host/weights.rs` (`WeightPattern` enum, `WeightConfig`, `generate_pattern`, `generate_weights`, `parse_pattern`; 16 inline unit tests); updated `bootstrap/src/host/mod.rs`; new CLI `Commands::HostWeightGen` + `run_host_weight_gen()`; new test file `bootstrap/tests/host_weights.rs` (19 integration tests).
+- **Why** (R-HT-2): W44 gave us the ternary packer. W45 generates deterministic packed-trit weight patterns (all-N, all-Z, all-P, alternating, phi-sequence, seeded-random) for a given (neurons, chunks) config. Bridges W44 with W41 InferenceEngine for realistic weight initialization.
+- **Tests**: 35 new (16 inline + 19 integration). All pass. Zero regressions.
+
 ## wave-44 -- t27c host-pack/host-unpack -- ternary weight packer/unpacker (R-HT-1, Closes #797)
 
 - **WHERE** (bootstrap-only, additive): new file `bootstrap/src/host/ternary.rs` (`Trit` enum, `pack_word`/`unpack_word`/`pack_words`/`unpack_words`/`parse_trit_string`/`format_trits`; 17 inline unit tests); updated `bootstrap/src/host/mod.rs`; new CLI `Commands::HostPack` + `Commands::HostUnpack`; new test file `bootstrap/tests/host_ternary.rs` (19 integration tests).

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,12 @@
 
 Last updated: 2026-05-23
 
+## wave-46 -- t27c host-e2e -- end-to-end host stack integration (R-HS-6, Closes #802)
+
+- **WHERE** (bootstrap-only, additive): new file `bootstrap/src/host/e2e.rs` (`E2eConfig`, `E2eResult`, `E2eJson`, `run_e2e`; 13 inline unit tests); updated `bootstrap/src/host/mod.rs`; new CLI `Commands::HostE2e` + `run_host_e2e()` with `--json` support; new test file `bootstrap/tests/host_e2e.rs` (20 integration tests).
+- **Why** (R-HS-6): Capstone wave for the host driver stack. Wires W45 weight-gen → W41 InferenceEngine → W42 PerformanceEstimate in a single `host-e2e` command. Generates weights, runs inference on MockMmio, estimates analytical performance, and prints a comparison summary. Validates the full host stack works end-to-end.
+- **Tests**: 33 new (13 inline + 20 integration). All pass. Zero regressions.
+
 ## wave-45 -- t27c host-weight-gen -- deterministic weight pattern generator (R-HT-2, Closes #799)
 
 - **WHERE** (bootstrap-only, additive): new file `bootstrap/src/host/weights.rs` (`WeightPattern` enum, `WeightConfig`, `generate_pattern`, `generate_weights`, `parse_pattern`; 16 inline unit tests); updated `bootstrap/src/host/mod.rs`; new CLI `Commands::HostWeightGen` + `run_host_weight_gen()`; new test file `bootstrap/tests/host_weights.rs` (19 integration tests).

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,13 @@
 
 Last updated: 2026-05-23
 
+## wave-44 -- t27c host-pack/host-unpack -- ternary weight packer/unpacker (R-HT-1, Closes #797)
+
+- **WHERE** (bootstrap-only, additive): new file `bootstrap/src/host/ternary.rs` (`Trit` enum, `pack_word`/`unpack_word`/`pack_words`/`unpack_words`/`parse_trit_string`/`format_trits`; 17 inline unit tests); updated `bootstrap/src/host/mod.rs`; new CLI `Commands::HostPack` + `Commands::HostUnpack`; new test file `bootstrap/tests/host_ternary.rs` (19 integration tests).
+- **Why** (R-HT-1): W36a weight BRAM uses packed-trit format (27 trits × 2 bits/trit = 54 bits per word). This wave adds the host-side packer/unpacker bridging human-readable `[-1, 0, +1]` arrays and the hardware hex-word format. Enables realistic weight generation for the InferenceEngine and DMA content verification.
+- **Encoding**: 2'b00 = -1 (TRIT_N), 2'b01 = 0 (TRIT_Z), 2'b10 = +1 (TRIT_P), LSB-first. Matches trit_stdlib.rs.
+- **Tests**: 36 new (17 inline + 19 integration). All pass. Zero regressions.
+
 ## wave-43 -- t27c --json flag for host CLI commands (R-HS-5, Closes #795)
 
 - **WHERE** (bootstrap-only, additive): new file `bootstrap/src/host/json_output.rs` (`HostSmokeJson`, `HostPollVsIrqJson`, `HostInferenceJson`, `HostPerfJson` structs, `print_json` helper); updated `bootstrap/src/host/mod.rs`; added `--json` flag to all 4 host commands in `main.rs`; new test file `bootstrap/tests/host_json.rs` (23 integration tests).

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,12 @@
 
 Last updated: 2026-05-23
 
+## wave-40 -- t27c host-poll-vs-irq -- IRQ-handler harness + poll-vs-IRQ comparison (R-HS-2, Closes #786)
+
+- **WHERE** (bootstrap-only, additive): new file `bootstrap/src/host/irq.rs` (`IrqSource` enum, `IrqHandler<M>` callback registry, `IrqDrivenDriver<M>` with `wait_done_irq`; 11 inline unit tests); updated `bootstrap/src/host/mod.rs`; new CLI `Commands::HostPollVsIrq` + `run_host_poll_vs_irq()`; new test file `bootstrap/tests/host_irq.rs` (21 integration tests).
+- **Why** (R-HS-2): W39 added poll-mode driver. W40 adds interrupt-driven completion path with callback dispatch and side-by-side poll-vs-IRQ comparison on MockMmio.
+- **Tests**: 32 new (11 inline + 21 integration). All pass.
+
 ## wave-39 -- t27c host-side Rust driver module: BitNet AXI-Lite CSR aperture (R-HS-1, Closes #784)
 
 - **WHERE** (bootstrap-only, additive): new directory `bootstrap/src/host/` with four files -- `mod.rs` (re-exports), `csr_map.rs` (10 CSR offset constants + status/IRQ bit masks + 10 inline unit tests), `mmio.rs` (`Mmio` trait + `MockMmio` deterministic BTreeMap backend + transaction log + 10 inline unit tests), `driver.rs` (`BitnetDriver<M: Mmio>` orchestrator with configure / start / poll / IRQ / dump methods + `CsrSnapshot` struct + `DriverError` enum + 11 inline unit tests). One new `mod host;` declaration in `bootstrap/src/main.rs`. One new CLI subcommand `Commands::HostSmoke { num_layers, neurons, chunks, threshold, weight_addr, max_polls }` registered in the `Commands` enum and dispatched in both HTTP-server and CLI match arms via `run_host_smoke(...)`. **Zero** edits under `gen/`, `coq/`, `trios-coq/`, `proofs/`, `specs/`, `conformance/`, `architecture/`, `rings/`, root `Cargo.toml`. Doc-only update to this file. New test file `bootstrap/tests/host_driver.rs` (25 integration tests via `CARGO_BIN_EXE_t27c`).


### PR DESCRIPTION
## Wave 46 — R-HS-6: End-to-end host stack integration

Closes #802

### What changed
- **New file** `bootstrap/src/host/e2e.rs`: E2eConfig, E2eResult, E2eJson, run_e2e()
  - Generates weights (W45), runs InferenceEngine (W41), estimates performance (W42)
  - 13 inline unit tests
- **New CLI**: `t27c host-e2e [--json] [--pattern=...] [--num-layers=N]`
- **Updated** mod.rs, main.rs, NOW.md
- **New file** `bootstrap/tests/host_e2e.rs`: 20 integration tests

### Capstone for the host driver stack
Wires the full W39-W45 pipeline: CSR map → driver → IRQ handler → inference engine → perf model → weight generator → JSON output.

### Test results
33 new (13 inline + 20 integration). Zero regressions.