### PR TITLE
docs(numeric): list all 11 members in SSOT §1 (add TF3 + GFTernary rows)

### DIFF
--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,12 @@
 
 Last updated: 2026-05-28
 
+## docs-ternary-rows -- TF3 + GFTernary added to NUMERIC_FORMATS_SSOT section-1 table (Closes #973)
+
+- **WHERE** (doc-only): `docs/NUMERIC_FORMATS_SSOT.md` section 1. Added two rows so the canonical verified-constants table lists all 11 specced members (was 9 floats only): **TF3** (1+3+4, 8-bit, bias 3, phi-distance 0.132 -- shares GF8 geometry; ternary-weight container) and **GFTernary** (2-bit code; E/M columns N/A; phi-distance 0.000 by construction). Added a footnote that these two are not float-ladder rungs and a note that GFTernary's 0.000 is by-construction (not an E/M split), so "closest split = GF64" is unchanged.
+- **Why**: the derived GOLDEN CHAIN brochure now lists all 11 members in one table; the canonical SSOT listed the ternary members only in section 4, a float/ternary drift. This keeps the canonical doc, the brochure, `gf-format-audit`, and `GOLDENFLOAT_FAMILY.md` mutually consistent. Closes #973.
+- **Anchor**: phi^2 + phi^-2 = 3
+
 ## spec-gfternary -- normative 2-bit GoldenFloat ternary {-phi,0,+phi} (Closes #946)
 
 - **WHERE**: added `specs/numeric/gfternary.t27` -- a normative spec for the 2-bit golden-ratio ternary format. Representable values { -phi, 0, +phi } = phi * {-1, 0, +1}: a ternary-weight quantizer (cf. TWN / BitNet b1.58) with the scale fixed at phi rather than learned per layer. 2-bit codes (00->0, 01->+phi, 10->-phi, 11->reserved/folds-to-zero) in a u8 container; encode/decode/sign/negate + a `gft_from_f64(value, threshold)` TWN-style quantizer. 6 `test` + 2 `bench` (L4); phi^2 = phi + 1 and phi^2 + phi^-2 = 3 verified with f64 tolerance (L5); ASCII-only (L3). Promoted section 4 of `docs/NUMERIC_FORMATS_SSOT.md` from "concept; no normative spec" to spec-present.

--- a/docs/NUMERIC_FORMATS_SSOT.md
+++ b/docs/NUMERIC_FORMATS_SSOT.md
@@ -28,15 +28,22 @@ These four columns are mathematically exact and independently re-derived.
 | GF32 | 1+12+19| 32 | 2047    | 4095     | 0.632 | 0.014 | [`gf32.t27`](../specs/numeric/gf32.t27) |
 | GF64 | 1+24+39| 64 | 8388607 | 16777215 | 0.615 | 0.003 | [`gf64.t27`](../specs/numeric/gf64.t27) |
 | GF256| 1+97+158|256| 2⁹⁶−1 †  | 2⁹⁷−1 †  | 0.614 | 0.004 | *gamma; bias OPEN* |
+| TF3  | 1+3+4  | 8  | 3       | 7        | 0.750 | 0.132 | [`tf3.t27`](../specs/numeric/tf3.t27) |
+| GFTernary | 2-bit code | 2 | — | — | — | 0.000 | [`gfternary.t27`](../specs/numeric/gfternary.t27) |
 
 † **GF256 caveat.** Its *stored* exponent-bias constant (≈ 2⁷¹) is unreconciled
 with `2^(E−1)−1 = 2⁹⁶−1`, so the bias is **OPEN** (see §3); only its geometry
 (97/158 split, φ-distance 0.004) is verified. The spec lives in
 `tt-trinity-gamma/specs/fpga/gf256.t27`, **not** this repo.
 
+The last two rows are **not** float-ladder rungs: **TF3** is an 8-bit
+ternary-weight container reusing GF8's 1:3:4 geometry (so it shares GF8's
+constants); **GFTernary** is the 2-bit {−φ, 0, +φ} limit — no exponent/mantissa
+split (columns N/A), φ-distance 0 by construction.
+
 Family base: [`goldenfloat_family.t27`](../specs/numeric/goldenfloat_family.t27).
-Closest split to 1/φ is GF64 (0.003), then GF256 (0.004); GF12 (0.047) is best
-among ≤16-bit.
+Closest *split* to 1/φ is GF64 (0.003), then GF256 (0.004); GF12 (0.047) is best
+among ≤16-bit. (GFTernary's 0.000 is by construction, not an E/M split.)
 GF64 carries `PHI_BIAS = 8388608` — the one format where it coincides with
 `EXP_MAX − BIAS = 2²³`.
 


### PR DESCRIPTION
## Summary

Makes the canonical verified-constants table (§1) list **all 11 specced members**, matching the derived GOLDEN CHAIN brochure. Adds two rows:
- **TF3** — 1+3+4, 8-bit, bias 3, φ-distance 0.132 (shares GF8 geometry; ternary-weight container) → `tf3.t27`
- **GFTernary** — 2-bit code, E/M columns N/A, φ-distance 0.000 by construction → `gfternary.t27`

Plus a footnote that these two are **not** float-ladder rungs, and a note that GFTernary's 0.000 is by-construction (not an E/M split) so the "closest split = GF64" analysis is unchanged.

Doc-only. Closes the last float/ternary drift between the canonical SSOT and the brochure / `gf-format-audit` / `GOLDENFLOAT_FAMILY.md`.

## Test plan
- [x] §1 table now has 11 rows; §4 (ternary members) unchanged and consistent.
- [x] `docs/NOW.md` updated (now-sync gate), date 2026-05-28.
- [ ] CI gates green.

Closes #973