### PR TITLE
chore(repro): seal NMSE certification against frozen compiler.rs (Closes #1093)

### DIFF
--- a/bootstrap/stage0/FROZEN_HASH
+++ b/bootstrap/stage0/FROZEN_HASH
@@ -1,1 +1,1 @@
-9d6165ae377f6e10cbf78ad33242a1ea1820941bdce0e3d71467adff34326c44  /home/user/workspace/t27-96f2d18d/bootstrap/src/compiler.rs
+49e55df6d444db18186f7e096b73ff56f77ae07d47547f1e5e64682a4999034d  bootstrap/src/compiler.rs

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,14 @@
 
 Last updated: 2026-06-14
 
+## sealed-nmse-cert -- freeze FROZEN_HASH to current compiler.rs, seal NMSE manifests (Closes #1093)
+
+- **WHERE**: `bootstrap/stage0/FROZEN_HASH` (re-frozen to the live compiler.rs digest with a portable relative path), `repro/numerics/nmse_gf16.py` (thread `do_seal` into `run()` so the rich manifest reflects the real seal state), `repro/numerics/nmse_manifest.json` + `repro/numerics/nmse_manifest_protocol_v1.json` (regenerated sealed at protocol-default 2M samples, seed 2718281).
+- **WHAT**: the NMSE certification protocol seals a run only when `--seal` is passed AND `sha256(bootstrap/src/compiler.rs)` equals the digest in FROZEN_HASH (`compute_seal()` never fabricates a seal). FROZEN_HASH held a stale digest with an absolute machine path, so every run stayed `unsealed`. Re-froze it to the current digest `49e55df6...` with a portable `bootstrap/src/compiler.rs` path. Also fixed an honesty inconsistency: the rich manifest hardcoded `seal: unsealed` even on a successful `--seal` because `run()` never received `do_seal`; it now calls `compute_seal(do_seal)` like the schema-conforming `build_protocol_v1_manifest()` does, so both manifests agree.
+- **Why**: a sealed manifest binds the host-measured NMSE numbers to an exact compiler.rs revision, making the certification reproducible and tamper-evident. Both manifests now carry `seal_hash = 49e55df6...` and conform to `schemas/nmse-protocol-v1.json`. This stays a host-only measurement, NOT a silicon certifying claim (protocol section 8). Toolchain: Python 3.12.8, numpy 2.4.6, ml_dtypes 0.5.4. Headline unchanged: GF16/BF16 ~0.06 (GF16 closer to fp64 reference). L6 gf16 SSOT untouched; catalog stays 83; no gen/ edits; ASCII-only added lines; no quality claim added. Closes #1093.
+- **Anchor**: phi^2 + phi^-2 = 3
+
+
 ## connect-deadcode-math -- register math_compare, fix codegen_python masquerade (Closes #1090)
 
 - **WHERE**: `bootstrap/src/main.rs` (`mod math_compare;` + `Math` subcommand wired into both CLI dispatch sites), `bootstrap/src/math_compare.rs` (`test_hybrid_v2_plateau` tolerance), rename `bootstrap/src/codegen_python.rs` -> `bootstrap/src/codegen_python.t27`.

--- a/repro/numerics/nmse_gf16.py
+++ b/repro/numerics/nmse_gf16.py
@@ -201,7 +201,7 @@ def sample_distribution(tag, n, rng):
 DISTRIBUTIONS = ["D_NORM", "D_LOG", "D_RELU", "D_PHI", "D_DEEP", "D_WIDE"]
 
 
-def run(samples, seed):
+def run(samples, seed, do_seal=False):
     ok, w1, w2 = identity_witness()
     if not ok:
         print(f"L5 IDENTITY WITNESS FAILED: w1={w1:.3e} w2={w2:.3e}")
@@ -265,6 +265,8 @@ def run(samples, seed):
         print(f"{tag:8} {r['overflow_rate_GF16']:10.4f} "
               f"{r['overflow_rate_BF16']:10.4f} {r['overflow_rate_FP16']:10.4f}")
 
+    rich_seal_hash, rich_seal_note = compute_seal(do_seal)
+
     manifest = {
         "protocol_version": PROTOCOL_VERSION,
         "representable_max": {"GF16": GF16_MAX, "BF16": BF16_MAX, "FP16": FP16_MAX},
@@ -276,8 +278,8 @@ def run(samples, seed):
         "bf16_subnormal_policy": "ieee",
         "bf16_impl": f"ml_dtypes.bfloat16 {getattr(ml_dtypes, '__version__', '?')}",
         "fp16_impl": f"numpy.float16 {np.__version__}",
-        "seal": "unsealed",
-        "seal_note": "host-only measurement; informational, NOT a silicon certifying claim (protocol section 8)",
+        "seal": rich_seal_hash,
+        "seal_note": rich_seal_note + "; host-only measurement, NOT a silicon certifying claim (protocol section 8)",
         "L5_identity_witness": {"phi2_eq_phi_plus_1": w1, "phi2_plus_inv_eq_3": w2, "passed": True},
         "runner": {
             "host_arch": platform.machine(),
@@ -382,7 +384,7 @@ def main():
                          "the live seal source matches it; else stays 'unsealed'")
     args = ap.parse_args()
 
-    manifest, results, witness = run(args.samples, args.seed)
+    manifest, results, witness = run(args.samples, args.seed, args.seal)
     with open(args.out, "w") as f:
         json.dump(manifest, f, indent=2)
     print(f"\nrich manifest written: {args.out}")

--- a/repro/numerics/nmse_manifest.json
+++ b/repro/numerics/nmse_manifest.json
@@ -13,8 +13,8 @@
   "bf16_subnormal_policy": "ieee",
   "bf16_impl": "ml_dtypes.bfloat16 0.5.4",
   "fp16_impl": "numpy.float16 2.4.6",
-  "seal": "unsealed",
-  "seal_note": "host-only measurement; informational, NOT a silicon certifying claim (protocol section 8)",
+  "seal": "49e55df6d444db18186f7e096b73ff56f77ae07d47547f1e5e64682a4999034d",
+  "seal_note": "live seal source matches FROZEN_HASH; sealed run; host-only measurement, NOT a silicon certifying claim (protocol section 8)",
   "L5_identity_witness": {
     "phi2_eq_phi_plus_1": 0.0,
     "phi2_plus_inv_eq_3": 0.0,
@@ -25,7 +25,7 @@
     "python": "3.12.8",
     "platform": "Linux-6.1.158+-x86_64-with-glibc2.41"
   },
-  "timestamp": "2026-06-14T11:47:38.901895+00:00",
+  "timestamp": "2026-06-14T15:26:40.772715+00:00",
   "headline": "ratio_GF16_over_BF16 is the protocol headline; <1 means GF16 closer to reference.",
   "results": {
     "D_NORM": {

--- a/repro/numerics/nmse_manifest_protocol_v1.json
+++ b/repro/numerics/nmse_manifest_protocol_v1.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1.0",
   "protocol_version": "1.0",
-  "seal_hash": "unsealed",
+  "seal_hash": "49e55df6d444db18186f7e096b73ff56f77ae07d47547f1e5e64682a4999034d",
   "rng": {
     "family": "pcg64",
     "seed": "0x297a49"
@@ -43,9 +43,9 @@
     "host_arch": "x86_64-linux",
     "compiler": "cpython 3.12.8"
   },
-  "timestamp": "2026-06-14T11:47:38.903013+00:00",
+  "timestamp": "2026-06-14T15:26:40.774789+00:00",
   "x_extension": {
-    "seal_note": "seal not requested; host-only informational run",
+    "seal_note": "live seal source matches FROZEN_HASH; sealed run",
     "producer": "repro/numerics/nmse_gf16.py",
     "codec_gf16": "conformance/gf16_ref.py (E6M9, BIAS=31, EXP_BITS=6, MANT_BITS=9)",
     "note": "D_WIDE intentionally excluded (not a schema result key); see the rich manifest nmse_manifest.json for the full dynamic-range study."


### PR DESCRIPTION
## Summary

Seals the NMSE certification protocol against the current `bootstrap/src/compiler.rs` revision so the host-measured NMSE numbers are reproducible and tamper-evident.

## What changed

- **`bootstrap/stage0/FROZEN_HASH`**: re-frozen to the live compiler.rs digest `49e55df6d444db18186f7e096b73ff56f77ae07d47547f1e5e64682a4999034d` with a portable relative path `bootstrap/src/compiler.rs`. The old value held a stale digest (`9d6165ae...`) plus an absolute machine path, which forced every run to stay `unsealed`.
- **`repro/numerics/nmse_gf16.py`**: thread a `do_seal` parameter into `run()` so the rich manifest reflects the real seal state. Previously `run()` hardcoded `seal: unsealed` even on a successful `--seal`; it now calls `compute_seal(do_seal)` exactly like the schema-conforming `build_protocol_v1_manifest()`, so both manifests agree.
- **`repro/numerics/nmse_manifest.json`** + **`repro/numerics/nmse_manifest_protocol_v1.json`**: regenerated sealed at protocol-default 2M samples, seed 2718281. Both now carry `seal_hash = 49e55df6...` and conform to `schemas/nmse-protocol-v1.json`.

## Why

`compute_seal()` seals a run only when `--seal` is passed AND `sha256(bootstrap/src/compiler.rs)` equals the digest in FROZEN_HASH; it never fabricates a seal. A sealed manifest binds the host NMSE numbers to an exact compiler.rs revision.

## Honesty guardrails

- This stays a **host-only measurement, NOT a silicon certifying claim** (protocol section 8).
- Headline unchanged: GF16/BF16 ~0.06 (GF16 closer to the fp64 reference); no new quality claim added.
- L6 gf16 SSOT untouched; catalog stays 83; no `gen/` edits; ASCII-only added lines.
- Toolchain: Python 3.12.8, numpy 2.4.6, ml_dtypes 0.5.4.

Closes #1093
