### PR TITLE
ci: bypass L1/Issue/NOW gates for trusted bots (Closes #1059)

### DIFF
--- a/.github/workflows/issue-gate.yml
+++ b/.github/workflows/issue-gate.yml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   check-linked-issue:
     runs-on: ubuntu-latest
+    # Closes #1059: bypass Issue Gate for trusted bots (Dependabot opens dep PRs without issues)
+    if: github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]'
     steps:
       - name: Check for linked issues in PR
         env:

--- a/.github/workflows/l1-traceability.yml
+++ b/.github/workflows/l1-traceability.yml
@@ -8,6 +8,8 @@ jobs:
   check-traceability:
     name: Check L1 TRACEABILITY
     runs-on: ubuntu-latest
+    # Closes #1059: bypass L1 gate for trusted bots (Dependabot maintains deps, not features)
+    if: github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -138,6 +140,8 @@ jobs:
           echo "### L1 TRACEABILITY Check Results" >> $GITHUB_STEP_SUMMARY
           if [ "${{ needs.check-traceability.result }}" = "success" ]; then
             echo "✅ All commits comply with L1 TRACEABILITY" >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ needs.check-traceability.result }}" = "skipped" ]; then
+            echo "⏭️ L1 TRACEABILITY check skipped (trusted bot actor)" >> $GITHUB_STEP_SUMMARY
           else
             echo "❌ L1 TRACEABILITY violations detected" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/now-sync-gate.yml
+++ b/.github/workflows/now-sync-gate.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   check-now-freshness:
     runs-on: ubuntu-latest
+    # Closes #1059: bypass NOW Sync Gate for trusted bots (deps PRs don't touch docs/NOW.md)
+    if: github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,6 +1,12 @@
 # NOW -- Trinity t27 sync
 
-Last updated: 2026-06-07
+Last updated: 2026-06-08
+
+## ci-bot-bypass -- bypass L1/Issue/NOW gates for trusted bots (Closes #1059)
+
+- **WHERE** (CI only): three workflow files gain a job-level guard `if: github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]'` -- `.github/workflows/l1-traceability.yml`, `.github/workflows/issue-gate.yml`, `.github/workflows/now-sync-gate.yml`. The L1 summary job gains an explicit `skipped` branch that prints `Skipped (trusted bot actor)` so the run page reads cleanly. No source, no specs, no codegen, no conformance JSON, no `gen/` artefacts touched.
+- **Why**: Dependabot opened #1057 (rusqlite 0.40.1) and #1058 (chrono 0.4.45). Both PRs failed all three gates simultaneously because bots cannot reference issues with `Closes #N` and do not update `docs/NOW.md` for routine dependency bumps. The failures were structural, not substantive. After this PR merges, trusted-bot PRs SKIP the three gates (not FAIL); human PRs remain fully gated by Constitutional Law L1. L6 untouched (gf16 SSOT and conformance JSON unchanged); L5 untouched (no silicon impact); L4 not applicable (workflow YAML, not a `.t27` spec). Acceptance: rerun #1057 and #1058 after merge -- all three gates show `skipped`.
+- **Anchor**: phi^2 + phi^-2 = 3
 
 ## feat-gf-ladder-expansion-v1.2 -- GF ladder expansion v1.2 closed-form rule + Corona ROM CATALOG fix (Closes #1052)
 


### PR DESCRIPTION
## What

Adds `if: github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]'` to three job-level guards:
- `.github/workflows/l1-traceability.yml`
- `.github/workflows/issue-gate.yml`
- `.github/workflows/now-sync-gate.yml`

## Why

Dependabot PRs #1057 (rusqlite) and #1058 (chrono) failed all three gates because bots cannot reference issues or update docs/NOW.md for routine dep bumps.

Failing runs:
- https://github.com/gHashTag/t27/actions/runs/27128331933
- https://github.com/gHashTag/t27/actions/runs/27128331930
- https://github.com/gHashTag/t27/actions/runs/27128329910
- https://github.com/gHashTag/t27/actions/runs/27128321517
- https://github.com/gHashTag/t27/actions/runs/27128321287

## Effect

- Trusted bot PRs: gates SKIPPED (not failed)
- Human PRs: gates remain fully enforced
- L1 summary job now prints `Skipped (trusted bot actor)` for clarity

## Acceptance

After merge, rerun #1057 and #1058 -- all three gates should show 'skipped' instead of 'failed'.

Closes #1059