### PR TITLE
feat(host): session manager with seq tracking and retry (W69, R-HS-17)

### DIFF
--- a/bootstrap/src/host/mod.rs
+++ b/bootstrap/src/host/mod.rs
@@ -21,6 +21,7 @@ pub mod irq;
 pub mod mmio;
 pub mod protocol;
 pub mod scatter_gather;
+pub mod session;
 pub mod transport;
 pub mod weight_header;
 pub mod weight_loader;
@@ -32,6 +33,7 @@ pub use irq::{IrqCallback, IrqCounters, IrqDrivenDriver, IrqHandler, IrqSource, 
 pub use mmio::{MmioOp, MmioRecord, MockMmio};
 pub use protocol::{Cmd, CmdPacket, ProtocolError, RespCode, RespPacket, CMD_HEADER_SIZE, RESP_HEADER_SIZE};
 pub use scatter_gather::{SgDescriptor, SgError, SgSegment};
+pub use session::{Session, SessionConfig, SessionError, SessionStats};
 pub use transport::{TransportError, TransportFrame};
 pub use weight_header::{HeaderError, WeightHeader, HEADER_SIZE, MAGIC, VERSION};
 pub use weight_loader::{load_from_reader, load_words, encode_words, encode_with_crc, LoadConfig, LoadError, LoadReport, WordFormat};

--- a/bootstrap/src/host/session.rs
+++ b/bootstrap/src/host/session.rs
@@ -1,0 +1,317 @@
+use super::protocol::{Cmd, CmdPacket, RespCode, RespPacket};
+use super::transport::TransportFrame;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionError {
+    SeqOverflow,
+    MaxRetriesExceeded { retries: u8 },
+    UnexpectedSeq { expected: u8, got: u8 },
+    TransportError(super::transport::TransportError),
+}
+
+impl std::fmt::Display for SessionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SessionError::SeqOverflow => write!(f, "sequence number overflow"),
+            SessionError::MaxRetriesExceeded { retries } => {
+                write!(f, "max retries exceeded: {retries}")
+            }
+            SessionError::UnexpectedSeq { expected, got } => {
+                write!(f, "unexpected seq: expected {expected}, got {got}")
+            }
+            SessionError::TransportError(e) => write!(f, "transport error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for SessionError {}
+
+impl From<super::transport::TransportError> for SessionError {
+    fn from(e: super::transport::TransportError) -> Self {
+        SessionError::TransportError(e)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SessionConfig {
+    pub max_retries: u8,
+    pub cmd_timeout_ms: u32,
+}
+
+impl Default for SessionConfig {
+    fn default() -> Self {
+        Self {
+            max_retries: 3,
+            cmd_timeout_ms: 1000,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PendingRequest {
+    pub seq: u8,
+    pub cmd: Cmd,
+    pub frame: Vec<u8>,
+    pub retries: u8,
+}
+
+#[derive(Debug, Clone)]
+pub struct Session {
+    config: SessionConfig,
+    next_seq: u8,
+    pending: Option<PendingRequest>,
+}
+
+impl Session {
+    pub fn new(config: SessionConfig) -> Self {
+        Self {
+            config,
+            next_seq: 0,
+            pending: None,
+        }
+    }
+
+    pub fn next_seq(&self) -> u8 {
+        self.next_seq
+    }
+
+    pub fn has_pending(&self) -> bool {
+        self.pending.is_some()
+    }
+
+    pub fn pending_cmd(&self) -> Option<Cmd> {
+        self.pending.as_ref().map(|p| p.cmd)
+    }
+
+    pub fn build_request(&mut self, cmd: Cmd, payload: &[u8]) -> Result<Vec<u8>, SessionError> {
+        let seq = self.next_seq;
+        let pkt = CmdPacket::new(cmd)
+            .with_seq(seq)
+            .with_payload_len(payload.len() as u16);
+        let frame = TransportFrame::new(pkt, payload)?;
+        let encoded = frame.encode();
+        self.pending = Some(PendingRequest {
+            seq,
+            cmd,
+            frame: encoded.clone(),
+            retries: 0,
+        });
+        self.advance_seq()?;
+        Ok(encoded)
+    }
+
+    fn advance_seq(&mut self) -> Result<(), SessionError> {
+        let (next, overflowed) = self.next_seq.overflowing_add(1);
+        if overflowed {
+            return Err(SessionError::SeqOverflow);
+        }
+        self.next_seq = next;
+        Ok(())
+    }
+
+    pub fn handle_response(&mut self, resp_frame: &[u8]) -> Result<RespPacket, SessionError> {
+        let decoded = super::transport::RespFrame::decode(resp_frame)?;
+        let resp = decoded.header;
+        if let Some(ref pending) = self.pending {
+            if resp.seq != pending.seq {
+                return Err(SessionError::UnexpectedSeq {
+                    expected: pending.seq,
+                    got: resp.seq,
+                });
+            }
+        }
+        if resp.code == RespCode::ErrBusy {
+            if let Some(ref mut p) = self.pending {
+                p.retries += 1;
+            }
+        }
+        if resp.code.is_ok() || resp.code != RespCode::ErrBusy {
+            self.pending = None;
+        }
+        Ok(resp)
+    }
+
+    pub fn should_retry(&self) -> bool {
+        match &self.pending {
+            Some(p) => p.retries < self.config.max_retries,
+            None => false,
+        }
+    }
+
+    pub fn retry_frame(&self) -> Option<&[u8]> {
+        self.pending.as_ref().map(|p| p.frame.as_slice())
+    }
+
+    pub fn reset(&mut self) {
+        self.next_seq = 0;
+        self.pending = None;
+    }
+
+    pub fn stats(&self) -> SessionStats {
+        SessionStats {
+            next_seq: self.next_seq,
+            has_pending: self.pending.is_some(),
+            pending_retries: self.pending.as_ref().map_or(0, |p| p.retries),
+            max_retries: self.config.max_retries,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionStats {
+    pub next_seq: u8,
+    pub has_pending: bool,
+    pub pending_retries: u8,
+    pub max_retries: u8,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::host::transport::RespFrame;
+
+    fn make_session() -> Session {
+        Session::new(SessionConfig::default())
+    }
+
+    fn make_resp(seq: u8, code: RespCode) -> Vec<u8> {
+        RespFrame::new(RespPacket::new(code).with_seq(seq), &[]).encode()
+    }
+
+    #[test]
+    fn new_session_seq_zero() {
+        let s = make_session();
+        assert_eq!(s.next_seq(), 0);
+        assert!(!s.has_pending());
+    }
+
+    #[test]
+    fn build_request_advances_seq() {
+        let mut s = make_session();
+        s.build_request(Cmd::Reset, &[]).unwrap();
+        assert_eq!(s.next_seq(), 1);
+        assert!(s.has_pending());
+    }
+
+    #[test]
+    fn build_request_with_payload() {
+        let mut s = make_session();
+        let frame = s.build_request(Cmd::LoadWeights, &[0xAA, 0xBB]).unwrap();
+        assert!(!frame.is_empty());
+        assert_eq!(s.pending_cmd(), Some(Cmd::LoadWeights));
+    }
+
+    #[test]
+    fn handle_response_ok_clears_pending() {
+        let mut s = make_session();
+        s.build_request(Cmd::Reset, &[]).unwrap();
+        let resp = make_resp(0, RespCode::Ok);
+        let pkt = s.handle_response(&resp).unwrap();
+        assert_eq!(pkt.code, RespCode::Ok);
+        assert!(!s.has_pending());
+    }
+
+    #[test]
+    fn handle_response_wrong_seq() {
+        let mut s = make_session();
+        s.build_request(Cmd::Reset, &[]).unwrap();
+        let resp = make_resp(99, RespCode::Ok);
+        let err = s.handle_response(&resp).unwrap_err();
+        assert!(matches!(
+            err,
+            SessionError::UnexpectedSeq {
+                expected: 0,
+                got: 99
+            }
+        ));
+    }
+
+    #[test]
+    fn handle_response_busy_increments_retry() {
+        let mut s = make_session();
+        s.build_request(Cmd::RunInference, &[]).unwrap();
+        let resp = make_resp(0, RespCode::ErrBusy);
+        s.handle_response(&resp).unwrap();
+        assert!(s.has_pending());
+        assert!(s.should_retry());
+        assert_eq!(s.stats().pending_retries, 1);
+    }
+
+    #[test]
+    fn should_retry_respects_max() {
+        let mut s = make_session();
+        s.build_request(Cmd::RunInference, &[]).unwrap();
+        for _ in 0..3 {
+            let resp = make_resp(0, RespCode::ErrBusy);
+            s.handle_response(&resp).unwrap();
+        }
+        assert!(!s.should_retry());
+    }
+
+    #[test]
+    fn retry_frame_returns_encoded() {
+        let mut s = make_session();
+        let frame = s.build_request(Cmd::Reset, &[]).unwrap();
+        assert_eq!(s.retry_frame(), Some(frame.as_slice()));
+    }
+
+    #[test]
+    fn reset_clears_state() {
+        let mut s = make_session();
+        s.build_request(Cmd::Reset, &[]).unwrap();
+        s.reset();
+        assert_eq!(s.next_seq(), 0);
+        assert!(!s.has_pending());
+    }
+
+    #[test]
+    fn stats_reflects_state() {
+        let mut s = make_session();
+        let stats = s.stats();
+        assert_eq!(stats.next_seq, 0);
+        assert!(!stats.has_pending);
+        assert_eq!(stats.pending_retries, 0);
+        assert_eq!(stats.max_retries, 3);
+    }
+
+    #[test]
+    fn multiple_requests_sequential_seq() {
+        let mut s = make_session();
+        s.build_request(Cmd::Reset, &[]).unwrap();
+        let resp = make_resp(0, RespCode::Ok);
+        s.handle_response(&resp).unwrap();
+        s.build_request(Cmd::ReadStatus, &[]).unwrap();
+        assert_eq!(s.next_seq(), 2);
+        let resp = make_resp(1, RespCode::Ok);
+        s.handle_response(&resp).unwrap();
+    }
+
+    #[test]
+    fn custom_max_retries() {
+        let s = Session::new(SessionConfig {
+            max_retries: 5,
+            cmd_timeout_ms: 2000,
+        });
+        assert_eq!(s.config.max_retries, 5);
+    }
+
+    #[test]
+    fn error_display() {
+        let e = SessionError::SeqOverflow;
+        assert!(e.to_string().contains("overflow"));
+        let e = SessionError::MaxRetriesExceeded { retries: 3 };
+        assert!(e.to_string().contains("3"));
+        let e = SessionError::UnexpectedSeq { expected: 1, got: 2 };
+        assert!(e.to_string().contains("expected"));
+    }
+
+    #[test]
+    fn handle_response_err_crc_clears_pending() {
+        let mut s = make_session();
+        s.build_request(Cmd::LoadWeights, &[]).unwrap();
+        let resp = make_resp(0, RespCode::ErrCrc);
+        let pkt = s.handle_response(&resp).unwrap();
+        assert_eq!(pkt.code, RespCode::ErrCrc);
+        assert!(!s.has_pending());
+    }
+}

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -75,6 +75,10 @@ Last updated: 2026-05-30
 
 - **WHERE** (host-only, additive): new `bootstrap/src/host/transport.rs` with `TransportFrame` (length-prefix + CmdPacket header + payload + CRC32 footer), `RespFrame` (same layout with RespPacket), encode/decode, `MAX_PAYLOAD=4096`; includes `protocol.rs` from W67. 15 inline tests. All pass. 847 total.
 
+## wave-69 -- host session manager (R-HS-17, Closes #851)
+
+- **WHERE** (host-only, additive): new `bootstrap/src/host/session.rs` with `Session` (seq tracking, request building, response matching, retry on ErrBusy), `SessionConfig`, `SessionStats`, `SessionError`; includes protocol+transport from W67/W68. 14 inline tests. All pass. 861 total.
+
 ## docs-readme-bitnet-rtt -- README.md aligned with post-W45 state (doc-only, Closes #805)
 
 - **WHERE** (doc-only, repo-root): updated `README.md` (+110 lines).  Added four new System Status rows (BitNet HLS / Host stack / R-TT track / Chips) and a brand-new section `## BitNet HLS Pipeline & R-TT Reproducibility Track` documenting the 9/9 RTL pipeline, the host stack CLIs (`host-smoke`, `host-poll-vs-irq`), the R-TT track CLIs (`tt-manifest`, `tt-profile`, `tt-conform`), the three chip submodules under `chips/`, and a test-coverage summary (365/366 integration).  Cross-links to `docs/NOW.md` as the live wave log.  This is a housekeeping commit between waves (W45 merged at `7f463018`, W46 R-TT-3 next).  Zero edits to code, kernel, spec, RTL, tests, `.gitmodules`, or `chips/`.


### PR DESCRIPTION
Closes #851

## Wave 69 (R-HS-17): Host session manager

### What
- New `bootstrap/src/host/session.rs`
- `Session`: sequence tracking, `build_request()`, `handle_response()` with seq matching
- Automatic retry on `ErrBusy` up to `max_retries`
- `SessionConfig`, `SessionStats`, `SessionError`
- Includes protocol + transport from W67/W68

### Tests
14 new inline tests, all pass. 861 total.