### PR TITLE
spec(numeric): add gfternary.t27 — normative 2-bit ternary {−φ,0,+φ}

### DIFF
--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,12 @@
 
 Last updated: 2026-05-28
 
+## spec-gfternary -- normative 2-bit GoldenFloat ternary {-phi,0,+phi} (Closes #946)
+
+- **WHERE**: added `specs/numeric/gfternary.t27` -- a normative spec for the 2-bit golden-ratio ternary format. Representable values { -phi, 0, +phi } = phi * {-1, 0, +1}: a ternary-weight quantizer (cf. TWN / BitNet b1.58) with the scale fixed at phi rather than learned per layer. 2-bit codes (00->0, 01->+phi, 10->-phi, 11->reserved/folds-to-zero) in a u8 container; encode/decode/sign/negate + a `gft_from_f64(value, threshold)` TWN-style quantizer. 6 `test` + 2 `bench` (L4); phi^2 = phi + 1 and phi^2 + phi^-2 = 3 verified with f64 tolerance (L5); ASCII-only (L3). Promoted section 4 of `docs/NUMERIC_FORMATS_SSOT.md` from "concept; no normative spec" to spec-present.
+- **Why**: GFTernary was the one family member with no normative spec; this lands it at the same status tier as GF64 (spec present; Rust + `tri gen` codegen are a later phase). Closes #946.
+- **Anchor**: phi^2 + phi^-2 = 3
+
 ## docs-numeric-ssot-sync -- GF256 row + TF3/GFTernary split + IGLA RACE bench (Closes #944)
 
 - **WHERE** (doc-only): `docs/NUMERIC_FORMATS_SSOT.md`. (1) Added the GF256 row to the section-1 verified-constants table (1+97+158, E/M 0.614, phi-distance 0.004; stored bias OPEN so geometry-only -- spec lives in tt-trinity-gamma, not this repo). (2) Rewrote section 4: TF3 is an 8-bit format [S1 E3 M4]=1:3:4 (GF8 geometry, BIAS 3) per `tf3.t27` line 3, NOT a 2-bit format; GFTernary is the separate 2-bit {-phi,0,+phi} concept. The doc previously contradicted its own linked spec. (3) Added section 7 measured comparison (IGLA RACE v2 val_bpb sweep: gf16 beats bf16 / parity-class fp16; gf8 ties posit8; honest caveats incl. E4M3 NO_EVAL), renumbered Uniqueness to section 8. (4) Fixed section 6 stale "GF64 no t27 spec" -> `gf64.t27` is present (#916), only C codegen missing.

--- a/docs/NUMERIC_FORMATS_SSOT.md
+++ b/docs/NUMERIC_FORMATS_SSOT.md
@@ -77,9 +77,12 @@ Two **distinct** objects — do not conflate (the spec is authoritative):
   geometry as GF8), BIAS 3, used to encode ternary neural-network *weights*. It
   is a storage container, **not** a 2-bit format. Spec:
   [`tf3.t27`](../specs/numeric/tf3.t27) (line 3: "8-bit representation").
-- **GFTernary** — the conceptual **2-bit** limit case, values in {−φ, 0, +φ},
-  φ-distance **0.000** by construction; the {−1, 0, +1} substrate of the Three
-  Crowns. Concept only — **no normative spec**; ROADMAP.
+- **GFTernary** — the **2-bit** member, values in {−φ, 0, +φ} = φ·{−1, 0, +1}:
+  a ternary-weight quantizer with the scale fixed at φ (cf. TWN / BitNet b1.58,
+  whose scale α is learned per layer). φ-distance **0.000** by construction (its
+  nonzero magnitude is exactly the anchor φ); the {−1, 0, +1} substrate of the
+  Three Crowns. Spec: [`gfternary.t27`](../specs/numeric/gfternary.t27);
+  Rust / `tri gen` codegen ROADMAP (same tier as GF64).
 - **Candidates (no normative spec):** GF6 (φ-gap fill 4↔8), GF128
   (binary128-range φ). NOT CLAIMED.
 

--- a/specs/numeric/gfternary.t27
+++ b/specs/numeric/gfternary.t27
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+; gfternary.t27 0 GFTernary Format Specification
+; 2-bit golden-ratio ternary: representable values { -phi, 0, +phi }
+; The phi-scaled limit of the ternary-weight family: GFTernary = phi * {-1,0,+1}
+; (a ternary-weight quantizer, cf. TWN / BitNet, with the scale fixed at phi).
+; phi^2 + phi^-2 = 3 | TRINITY
+
+module triformat-gfternary;
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+// Golden ratio phi = (1 + sqrt(5)) / 2 and its reciprocal phi^-1 = phi - 1.
+pub const PHI : f64 = 1.6180339887498949;
+pub const PHI_INV : f64 = 0.6180339887498949;
+
+// 2-bit code points, stored in the low two bits of a u8 container.
+pub const CODE_MASK : u8 = 0x03;
+pub const GFT_ZERO : u8 = 0x00;   // 0b00 -> 0
+pub const GFT_POS  : u8 = 0x01;   // 0b01 -> +phi
+pub const GFT_NEG  : u8 = 0x02;   // 0b10 -> -phi
+pub const GFT_RSVD : u8 = 0x03;   // 0b11 -> reserved (folds to zero)
+
+// ============================================================================
+// Types
+// ============================================================================
+
+pub const GFTernary = u8;
+
+// ============================================================================
+// Core functions
+// ============================================================================
+
+// gft_canonical(code) GFTernary
+// Mask to the low two bits and fold the reserved code 0b11 onto zero.
+pub fn gft_canonical(code: GFTernary) GFTernary {
+    const c = code & CODE_MASK;
+    return if (c == GFT_RSVD) GFT_ZERO else c;
+}
+
+// gft_is_zero(code) bool
+pub fn gft_is_zero(code: GFTernary) bool {
+    return gft_canonical(code) == GFT_ZERO;
+}
+
+// gft_sign(code) i8 -> -1, 0, +1
+pub fn gft_sign(code: GFTernary) i8 {
+    const c = gft_canonical(code);
+    return if (c == GFT_POS) 1 else if (c == GFT_NEG) -1 else 0;
+}
+
+// gft_from_sign(s) GFTernary  (s in {-1, 0, +1})
+pub fn gft_from_sign(s: i8) GFTernary {
+    return if (s > 0) GFT_POS else if (s < 0) GFT_NEG else GFT_ZERO;
+}
+
+// gft_negate(code) GFTernary  -- flips +phi <-> -phi, zero is fixed.
+pub fn gft_negate(code: GFTernary) GFTernary {
+    const c = gft_canonical(code);
+    return if (c == GFT_POS) GFT_NEG else if (c == GFT_NEG) GFT_POS else GFT_ZERO;
+}
+
+// gft_to_f64(code) f64 -> { +PHI, -PHI, 0.0 }
+pub fn gft_to_f64(code: GFTernary) f64 {
+    const c = gft_canonical(code);
+    return if (c == GFT_POS) PHI else if (c == GFT_NEG) -PHI else 0.0;
+}
+
+// gft_from_f64(value, threshold) GFTernary
+// Ternary-weight quantizer with fixed phi scale (TWN with alpha = phi):
+//   |value| <= |threshold|        -> 0
+//   value   >  |threshold|        -> +phi
+//   value   < -|threshold|        -> -phi
+pub fn gft_from_f64(value: f64, threshold: f64) GFTernary {
+    const t = if (threshold < 0.0) -threshold else threshold;
+    if (value > t) return GFT_POS;
+    if (value < -t) return GFT_NEG;
+    return GFT_ZERO;
+}
+
+// ============================================================================
+// Tests (L4 TESTABILITY). f64 checks use a tolerance (L5 IDENTITY).
+// ============================================================================
+
+test "gft_three_representable_values" {
+    const dp = gft_to_f64(GFT_POS) - PHI;
+    const dn = gft_to_f64(GFT_NEG) + PHI;
+    try std.testing.expect(gft_to_f64(GFT_ZERO) == 0.0);
+    try std.testing.expect(dp > -1e-12 and dp < 1e-12);
+    try std.testing.expect(dn > -1e-12 and dn < 1e-12);
+}
+
+test "gft_reserved_code_folds_to_zero" {
+    try std.testing.expect(gft_is_zero(GFT_RSVD));
+    try std.testing.expect(gft_to_f64(GFT_RSVD) == 0.0);
+}
+
+test "gft_negate_symmetry" {
+    const d = gft_to_f64(gft_negate(GFT_POS)) + PHI;
+    try std.testing.expect(d > -1e-12 and d < 1e-12);
+    try std.testing.expect(gft_negate(GFT_ZERO) == GFT_ZERO);
+}
+
+test "gft_sign_roundtrip" {
+    try std.testing.expect(gft_from_sign(gft_sign(GFT_POS)) == GFT_POS);
+    try std.testing.expect(gft_from_sign(gft_sign(GFT_NEG)) == GFT_NEG);
+    try std.testing.expect(gft_from_sign(gft_sign(GFT_ZERO)) == GFT_ZERO);
+}
+
+test "gft_quantizer_threshold" {
+    try std.testing.expect(gft_from_f64(2.0, 0.5) == GFT_POS);
+    try std.testing.expect(gft_from_f64(-2.0, 0.5) == GFT_NEG);
+    try std.testing.expect(gft_from_f64(0.1, 0.5) == GFT_ZERO);
+}
+
+// L5 IDENTITY: phi^2 = phi + 1; phi^2 + phi^-2 = 3; phi * phi^-1 = 1.
+test "gft_phi_identity_l5" {
+    const d1 = PHI * PHI - (PHI + 1.0);
+    const d2 = PHI * PHI + PHI_INV * PHI_INV - 3.0;
+    const d3 = PHI * PHI_INV - 1.0;
+    try std.testing.expect(d1 > -1e-12 and d1 < 1e-12);
+    try std.testing.expect(d2 > -1e-12 and d2 < 1e-12);
+    try std.testing.expect(d3 > -1e-12 and d3 < 1e-12);
+}
+
+// ============================================================================
+// Bench (L4 TESTABILITY)
+// ============================================================================
+
+bench "bench_gft_decode_latency" {
+    // measure: nanoseconds to decode a code to f64
+    // target: < 20ns (mask + two compares)
+    @setEvalBranchQuota(10000);
+    var result: f64 = 0.0;
+    const code: GFTernary = GFT_NEG;
+    for (0..1000) |_| {
+        result = gft_to_f64(code);
+    }
+    _ = result;
+}
+
+bench "bench_gft_quantize_latency" {
+    // measure: nanoseconds to ternary-quantize one f64 with a threshold
+    // target: < 30ns (abs + two compares)
+    @setEvalBranchQuota(10000);
+    var result: GFTernary = 0;
+    const v: f64 = 1.3;
+    const thr: f64 = 0.5;
+    for (0..1000) |_| {
+        result = gft_from_f64(v, thr);
+    }
+    _ = result;
+}


### PR DESCRIPTION
## Summary

Promotes **GFTernary** from concept-only to a **normative spec**, the same status tier as `gf64.t27` (#916): spec present, Rust + `tri gen` codegen a later phase.

`specs/numeric/gfternary.t27` defines the 2-bit golden-ratio ternary format:
- Representable values **{ −φ, 0, +φ } = φ · {−1, 0, +1}** — a ternary-weight quantizer (cf. TWN, BitNet b1.58) with the scale **fixed at φ** instead of learned per layer; φ ties it to the family's Lucas closure (φ² + φ⁻² = 3).
- 2-bit codes in a `u8` container: `00`→0, `01`→+φ, `10`→−φ, `11`→reserved (folds to zero).
- `gft_canonical / is_zero / sign / from_sign / negate / to_f64` + a TWN-style `gft_from_f64(value, threshold)` quantizer.
- **L4**: 6 `test` + 2 `bench`. **L5**: φ²=φ+1, φ²+φ⁻²=3, φ·φ⁻¹=1 verified with f64 tolerance. **L3**: ASCII-only.

Also updates **§4** of `docs/NUMERIC_FORMATS_SSOT.md` (concept → spec-present) and `docs/NOW.md`.

## Test plan

- [x] Brace-balanced (21/21); 6 `test`, 2 `bench`, 7 `pub fn`; ASCII-clean (L3).
- [x] Syntax modeled on the merged `tf3.t27` (Zig: `pub fn` / `test` / `bench`, `std.testing.expect`, `if/else` expr).
- [x] Spec-only scope precedented by `gf64.t27` (#916, landed without gen/seal).
- [ ] `tri gen` / `tri seal` / Rust impl — explicitly deferred (ROADMAP), not in this PR.

Closes #946