### PR TITLE
chore: unify contact email to admin@t27.ai across corpus

### DIFF
--- a/.github/workflows/brain-seal-refresh.yml
+++ b/.github/workflows/brain-seal-refresh.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Commit brain seals
         run: |
-          git config --local user.email "t27-bot@trinity.ai"
+          git config --local user.email "admin@t27.ai"
           git config --local user.name "T27 Autonomous Agent"
           git add .trinity/seals/brain_*.json
           git diff --staged --quiet || echo "No changes to commit"

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 license = { text = "MIT" }
 authors = [
-    { name = "Trinity S3AI", email = "t27@trinity.ai" }
+    { name = "Trinity S3AI", email = "admin@t27.ai" }
 ]
 keywords = ["golden-float", "phi", "floating-point", "ml", "numpy"]
 classifiers = [

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,12 @@
 
 Last updated: 2026-06-13
 
+## ops-unify-email -- consolidate contact emails to admin@t27.ai (Closes #1067)
+
+- **WHERE** (metadata only): consolidates 7 ring-NN-rust Cargo.toml `authors` fields (rings 088, 089, 100..104), `bindings/python/pyproject.toml` `authors`, and `.github/workflows/brain-seal-refresh.yml` `user.email`/`user.name` from legacy addresses (`t27@trinity.ai`, `t27-bot@trinity.ai`, `dev@trinity-s3ai.local`) to the single canonical `admin@t27.ai`. No code changes, no spec edits, no `gen/` edits, no conformance JSON touched.
+- **Why**: per ops directive 2026-06-10, `admin@t27.ai` is the only allowed contact surface for this corpus. Other addresses (gmail, trinity.ai placeholders, .local) are deprecated and were either inactive or were placeholders that never resolved. Pure metadata cleanup. L6 untouched. L2 untouched. Closes #1067.
+- **Anchor**: phi^2 + phi^-2 = 3
+
 ## docs-hf-cross-links -- add HuggingFace datasets section to README (Closes #1068)
 
 - **WHERE** (docs only): adds an "HuggingFace mirror" section to `README.md`. Lists the two HF datasets (`playra/numeric-format-catalog`, `playra/numeric-conformance-packs`) and the HF paper page (arXiv:2606.09686). Stresses GitHub remains primary source of truth. No code, no specs, no `gen/` edits, no conformance JSON touched.

--- a/rings/ring-088-rust/Cargo.toml
+++ b/rings/ring-088-rust/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 description = "Trinity ring-088 -- GF16 numeric codec + multiply-accumulate kernel. First honestly-imported Wave-11 crate (Wave 15)."
-authors = ["Trinity Project <dev@trinity-s3ai.local>"]
+authors = ["Trinity Project <admin@t27.ai>"]
 repository = "https://github.com/gHashTag/t27"
 readme = "README.md"
 

--- a/rings/ring-089-rust/Cargo.toml
+++ b/rings/ring-089-rust/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 description = "Trinity ring-089 -- balanced-ternary core ISA: 27 registers x 27 trits, full trit-level add/sub, 9-opcode minimum instruction set, deterministic single-step CPU model. Second honestly-imported Wave-11 crate (Wave 16)."
-authors = ["Trinity Project <dev@trinity-s3ai.local>"]
+authors = ["Trinity Project <admin@t27.ai>"]
 repository = "https://github.com/gHashTag/t27"
 readme = "README.md"
 

--- a/rings/ring-100-rust/Cargo.toml
+++ b/rings/ring-100-rust/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 description = "Trinity ring-100 — Multi-Chip Mesh routing (Phi + Euler + Gamma triad fabric). Wave 12 / Track C / spec-first scaffolding."
-authors = ["Trinity Project <dev@trinity-s3ai.local>"]
+authors = ["Trinity Project <admin@t27.ai>"]
 repository = "https://github.com/gHashTag/t27"
 readme = "README.md"
 

--- a/rings/ring-101-rust/Cargo.toml
+++ b/rings/ring-101-rust/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 description = "Trinity ring-101 — Analog GF16 numeric kernel model (quantize / dequantize, noise injection). Wave 12 / Track C / spec-first scaffolding."
-authors = ["Trinity Project <dev@trinity-s3ai.local>"]
+authors = ["Trinity Project <admin@t27.ai>"]
 repository = "https://github.com/gHashTag/t27"
 
 [lib]

--- a/rings/ring-102-rust/Cargo.toml
+++ b/rings/ring-102-rust/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 description = "Trinity ring-102 — Photonic MAC unit model (wavelength-multiplexed dot product, insertion loss). Wave 12 / Track C / spec-first scaffolding."
-authors = ["Trinity Project <dev@trinity-s3ai.local>"]
+authors = ["Trinity Project <admin@t27.ai>"]
 repository = "https://github.com/gHashTag/t27"
 
 [lib]

--- a/rings/ring-103-rust/Cargo.toml
+++ b/rings/ring-103-rust/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 description = "Trinity ring-103 — On-Chip Learning weight update (φ-tempered SGD step). Wave 12 / Track C / spec-first scaffolding."
-authors = ["Trinity Project <dev@trinity-s3ai.local>"]
+authors = ["Trinity Project <admin@t27.ai>"]
 repository = "https://github.com/gHashTag/t27"
 
 [lib]

--- a/rings/ring-104-rust/Cargo.toml
+++ b/rings/ring-104-rust/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 description = "Trinity ring-104 — Telemetry Bus (bounded, lossy ring buffer for chip-side counters). Wave 12 / Track C / spec-first scaffolding."
-authors = ["Trinity Project <dev@trinity-s3ai.local>"]
+authors = ["Trinity Project <admin@t27.ai>"]
 repository = "https://github.com/gHashTag/t27"
 
 [lib]


### PR DESCRIPTION
## What

Replace all legacy author/contact emails with the single canonical `admin@t27.ai`.

Closes #1067.

## Why

Per ops directive 2026-06-10: `admin@t27.ai` is the only allowed contact surface for this corpus. Other emails (gmail, trinity.ai placeholders, .local) are deprecated.

## What changed (10 files, 10 lines)

| Old | New | Files |
|---|---|---|
| `t27@trinity.ai` | `admin@t27.ai` | `bindings/python/pyproject.toml` |
| `t27-bot@trinity.ai` | `admin@t27.ai` | `.github/workflows/brain-seal-refresh.yml` (x2) |
| `dev@trinity-s3ai.local` | `admin@t27.ai` | `rings/ring-{088,089,100,101,102,103,104}-rust/Cargo.toml` (x7) |

## Scope

- No code changes.
- No behavior changes.
- Pure metadata: `authors` field in Cargo/pyproject manifests; `user.email` in one CI workflow.

## Risk

Low. Cargo/pyproject `authors` is informational; CI bot identity is cosmetic on signed commits.

## Out of scope

- `docs/` markdown files retain their `admin@t27.ai` mentions (already correct).
- No git history rewrite.
- No other repos in this PR.

## NOW.md

`docs/NOW.md` updated with `ops-unify-email` entry per NOW Sync Gate.