### PR TITLE
docs(numerics): reflect sealed manifest state in NUMERICS_VALIDATION (Closes #1095)

### DIFF
--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,14 @@
 
 Last updated: 2026-06-14
 
+## docs-validation-sealed-state -- reflect sealed manifest state in NUMERICS_VALIDATION (Closes #1095)
+
+- **WHERE**: `docs/NUMERICS_VALIDATION.md` (validation-ladder rows L4/L5, the section 5 and section 6 captions, the section 11 reproduction notes, and the closing summary line).
+- **WHAT**: after PR #1094 sealed the committed NMSE manifests, this doc still described the L4/L5 oracle runs as `unsealed` in five places, contradicting the committed `repro/numerics/nmse_manifest.json` which carries `seal = 49e55df6...`. Updated those statements to read host-sealed against `compiler.rs 49e55df6` (reproduce with `python repro/numerics/nmse_gf16.py --seal`) and recorded the pinned toolchain (Python 3.12.8, numpy 2.4.6, ml_dtypes 0.5.4).
+- **Why**: keep the validation contract consistent with the committed sealed manifests so reviewers are not misled. Documentation-only: no numeric, claim, catalog, or SSOT changes; the remaining silicon-sealed FPGA certifying run stays explicitly future work. L6 gf16 SSOT untouched; catalog stays 83; no gen/ edits; ASCII-only added lines. Closes #1095.
+- **Anchor**: phi^2 + phi^-2 = 3
+
+
 ## sealed-nmse-cert -- freeze FROZEN_HASH to current compiler.rs, seal NMSE manifests (Closes #1093)
 
 - **WHERE**: `bootstrap/stage0/FROZEN_HASH` (re-frozen to the live compiler.rs digest with a portable relative path), `repro/numerics/nmse_gf16.py` (thread `do_seal` into `run()` so the rich manifest reflects the real seal state), `repro/numerics/nmse_manifest.json` + `repro/numerics/nmse_manifest_protocol_v1.json` (regenerated sealed at protocol-default 2M samples, seed 2718281).

--- a/docs/NUMERICS_VALIDATION.md
+++ b/docs/NUMERICS_VALIDATION.md
@@ -44,15 +44,15 @@ Until filled, treat numeric behavior as **implementation-defined** outside confo
 | L1 | **Exhaustive** encode/decode + op table | GF4 (and GF8 if feasible) | TBD |
 | L2 | **Conformance JSON** — existing `conformance/gf*_vectors.json` | GF4–GF32 as covered | partial |
 | L3 | **Property-based / randomized** boundaries | GF16+ | TBD |
-| L4 | **Differential** vs reference (round-trip oracle) | GF16 primary | **measured (host, unsealed)** — `repro/numerics/` |
-| L5 | **Comparative** vs IEEE fp16 / bfloat16 on same corpus | GF16 vs fp16/bf16 | **measured (host, unsealed)** — `repro/numerics/nmse_manifest.json` |
+| L4 | **Differential** vs reference (round-trip oracle) | GF16 primary | **measured (host, sealed vs compiler.rs `49e55df6`)** — `repro/numerics/` |
+| L5 | **Comparative** vs IEEE fp16 / bfloat16 on same corpus | GF16 vs fp16/bf16 | **measured (host, sealed vs compiler.rs `49e55df6`)** — `repro/numerics/nmse_manifest.json` |
 | L6 | **Optional** posit reference (where tooling exists) | TBD | TBD |
 
 ---
 
 ## 5. Differential oracle — skeleton results table
 
-*Measured runs (host, unsealed). Reference oracle = f64 round-trip `real -> format -> real`. Seed 2718281, 2,000,000 samples/distribution. Reproduce: `python repro/numerics/nmse_gf16.py`.*
+*Measured runs (host, sealed against the frozen codec revision `49e55df6` in `bootstrap/stage0/FROZEN_HASH`). Reference oracle = f64 round-trip `real -> format -> real`. Seed 2718281, 2,000,000 samples/distribution. Reproduce: `python repro/numerics/nmse_gf16.py --seal`.*
 
 | Run ID | Format | Operation | Corpus | Reference oracle | Max abs err | ULP-like metric | Pass? | Artifact |
 |--------|--------|-----------|--------|------------------|-------------|-----------------|-------|----------|
@@ -68,7 +68,7 @@ Until filled, treat numeric behavior as **implementation-defined** outside confo
 
 Same inputs as §5 where bit patterns map sensibly; document **non-comparable** cases explicitly.
 
-*Measured, host, unsealed (`repro/numerics/nmse_manifest.json`). Non-comparable cases noted.*
+*Measured, host, sealed vs compiler.rs `49e55df6` (`repro/numerics/nmse_manifest.json`). Non-comparable cases noted.*
 
 | Metric | GF16 | IEEE fp16 | bfloat16 | Notes |
 |--------|------|-----------|----------|-------|
@@ -114,10 +114,10 @@ Constant comparisons (if any) must cite **year and revision** and uncertainty; d
 ## 11. Reproduction
 
 - **Smoke:** `make -C repro repro-numerics` (JSON validity).  
-- **L4/L5 oracle (measured):** `python repro/numerics/nmse_gf16.py` — round-trip NMSE/ULP of GF16 vs bf16/fp16 over the protocol distributions; writes `repro/numerics/nmse_manifest.json` (rich) and `repro/numerics/nmse_manifest_protocol_v1.json` (certifying). Host, unsealed.
+- **L4/L5 oracle (measured):** `python repro/numerics/nmse_gf16.py` — round-trip NMSE/ULP of GF16 vs bf16/fp16 over the protocol distributions; writes `repro/numerics/nmse_manifest.json` (rich) and `repro/numerics/nmse_manifest_protocol_v1.json` (certifying). Host; pass `--seal` to bind the run to the frozen compiler.rs digest.
 - **Certifying manifest:** `make -C repro repro-numerics-certify` (or `python repro/numerics/validate_manifest.py`) validates `repro/numerics/nmse_manifest_protocol_v1.json` against `schemas/nmse-protocol-v1.json` and enforces the seal-hash honesty rule.
-- **Sealed run:** `python repro/numerics/nmse_gf16.py --seal` sets `seal_hash` to the `bootstrap/stage0/FROZEN_HASH` digest **only** if the live seal source matches it under a pinned toolchain; otherwise it stays `unsealed`. As committed the manifest is `unsealed` (host, unpinned) — informational, not a silicon certifying claim (protocol section 8).
+- **Sealed run:** `python repro/numerics/nmse_gf16.py --seal` sets `seal_hash` to the `bootstrap/stage0/FROZEN_HASH` digest **only** if the live seal source matches it; otherwise it stays `unsealed`. As committed the manifest is **sealed** against compiler.rs `49e55df6` (host) — informational, NOT a silicon certifying claim (protocol section 8). Toolchain: Python 3.12.8, numpy 2.4.6, ml_dtypes 0.5.4.
 
 ---
 
-*The L4/L5 differential/comparative oracle is now MEASURED (host, unsealed) in `repro/numerics/` — the predictable-skepticism gap is closed at the host level; the remaining step is a sealed-toolchain certifying run.*
+*The L4/L5 differential/comparative oracle is now MEASURED and SEALED at the host level (sealed vs compiler.rs `49e55df6` in `repro/numerics/`) — the predictable-skepticism gap is closed at the host level; the remaining step is a silicon-sealed certifying run under a pinned FPGA toolchain.*


### PR DESCRIPTION
## Summary

Brings `docs/NUMERICS_VALIDATION.md` in line with the committed NMSE manifests. After PR #1094 sealed `repro/numerics/nmse_manifest.json` (and the protocol-v1 manifest) against `bootstrap/src/compiler.rs` digest `49e55df6`, this doc still described the L4/L5 oracle runs as `unsealed` in five places.

## What changed (docs-only)

- Validation-ladder rows **L4** and **L5**: `measured (host, unsealed)` -> `measured (host, sealed vs compiler.rs 49e55df6)`.
- Section 5 and section 6 captions: now say host-sealed against the frozen codec revision; reproduce with `python repro/numerics/nmse_gf16.py --seal`.
- Section 11 reproduction notes: the committed manifest is **sealed** against compiler.rs `49e55df6` (host); recorded the pinned toolchain (Python 3.12.8, numpy 2.4.6, ml_dtypes 0.5.4).
- Closing summary line: oracle is now MEASURED and SEALED at the host level; the remaining step is a silicon-sealed certifying run under a pinned FPGA toolchain.

## Guardrails

- No numeric, claim, catalog, or SSOT changes. The silicon-sealed FPGA run stays explicitly future work.
- L6 gf16 SSOT untouched; catalog stays 83; no `gen/` edits; ASCII added lines (em-dash reused from the surrounding doc).

Closes #1095
