### PR TITLE
feat(cli): wire up notebook + math_bayes, close dead-code #969 remainder (Closes #1097)

### DIFF
--- a/bootstrap/src/main.rs
+++ b/bootstrap/src/main.rs
@@ -19,6 +19,8 @@ mod jwt;
 mod proxy;
 mod formula_eval;
 mod math_compare;
+mod math_bayes;
+mod notebook;
 mod chimera_engine;
 mod sensitivity;
 mod runtime;
@@ -1251,6 +1253,12 @@ enum Commands {
     Math {
         #[command(subcommand)]
         cmd: math_compare::MathCommands,
+    },
+
+    /// Notebook: NotebookLM lifecycle (populate from issues, dashboard, sync, presentations)
+    Notebook {
+        #[command(subcommand)]
+        cmd: notebook::NbCommands,
     },
 }
 
@@ -8261,6 +8269,10 @@ async fn main() -> anyhow::Result<()> {
              let repo_root = std::env::current_dir()?;
              math_compare::run_math_command(cmd, &repo_root)?;
          }
+         Commands::Notebook { cmd } => {
+             let repo_root = std::env::current_dir()?;
+             notebook::run_nb(cmd, &repo_root)?;
+         }
          Commands::TernaryEncode { value } => {
             use crate::ternary::encode_trits;
             let encoded = encode_trits(value);
@@ -8512,6 +8524,10 @@ fn main() -> anyhow::Result<()> {
          Commands::Math { cmd } => {
              let repo_root = std::env::current_dir()?;
              math_compare::run_math_command(cmd, &repo_root)?;
+         }
+         Commands::Notebook { cmd } => {
+             let repo_root = std::env::current_dir()?;
+             notebook::run_nb(cmd, &repo_root)?;
          }
         Commands::TernaryEncode { value } => {
             use crate::ternary::encode_trits;

--- a/bootstrap/src/math_bayes.rs
+++ b/bootstrap/src/math_bayes.rs
@@ -184,7 +184,7 @@ fn compute_sacred_evidence(
     p_random: f64,
     data_norm: f64,
 ) -> ModelEvidence {
-    let n_obs = k * n;  // Total observations
+    let n_obs = (k * n) as usize;  // Total observations
 
     // Maximum likelihood:
     // For Sacred Formula, the compact structure suggests the model captures genuine patterns
@@ -219,7 +219,7 @@ fn compute_null_evidence(
     p_random: f64,
     data_norm: f64,
 ) -> ModelEvidence {
-    let n_obs = k * n;
+    let n_obs = (k * n) as usize;
 
     // Maximum likelihood under H₀:
     // Matches occur randomly with probability p_random
@@ -363,7 +363,8 @@ fn run_verification(experience_path: Option<String>, min_log_bf: f64) -> anyhow:
     let mut success_count = 0;
     let mut min_log_bf = f64::MAX;
 
-    for entry in data.as_array().unwrap_or(&serde_json::json!([])).iter() {
+    let empty_vec: Vec<serde_json::Value> = Vec::new();
+    for entry in data.as_array().unwrap_or(&empty_vec).iter() {
         if let Some(event) = entry.get("event") {
             if event.as_str() == Some("math_compare") {
                 // Extract configuration
@@ -404,4 +405,5 @@ pub fn run_bayes_command(
             run_verification(experience_path, min_log_bf)?;
         }
     }
+    Ok(())
 }

--- a/bootstrap/src/math_compare.rs
+++ b/bootstrap/src/math_compare.rs
@@ -50,6 +50,10 @@ pub enum MathCommands {
         #[arg(long)]
         sensitivity: bool,
     },
+
+    /// Bayes factor analysis for Sacred Formula vs null model (Issue #969 follow-up).
+    #[command(subcommand)]
+    Bayes(crate::math_bayes::BayesCommands),
 }
 
 pub fn run_math_command(cmd: MathCommands, repo_root: &Path) -> anyhow::Result<()> {
@@ -74,6 +78,7 @@ pub fn run_math_command(cmd: MathCommands, repo_root: &Path) -> anyhow::Result<(
                 sensitivity,
             },
         ),
+        MathCommands::Bayes(cmd) => crate::math_bayes::run_bayes_command(cmd, repo_root),
     }
 }
 

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,14 @@
 
 Last updated: 2026-06-14
 
+## connect-notebook-bayes -- wire up notebook + math_bayes, close dead-code #969 remainder (Closes #1097)
+
+- **WHERE**: `bootstrap/src/main.rs` (`mod notebook;` + `mod math_bayes;` registered; new top-level `Notebook` command wired into both CLI dispatch sites), `bootstrap/src/math_compare.rs` (added `Bayes` variant to the `Math` subcommand group + dispatch), `bootstrap/src/math_bayes.rs` (fixed 7 latent compile errors that had never been built).
+- **WHAT**: final slice of the #969 dead-code audit, after #1090 connected `math_compare`. Two modules were compiled-but-unreachable: (a) `notebook.rs` exposes `NbCommands` (Populate/Enrich/Dashboard/Sync/Presentations/ListTopics) and `run_nb` -- a SUPERSET of the live `enrichment` module (which only wires Enrich/audio), so it is NOT a duplicate; registered as a new top-level `notebook` command rather than deleted. (b) `math_bayes.rs` is a self-contained `tri math bayes` (Compute/Verify) distinct from `math_compare`; registered as a `math bayes` subcommand. Building it for the first time surfaced 7 latent errors (two `n_obs` int-width mismatches needing `usize`, a borrow-of-temporary in an `unwrap_or`, and a missing trailing `Ok(())`), all fixed.
+- **Why**: dead code that never compiles hides real defects (here, 7 errors that had never executed) and inflates the tree. The conservative connect-don't-delete choice preserves working functionality flagged for follow-up in #1090. Verified: `tri math bayes compute --k 38 --n 9` runs, `notebook --help` + `math --help` list the new commands, full suite 1442 passed / 0 failed / 2 ignored, 0 new regressions. L6 gf16 SSOT untouched; catalog stays 83; no gen/ edits; ASCII-only added lines; no quality claim added. Closes #1097.
+- **Anchor**: phi^2 + phi^-2 = 3
+
+
 ## docs-validation-sealed-state -- reflect sealed manifest state in NUMERICS_VALIDATION (Closes #1095)
 
 - **WHERE**: `docs/NUMERICS_VALIDATION.md` (validation-ladder rows L4/L5, the section 5 and section 6 captions, the section 11 reproduction notes, and the closing summary line).


### PR DESCRIPTION
## Summary

Final slice of the #969 dead-code audit (after #1090 connected `math_compare`). Two modules under `bootstrap/src/` were compiled-but-unreachable from the CLI. Both are connected (conservative connect-don't-delete), not removed.

## Changes

- **`notebook.rs`** -- exposes `NbCommands` (Populate/Enrich/Dashboard/Sync/Presentations/ListTopics) and `run_nb`. It is a **superset** of the live `enrichment` module (which only wires Enrich/audio), so NOT a true duplicate. Registered as a new top-level `notebook` command, wired into both CLI dispatch sites in `main.rs`.
- **`math_bayes.rs`** -- self-contained `tri math bayes` (Compute/Verify), distinct from `math_compare`. Registered as a `math bayes` subcommand under the existing `Math` group. Building it for the first time surfaced **7 latent compile errors** (two `n_obs` int-width mismatches needing `usize`, a borrow-of-temporary in `unwrap_or`, and a missing trailing `Ok(())`), all fixed.

## Verification

- `tri math bayes compute --k 38 --n 9` runs and prints the Bayes factor.
- `notebook --help` and `math --help` list the new commands.
- Full suite: **1442 passed, 0 failed, 2 ignored, 0 new regressions**.

L6 gf16 SSOT untouched; catalog stays 83; no `gen/` edits; ASCII-only added lines; no quality claim added.

Closes #1097
