### PR TITLE
fix(compiler): W49 Verilog assertion precedence — parenthesise masked equality (Closes #921)

### DIFF
--- a/bootstrap/src/compiler.rs
+++ b/bootstrap/src/compiler.rs
@@ -9978,8 +9978,14 @@ impl HirTestbench {
             tb.push_str("    initial begin\n");
             for c in &self.checks {
                 let delay_ps = c.cycle * self.clock.period_ns * 1000;
+                // W49 R-EMIT-1 (issue #921): Verilog `==` binds TIGHTER than
+                // `&`, so `signal & MASK == EXPECTED` parses as
+                // `signal & (MASK == EXPECTED)` -- a 1-bit AND of `signal`
+                // with the comparison result, not the intended masked
+                // equality. Wrap the masked load in explicit parentheses so
+                // the emitted check is `(signal & MASK) == EXPECTED`.
                 tb.push_str(&format!(
-                    "        #{} assert(uut.{} & 32'h{:08X} == 32'h{:08X})\n",
+                    "        #{} assert((uut.{} & 32'h{:08X}) == 32'h{:08X})\n",
                     delay_ps, c.signal, c.mask, c.expected
                 ));
                 tb.push_str(&format!(
@@ -17330,6 +17336,32 @@ mod tests_hir_testbench {
         let mut tb = HirTestbench::new("dut", 1000, 10);
         tb.add_check_masked(20, "status", 0xFF, 0xFF);
         assert_eq!(tb.checks[0].mask, 0xFF);
+    }
+
+    #[test]
+    fn test_testbench_masked_assert_parenthesises_and_before_eq_w49() {
+        // W49 R-EMIT-1 / issue #921 regression: in Verilog `==` has higher
+        // precedence than `&`, so a masked equality MUST be emitted as
+        // `(signal & MASK) == EXPECTED`. The previous emitter wrote
+        // `signal & MASK == EXPECTED`, which Verilog parses as
+        // `signal & (MASK == EXPECTED)` -- silently turning the check into
+        // a 1-bit AND of `signal` with the result of the comparison and
+        // producing false passes on real silicon.
+        let mut tb = HirTestbench::new("dut", 1000, 10);
+        tb.add_check_masked(50, "status", 0xABCD, 0xFFFF);
+        let verilog = tb.emit_verilog();
+        // The corrected form (with parens around the AND) must appear.
+        assert!(
+            verilog.contains("(uut.status & 32'h0000FFFF) == 32'h0000ABCD"),
+            "masked assert missing parentheses around the AND; got:\n{}",
+            verilog
+        );
+        // The broken form (no parens) must NOT appear anywhere.
+        assert!(
+            !verilog.contains("uut.status & 32'h0000FFFF == 32'h0000ABCD"),
+            "masked assert still emits the precedence-bug shape; got:\n{}",
+            verilog
+        );
     }
 
     #[test]

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,12 @@
 
 Last updated: 2026-05-31
 
+## verilog-assert-precedence-w49 -- parenthesise masked equality in emitted Verilog asserts (Closes #921)
+
+- **WHERE** (testbench emitter): `bootstrap/src/compiler.rs` (around the masked-assert format in `HirTestbench::emit_verilog`). Verilog's `==` has higher precedence than bitwise `&`, so the previously emitted line `#delay assert(uut.signal & 32'hMASK == 32'hEXPECTED)` parses as `signal & (MASK == EXPECTED)` -- a 1-bit AND of `signal` with the (typically false, hence zero) comparison result, never the intended masked equality. The fix wraps the AND in explicit parens: `#delay assert((uut.signal & 32'hMASK) == 32'hEXPECTED)`. Added regression `test_testbench_masked_assert_parenthesises_and_before_eq_w49` that asserts the parenthesised shape is emitted and the bare-precedence shape is not.
+- **Why**: CRITICAL R-EMIT-1 audit-wave finding (W49). Every masked testbench check in the generated Verilog silently checked the wrong condition, producing false passes on real silicon. Closes #921.
+- **Anchor**: phi^2 + phi^-2 = 3
+
 ## timing-from-mhz-w106 -- correct ps-per-MHz unit conversion (Closes #984)
 
 - **WHERE** (compiler timing model): `bootstrap/src/compiler.rs`. `TimingConstraint::from_mhz` now computes `period_ps = 1_000_000 / mhz` (was `1_000_000_000 / mhz`). Derivation: 1 MHz = 1e6 Hz; period = 1/(mhz * 1e6) s = 1e12/(mhz * 1e6) ps = 1_000_000/mhz ps. Previous body returned a period 1000x too large -- a 100 MHz constraint produced 10_000_000 ps (10 us) instead of 10_000 ps (10 ns), so every test that fed a clock-MHz constraint into `TimingModel::analyze_module` compared nanosecond-scale path delays against a 10-microsecond budget and passed vacuously. Fallback for `mhz == 0` raised to 1_000_000 ps (1 MHz, obviously slow but still satisfiable) instead of the prior 10000 ps which collided with the broken 100 MHz value. Updated `test_clock_mhz` to expect 10_000, added `test_clock_mhz_various_frequencies` (1/50/100/200/500 MHz spot-checks), and updated `test_clock_mhz_zero` to expect 1_000_000.


### PR DESCRIPTION
## Summary

Fixes a Verilog operator-precedence bug in the testbench emitter
(`HirTestbench::emit_verilog` in `bootstrap/src/compiler.rs`).

In Verilog, `==` has higher precedence than `&`. The emitter previously wrote

```verilog
#delay assert(uut.signal & 32'hMASK == 32'hEXPECTED)
```

which Verilog parses as `signal & (MASK == EXPECTED)` — a 1-bit AND of `signal` with the comparison result, **not** the intended `(signal & MASK) == EXPECTED`. Every masked testbench check in generated Verilog therefore silently checked the wrong condition.

## Fix

Wrap the masked load in explicit parentheses:

```verilog
#delay assert((uut.signal & 32'hMASK) == 32'hEXPECTED)
```

A doc-comment at the emit site records the Verilog precedence rule so future readers do not silently drop the parens again.

## Regression test

`test_testbench_masked_assert_parenthesises_and_before_eq_w49` builds a `HirTestbench` with a masked check, emits Verilog, and asserts:

- the corrected shape `(uut.status & 32'h0000FFFF) == 32'h0000ABCD` IS in the output;
- the bare-precedence shape `uut.status & 32'h0000FFFF == 32'h0000ABCD` is NOT.

## Critical-honesty note

This PR only fixes the assertion-emission shape. It does **not** retroactively re-run any pre-existing FPGA testbench that may have passed under the broken form; any silicon previously stamped "verified" against these generated TBs should be considered to have unverified masked-equality conditions until re-checked. Worth tracking as a follow-up if any FPGA bring-ups relied on it.

Closes #921
