### PR TITLE
docs: cross-link HuggingFace datasets in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ inspectable artefacts at every step.
   commercial NPUs on TOPS or SDK breadth; we own the inspectable open silicon
   and formal / assurance corner. Benchmark policy: [`BENCHMARKS.md`](BENCHMARKS.md).
 - **CLARA traceability:** [`CLARA_TRACEABILITY.md`](CLARA_TRACEABILITY.md).
+## HuggingFace mirror
+
+Discoverability mirror of the numeric corpus. GitHub remains the primary source of truth (one-way flow GitHub -> Zenodo -> Hugging Face).
+
+- **Catalog dataset:** [playra/numeric-format-catalog](https://huggingface.co/datasets/playra/numeric-format-catalog) -- the 83-format SSOT
+- **Conformance packs:** [playra/numeric-conformance-packs](https://huggingface.co/datasets/playra/numeric-conformance-packs) -- bit-exact JSON vectors (10 configs across GF4..GF32 + phi-identity)
+- **Paper page:** [arXiv:2606.09686 on HF](https://huggingface.co/papers/2606.09686)
+
+
 
 ---
 

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,12 @@
 
 Last updated: 2026-06-13
 
+## docs-hf-cross-links -- add HuggingFace datasets section to README (Closes #1068)
+
+- **WHERE** (docs only): adds an "HuggingFace mirror" section to `README.md`. Lists the two HF datasets (`playra/numeric-format-catalog`, `playra/numeric-conformance-packs`) and the HF paper page (arXiv:2606.09686). Stresses GitHub remains primary source of truth. No code, no specs, no `gen/` edits, no conformance JSON touched.
+- **Why**: per Niels Rogge feedback in #1063. Makes published artefacts discoverable from the canonical entry point. Closes #1068.
+- **Anchor**: phi^2 + phi^-2 = 3
+
 ## fix-parser-bias-formula -- handle bias formulas in numeric format SSOT (Closes #1064)
 
 - **WHERE** (codegen only): `tools/gen_formats_catalog.py` parser extended to handle bias formulas like `2^N-1` (gf512, gf1024) which were previously dropped on `int(s)` cast. No `specs/` edits, no `gen/` edits in this PR (codegen runs auto-regenerate on master post-merge). The fix raises live regen output from 81 to 83 rows, matching the SSOT raw-line count at HEAD `6ecad30`.


### PR DESCRIPTION
Closes #1068.

Per Niels Rogge's feedback in #1063: surface the two HF datasets in the canonical README.

- [playra/numeric-format-catalog](https://huggingface.co/datasets/playra/numeric-format-catalog)
- [playra/numeric-conformance-packs](https://huggingface.co/datasets/playra/numeric-conformance-packs)
- [arXiv:2606.09686 paper page](https://huggingface.co/papers/2606.09686)

GitHub remains primary source of truth; HF is a one-way mirror.