### PR TITLE
fix(compiler,axi): typechecker soundness + AXI deadlock (Closes #920, #925)

### DIFF
--- a/bootstrap/src/bitnet_axi.rs
+++ b/bootstrap/src/bitnet_axi.rs
@@ -170,6 +170,10 @@ pub fn build_axi_lite_slave(module_name: &str, addr_width: u32, data_width: u32)
     s.push_str("            s_axi_rdata <= {DATA_WIDTH{1'b0}};\n");
     s.push_str("        end else begin\n");
     s.push_str("            // ---- Write channel --------------------------------------------\n");
+    s.push_str("            // #925 fix: clear handshakes BEFORE accept so a same-cycle\n");
+    s.push_str("            // (accept + BREADY/RREADY) race lets the accept NBA win; the\n");
+    s.push_str("            // response is never silently dropped and the master never hangs.\n");
+    s.push_str("            if (s_axi_bvalid && s_axi_bready) s_axi_bvalid <= 1'b0;\n");
     s.push_str("            if (s_axi_awvalid && s_axi_wvalid && s_axi_awready && s_axi_wready) begin\n");
     s.push_str("                case (s_axi_awaddr[5:2])\n");
     s.push_str("                    4'h0: reg_ctrl                 <= s_axi_wdata[31:0];\n");
@@ -188,8 +192,8 @@ pub fn build_axi_lite_slave(module_name: &str, addr_width: u32, data_width: u32)
     s.push_str("                endcase\n");
     s.push_str("                s_axi_bvalid <= 1'b1; s_axi_bresp <= 2'b00;\n");
     s.push_str("            end\n");
-    s.push_str("            if (s_axi_bvalid && s_axi_bready) s_axi_bvalid <= 1'b0;\n");
     s.push_str("            // ---- Read channel ---------------------------------------------\n");
+    s.push_str("            if (s_axi_rvalid && s_axi_rready) s_axi_rvalid <= 1'b0;\n");
     s.push_str("            if (s_axi_arvalid && s_axi_arready) begin\n");
     s.push_str("                case (s_axi_araddr[5:2])\n");
     s.push_str("                    4'h0: s_axi_rdata <= reg_ctrl;\n");
@@ -212,7 +216,6 @@ pub fn build_axi_lite_slave(module_name: &str, addr_width: u32, data_width: u32)
     s.push_str("                endcase\n");
     s.push_str("                s_axi_rvalid <= 1'b1; s_axi_rresp <= 2'b00;\n");
     s.push_str("            end\n");
-    s.push_str("            if (s_axi_rvalid && s_axi_rready) s_axi_rvalid <= 1'b0;\n");
     s.push_str("        end\n");
     s.push_str("    end\n");
     s.push_str("\n");
@@ -385,6 +388,20 @@ mod tests {
         let v = build_axi_lite_slave(DEFAULT_AXI_LITE_SLAVE_NAME, 8, 32);
         assert!(v.contains("if (s_axi_bvalid && s_axi_bready) s_axi_bvalid <= 1'b0;"));
         assert!(v.contains("if (s_axi_rvalid && s_axi_rready) s_axi_rvalid <= 1'b0;"));
+    }
+
+    // Regression for #925: the handshake clear must come BEFORE the accept that
+    // raises bvalid/rvalid, so on a same-cycle (accept + BREADY/RREADY) race the
+    // accept NBA wins and the response is not silently dropped (master deadlock).
+    #[test]
+    fn axi_clear_precedes_accept_no_deadlock() {
+        let v = build_axi_lite_slave(DEFAULT_AXI_LITE_SLAVE_NAME, 8, 32);
+        let b_clear = v.find("if (s_axi_bvalid && s_axi_bready) s_axi_bvalid <= 1'b0;").unwrap();
+        let b_accept = v.find("s_axi_bvalid <= 1'b1; s_axi_bresp <= 2'b00;").unwrap();
+        assert!(b_clear < b_accept, "B-channel clear must precede accept (#925)");
+        let r_clear = v.find("if (s_axi_rvalid && s_axi_rready) s_axi_rvalid <= 1'b0;").unwrap();
+        let r_accept = v.find("s_axi_rvalid <= 1'b1; s_axi_rresp <= 2'b00;").unwrap();
+        assert!(r_clear < r_accept, "R-channel clear must precede accept (#925)");
     }
 
     #[test]

--- a/bootstrap/src/compiler.rs
+++ b/bootstrap/src/compiler.rs
@@ -7287,13 +7287,32 @@ fn types_compatible(target: &TypeInfo, value: &TypeInfo) -> bool {
     if target == value {
         return true;
     }
-    if *target == TypeInfo::F32 && *value == TypeInfo::F64 {
-        return true;
-    }
+    // Reject narrowing f64 -> f32 (precision loss). Widening f32 -> f64 is still
+    // permitted by the rank check below. Fixes #920 (typechecker unsoundness, bug 1).
     if *target == TypeInfo::GF16 && (*value == TypeInfo::F32 || *value == TypeInfo::F64) {
         return true;
     }
+    // Reject implicit cross-sign integer assignment of equal rank (e.g. i32 <-> u32):
+    // 0xFFFFFFFF would silently become -1. Fixes #920 (typechecker unsoundness, bug 3).
+    if is_integer_type(target) && is_integer_type(value)
+        && type_rank(target) == type_rank(value)
+        && is_signed_int(target) != is_signed_int(value)
+    {
+        return false;
+    }
     type_rank(target) >= type_rank(value)
+}
+
+fn is_integer_type(t: &TypeInfo) -> bool {
+    matches!(
+        t,
+        TypeInfo::I8 | TypeInfo::I16 | TypeInfo::I32 | TypeInfo::I64
+            | TypeInfo::U8 | TypeInfo::U16 | TypeInfo::U32 | TypeInfo::U64
+    )
+}
+
+fn is_signed_int(t: &TypeInfo) -> bool {
+    matches!(t, TypeInfo::I8 | TypeInfo::I16 | TypeInfo::I32 | TypeInfo::I64)
 }
 
 fn resolve_type_str(s: &str) -> TypeInfo {
@@ -22293,5 +22312,40 @@ mod tests_phase40_coverage {
         assert_eq!(stmts.len(), 1, "truly unused uninit local must still be dropped");
         assert_eq!(stmts[0].kind, NodeKind::ExprReturn);
         assert!(stats.dead_removed >= 1);
+    }
+}
+
+#[cfg(test)]
+mod tests_typecheck_soundness_920 {
+    use super::*;
+
+    // #920 bug 1: narrowing f64 -> f32 must be rejected (precision loss);
+    // widening f32 -> f64 must still be allowed.
+    #[test]
+    fn no_f64_to_f32_narrowing() {
+        assert!(!types_compatible(&TypeInfo::F32, &TypeInfo::F64),
+            "f64 -> f32 narrowing must be rejected");
+        assert!(types_compatible(&TypeInfo::F64, &TypeInfo::F32),
+            "f32 -> f64 widening must be allowed");
+        assert!(types_compatible(&TypeInfo::F32, &TypeInfo::F32));
+        assert!(types_compatible(&TypeInfo::F64, &TypeInfo::F64));
+    }
+
+    // #920 bug 3: implicit cross-sign integer assignment of equal rank must be
+    // rejected in both directions (0xFFFFFFFF would silently become -1).
+    #[test]
+    fn no_implicit_sign_mix() {
+        assert!(!types_compatible(&TypeInfo::I32, &TypeInfo::U32),
+            "u32 -> i32 must be rejected");
+        assert!(!types_compatible(&TypeInfo::U32, &TypeInfo::I32),
+            "i32 -> u32 must be rejected");
+        assert!(!types_compatible(&TypeInfo::I8, &TypeInfo::U8));
+        assert!(!types_compatible(&TypeInfo::U64, &TypeInfo::I64));
+        // same-sign same-type still compatible
+        assert!(types_compatible(&TypeInfo::I32, &TypeInfo::I32));
+        assert!(types_compatible(&TypeInfo::U32, &TypeInfo::U32));
+        // widening within same sign still allowed (rank check)
+        assert!(types_compatible(&TypeInfo::I64, &TypeInfo::I32));
+        assert!(types_compatible(&TypeInfo::U64, &TypeInfo::U32));
     }
 }

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,15 @@
 
 Last updated: 2026-06-14
 
+## typecheck-axi-soundness -- reject f64->f32 narrowing + cross-sign int assign; AXI clear-before-accept (Closes #920, #925)
+
+- **WHERE**: `bootstrap/src/compiler.rs` `types_compatible()` and `bootstrap/src/bitnet_axi.rs` `build_axi_lite_slave()`.
+- **TYPECHECKER** (#920): removed the inverted rule that allowed narrowing f64->f32 (silent precision loss); widening f32->f64 still permitted by the rank check. Added a cross-sign integer guard: equal-rank signed vs unsigned assignment (e.g. i32 <-> u32) is now rejected via new `is_integer_type` and `is_signed_int` helpers, so `0xFFFFFFFF` no longer silently becomes -1. Two unit tests added in `tests_typecheck_soundness_920`.
+- **AXI** (#925): the AXI-Lite handshake clear `bvalid<=0` / `rvalid<=0` now emits BEFORE the accept block that raises `bvalid<=1` / `rvalid<=1`, so on a same-cycle accept + BREADY/RREADY race the accept NBA wins and the B/R response is not silently dropped. This removes the protocol deadlock where an ARM Cortex-M master could hang forever. New regression test `axi_clear_precedes_accept_no_deadlock` asserts the ordering.
+- **Why**: two CRITICAL soundness/protocol defects from the deep code audit. Generated Verilog is now deadlock-free on the B/R channels and the typechecker rejects two classes of unsound implicit conversions. L6 gf16 SSOT untouched; `specs/numeric/formats_catalog.t27` untouched (still 83); no gen/ edits; ASCII-only; no quality claim added. Closes #920, #925.
+- **Anchor**: phi^2 + phi^-2 = 3
+
+
 ## ci-checkout6-container-root -- fix checkout@v6 EACCES inside container jobs (Closes #1031)
 
 - **WHERE** (CI only): `.github/workflows/coq-kernel.yml`, `.github/workflows/coq-proofs.yml`, `.github/workflows/rings-rust.yml`. Added `options: --user root` to each `container:` block. `actions/checkout@v6` runs on Node 24; inside container jobs the runner-injected `_temp/_runner_file_commands/save_state_*` files are root-owned but the action ran as a non-root container user, so the Post-checkout `save_state` failed with `EACCES: permission denied`, failing the job. Running the container as root lets the action write those state files. `vivado-synth.yml` already had `options: --user 0`; `build-vivado-image.yml` has no real container job. No source/specs/codegen/conformance/`gen/` touched.


### PR DESCRIPTION
## Summary

Two CRITICAL defects from the deep code audit, fixed in one focused PR.

### Typechecker soundness (Closes #920)
- Removed the inverted rule that allowed narrowing `f64 -> f32` (silent precision loss). Widening `f32 -> f64` is still permitted via the rank check.
- Added a cross-sign integer guard: equal-rank signed vs unsigned assignment (e.g. `i32 <-> u32`) is now rejected, so `0xFFFFFFFF` no longer silently becomes `-1`. New helpers `is_integer_type` / `is_signed_int`.
- Tests: `tests_typecheck_soundness_920::no_f64_to_f32_narrowing`, `::no_implicit_sign_mix`.

### AXI-Lite protocol deadlock (Closes #925)
- The handshake clear (`bvalid<=0` / `rvalid<=0`) now emits BEFORE the accept block that raises `bvalid<=1` / `rvalid<=1`. On a same-cycle accept + BREADY/RREADY race the accept NBA wins, so the B/R response is no longer silently dropped and the master never hangs.
- Test: `axi_clear_precedes_accept_no_deadlock` asserts clear precedes accept on both channels.

## Verification
- `cargo build`: clean (warnings pre-existing only).
- 3 new tests green; 0 new regressions (the 6 pre-existing master failures in jwt/ternary/trit_stdlib/hir_pipeline_parity are unchanged and unrelated).

## Constitution compliance
- L6 gf16 SSOT untouched; `specs/numeric/formats_catalog.t27` untouched (still 83); no `gen/` edits.
- ASCII-only; `docs/NOW.md` updated (newest entry at top); no quality claim added.

Closes #920, #925
