### PR TITLE
fix(sva,vcd,chimera): correct 3 confirmed output defects (Closes #969)

### DIFF
--- a/bootstrap/src/behavior_sva_v2.rs
+++ b/bootstrap/src/behavior_sva_v2.rs
@@ -301,12 +301,18 @@ fn extract_delay_cycles(then: &str) -> Option<usize> {
 fn remove_delay_phrase(then: &str) -> String {
     let lower = then.to_ascii_lowercase();
     if let Some(pos) = lower.find("after") {
-        let rest = &lower[pos + 5..].trim();
+        let rest = &lower[pos + 5..].trim_start();
         if let Some(n) = rest.split_whitespace().next() {
             if n.parse::<usize>().is_ok() {
-                let phrase = &then[pos..pos + 5 + n.len() + " cycles".len().min(rest.len())];
-                let cleaned = then.replace(phrase.trim(), "");
-                return cleaned.trim().to_string();
+                // Span from `after` through the end of the `cycles` keyword so
+                // we never leave a stray trailing `s`. Anchoring on the keyword
+                // is robust to the variable space between `after` and `N`.
+                if let Some(kw_rel) = lower[pos..].find("cycles") {
+                    let phrase_end = pos + kw_rel + "cycles".len();
+                    let phrase = &then[pos..phrase_end];
+                    let cleaned = then.replace(phrase, "");
+                    return cleaned.split_whitespace().collect::<Vec<_>>().join(" ");
+                }
             }
         }
     }
@@ -731,6 +737,22 @@ mod tests {
     #[test]
     fn extract_delay_hash_hash() {
         assert_eq!(extract_delay_cycles("##5 valid_out"), Some(5));
+    }
+
+    #[test]
+    fn remove_delay_phrase_no_stray_s_969() {
+        // Regression for #969 item 3: off-by-one left a trailing `s` because the
+        // space between `after` and `N` was not counted in the removed slice.
+        assert_eq!(remove_delay_phrase("after 3 cycles done"), "done");
+        assert_eq!(remove_delay_phrase("after 10 cycles busy"), "busy");
+        assert_eq!(
+            remove_delay_phrase("after 2 cycles increment count"),
+            "increment count"
+        );
+        // Phrase placed after the expression must also be removed cleanly.
+        assert_eq!(remove_delay_phrase("done after 5 cycles"), "done");
+        // `##N` form must remain intact.
+        assert_eq!(remove_delay_phrase("##5 valid_out"), "valid_out");
     }
 
     #[test]

--- a/bootstrap/src/chimera_engine.rs
+++ b/bootstrap/src/chimera_engine.rs
@@ -85,8 +85,19 @@ pub fn chimera_search(
                             "FOUND"
                         };
 
+                        // #969: unary ops (sin/cos/ln/exp) operate on f1 only;
+                        // render them as `op(f1)` so the printed expression
+                        // matches the value actually computed above. Binary ops
+                        // keep the `f1 op f2` infix form.
+                        let expr = match op {
+                            ChimeraOp::Sin
+                            | ChimeraOp::Cos
+                            | ChimeraOp::Log
+                            | ChimeraOp::Exp => format!("{}({})", op_str, f1_id),
+                            _ => format!("{} {} {}", f1_id, op_str, f2_id),
+                        };
                         results.push(ChimeraCandidate {
-                            expr: format!("{} {} {}", f1_id, op_str, f2_id),
+                            expr,
                             target_name: target_name.clone(),
                             target_value: *target_val,
                             chimera_value: chimera_val,
@@ -164,4 +175,36 @@ pub fn generate_basis(max_pow: i32) -> Vec<(String, f64)> {
     }
 
     basis
+}
+
+#[cfg(test)]
+mod tests_969 {
+    use super::*;
+
+    // #969 item 2: unary chimera ops must render as `op(f1)`, matching the
+    // value computed from f1 alone, not as a spurious binary `f1 op f2`.
+    #[test]
+    fn unary_ops_render_as_function_call() {
+        let base: Vec<(&str, f64)> = vec![("f1", 0.5_f64), ("f2", 2.0_f64)];
+        // sin(0.5) ~= 0.4794255386 -> aim a target right at it.
+        let mut targets = HashMap::new();
+        targets.insert("t_sin".to_string(), 0.5_f64.sin());
+        let ops = vec![ChimeraOp::Sin];
+        let res = chimera_search(&base, &ops, &targets, 1.0);
+        assert!(!res.is_empty(), "sin candidate should be found");
+        let c = &res[0];
+        assert_eq!(c.expr, "sin(f1)");
+        assert!(!c.expr.contains("f2"), "unary expr must not mention f2");
+    }
+
+    #[test]
+    fn binary_ops_keep_infix_form() {
+        let base: Vec<(&str, f64)> = vec![("a", 3.0_f64), ("b", 4.0_f64)];
+        let mut targets = HashMap::new();
+        targets.insert("t_sum".to_string(), 7.0_f64);
+        let ops = vec![ChimeraOp::Add];
+        let res = chimera_search(&base, &ops, &targets, 1.0);
+        assert!(!res.is_empty(), "add candidate should be found");
+        assert_eq!(res[0].expr, "a + b");
+    }
 }

--- a/bootstrap/src/compiler.rs
+++ b/bootstrap/src/compiler.rs
@@ -10239,7 +10239,10 @@ impl VcdChange {
 
     pub fn format_binary(&self) -> String {
         if self.bit_width == 1 {
-            format!("{}", self.value & 1)
+            // VCD scalar value change is `<value><ident>` with no separator
+            // (IEEE 1364 VCD). The ident was previously dropped, producing an
+            // invalid dump line. Fix for #969.
+            format!("{}{}", self.value & 1, self.ident)
         } else {
             format!(
                 "b{:0width$b} {}",
@@ -17739,8 +17742,11 @@ mod tests_hir_vcd_trace {
 
     #[test]
     fn test_format_binary_single_bit() {
+        // #969: scalar change must carry the signal ident (`<value><ident>`).
         let c = VcdChange::new(0, "!", 1, 1);
-        assert_eq!(c.format_binary(), "1");
+        assert_eq!(c.format_binary(), "1!");
+        let c0 = VcdChange::new(0, "#", 0, 1);
+        assert_eq!(c0.format_binary(), "0#");
     }
 
     #[test]

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,14 @@
 
 Last updated: 2026-06-14
 
+## sva-vcd-chimera-correctness -- fix 3 confirmed correctness defects (Closes #969)
+
+- **WHERE**: `bootstrap/src/behavior_sva_v2.rs` (`remove_delay_phrase`), `bootstrap/src/compiler.rs` (`VcdChange::format_binary`), `bootstrap/src/chimera_engine.rs` (`chimera_search` expr rendering).
+- **WHAT** (#969 was a 10-item grab-bag; this PR fixes the 3 sub-items confirmed by current code, leaving stale/obsolete items as-is): (item 3) SVA delay-phrase removal had an off-by-one -- for `after N cycles` the space between `after` and `N` was not counted, so the slice cut one char short and left a stray `s` in the consequent (e.g. `after 3 cycles done` -> `s done`); now the phrase is anchored on the `cycles` keyword end. (item 5) VCD scalar value change dropped the signal ident, emitting `0` instead of the IEEE-1364 `<value><ident>` form (`0!`), producing invalid dumps; the single-bit path now appends the ident. (item 2) chimera unary ops (sin/cos/ln/exp) compute from f1 only but were rendered as binary `f1 op f2`, so the printed expression did not match the computed value; unary ops now render as `op(f1)`.
+- **Why**: each defect silently produced wrong output (malformed SVA text, invalid VCD, mislabeled formula). New regression tests: `remove_delay_phrase_no_stray_s_969`, `test_format_binary_single_bit` (now asserts the ident), `tests_969::{unary_ops_render_as_function_call, binary_ops_keep_infix_form}`. Full suite 1426 passed, only the 6 pre-existing failures remain, 0 new regressions. math_compare dead-module item left untouched (not compiled). L6 gf16 SSOT untouched; catalog stays 83; no gen/ edits; ASCII-only added lines; no quality claim added. Closes #969.
+- **Anchor**: phi^2 + phi^-2 = 3
+
+
 ## bitnet-engine-top-wiring -- emit multilayer_sequencer + wire all 9 RTL modules (Closes #926)
 
 - **WHERE**: `bootstrap/src/bitnet_pipeline.rs` (new `build_multilayer_sequencer`), `bootstrap/src/bitnet_bundle.rs` (bundle now emits 11 SV files + manifest), `bootstrap/src/bitnet_top.rs` (`build_bitnet_engine_top` structural datapath).


### PR DESCRIPTION
## Summary

Fixes 3 correctness defects from the #969 grab-bag, each confirmed against the current code. #969 lists ~10 items with stale line numbers; this PR addresses the three that are real, compiled, and well-scoped, leaving obsolete/stale items as-is.

### item 3 -- SVA delay-phrase off-by-one (`behavior_sva_v2::remove_delay_phrase`)
For `after N cycles ...` the slice length did not count the space between `after` and `N`, so the removed phrase was one char short and left a stray `s` in the consequent: `after 3 cycles done` -> `s done`. Now the phrase is anchored on the end of the `cycles` keyword, so the consequent comes out clean (`done`). `##N` form unchanged.

### item 5 -- VCD scalar change dropped signal ident (`compiler::VcdChange::format_binary`)
The single-bit path emitted just the value digit (`0`), missing the signal identifier. IEEE 1364 VCD scalar value changes are `<value><ident>` with no separator (e.g. `0!`). Multi-bit path was already correct. Now the ident is appended.

### item 2 -- chimera unary expr/value mismatch (`chimera_engine::chimera_search`)
Unary ops (sin/cos/ln/exp) compute from `f1` only, but the printed expression rendered them as a binary `f1 op f2`, so the formula string did not match the value actually computed. Unary ops now render as `op(f1)`; binary ops keep the `f1 op f2` infix form.

## Tests
- `behavior_sva_v2::tests::remove_delay_phrase_no_stray_s_969`
- `compiler::tests_hir_vcd_trace::test_format_binary_single_bit` (now asserts the ident)
- `chimera_engine::tests_969::{unary_ops_render_as_function_call, binary_ops_keep_infix_form}`

Full suite: **1426 passed**, only the 6 pre-existing master failures remain, **0 new regressions**.

## Guardrails
- L6 gf16 SSOT untouched; numeric-format catalog stays 83.
- No `gen/` edits; ASCII-only in all added lines.
- No quality/performance claim added.
- math_compare dead-module sub-item intentionally left untouched (module is not compiled).

Anchor: phi^2 + phi^-2 = 3

Closes #969
