### PR TITLE
ci: advisory non-blocking warning when NMSE seal is stale vs compiler.rs (Closes #1099)

### DIFF
--- a/.github/workflows/seal-staleness-warn.yml
+++ b/.github/workflows/seal-staleness-warn.yml
@@ -1,0 +1,74 @@
+name: Seal Staleness Warning
+
+# Variant F (advisory, NON-blocking): when a PR touches the stage0 compiler or
+# the NMSE manifest, recompute sha256(bootstrap/src/compiler.rs) and compare it
+# against the digest the manifest was sealed with. If they diverge, the sealed
+# NMSE numbers were certified against an OLDER compiler and are therefore stale
+# for this branch -- the seal must be deliberately refrozen (a reviewed action).
+#
+# This job is intentionally advisory: it emits a GitHub ::warning:: annotation
+# and ALWAYS exits 0, so it never blocks merge. It is NOT in the required-check
+# set (check-now-freshness / validate / check / check-linked-issue). Honesty
+# rule: we never auto-reseal here; refreezing is an explicit human/PR step.
+
+on:
+  pull_request:
+    branches: [master]
+    paths:
+      - 'bootstrap/src/compiler.rs'
+      - 'bootstrap/stage0/FROZEN_HASH'
+      - 'repro/numerics/nmse_manifest.json'
+
+# Least-privilege: this advisory job only needs to read the checked-out tree.
+permissions:
+  contents: read
+
+jobs:
+  warn-if-seal-stale:
+    runs-on: ubuntu-latest
+    name: Warn if NMSE seal is stale vs compiler.rs
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Compare manifest seal against live sha256(compiler.rs)
+        shell: bash
+        run: |
+          set -uo pipefail
+          MANIFEST="repro/numerics/nmse_manifest.json"
+          SRC="bootstrap/src/compiler.rs"
+          FROZEN="bootstrap/stage0/FROZEN_HASH"
+
+          # Live digest of the stage0 compiler on this branch.
+          LIVE="$(sha256sum "$SRC" | awk '{print $1}')"
+
+          # Digest the certifying manifest was sealed with. An "unsealed" or
+          # missing value means there is no certification to be stale against.
+          SEAL="$(python3 -c "import json,sys; print(json.load(open('$MANIFEST')).get('seal',''))" 2>/dev/null || echo '')"
+
+          # Digest pinned in FROZEN_HASH (the value compute_seal() certifies to).
+          FROZEN_DIGEST="$(awk '{print $1}' "$FROZEN" 2>/dev/null | head -n1)"
+
+          echo "live  sha256(compiler.rs) = $LIVE"
+          echo "manifest seal            = $SEAL"
+          echo "FROZEN_HASH digest       = $FROZEN_DIGEST"
+
+          if [ -z "$SEAL" ] || [ "$SEAL" = "unsealed" ]; then
+            echo "::notice title=Seal advisory::Manifest is unsealed; nothing to compare. No staleness possible."
+            exit 0
+          fi
+
+          if [ "$LIVE" = "$SEAL" ]; then
+            echo "::notice title=Seal fresh::sha256(compiler.rs) matches the manifest seal. Certification is current."
+            exit 0
+          fi
+
+          # Divergence: the sealed NMSE was certified against a different compiler.
+          echo "::warning title=Stale NMSE seal::sha256(bootstrap/src/compiler.rs)=${LIVE:0:12} does NOT match the manifest seal=${SEAL:0:12}. The sealed NMSE numbers in ${MANIFEST} were certified against an older compiler. Re-run 'python repro/numerics/nmse_gf16.py --seal' after refreezing bootstrap/stage0/FROZEN_HASH to recertify. This warning is advisory and does not block merge."
+
+          if [ -n "$FROZEN_DIGEST" ] && [ "$LIVE" != "$FROZEN_DIGEST" ]; then
+            echo "::warning title=FROZEN_HASH drift::sha256(compiler.rs)=${LIVE:0:12} also differs from FROZEN_HASH=${FROZEN_DIGEST:0:12}; a future sealed run will report 'unsealed' until FROZEN_HASH is updated to the new compiler."
+          fi
+
+          # Advisory only -- never fail the build.
+          exit 0

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,14 @@
 
 Last updated: 2026-06-14
 
+## seal-staleness-warn -- advisory CI warning when NMSE seal is stale vs compiler.rs (Closes #1099)
+
+- **WHERE**: `.github/workflows/seal-staleness-warn.yml` (new advisory, NON-blocking workflow).
+- **WHAT**: the certifying NMSE manifest (`repro/numerics/nmse_manifest.json`) is sealed against `sha256(bootstrap/src/compiler.rs)` via `bootstrap/stage0/FROZEN_HASH` (see `compute_seal()` in `repro/numerics/nmse_gf16.py`). When the stage0 compiler changes, the manifest seal silently becomes stale -- the sealed numbers were certified against an older compiler -- with no CI signal. The new workflow triggers on PRs touching `compiler.rs`, `FROZEN_HASH`, or the manifest; it recomputes `sha256(compiler.rs)`, compares it to the manifest `seal`, and emits a GitHub `::warning::` annotation if they diverge (plus a secondary warning if it also diverges from FROZEN_HASH). It ALWAYS exits 0 and runs with `contents: read` only.
+- **Why**: makes seal staleness visible at review time without blocking work. It is deliberately advisory: NOT in the required-check set (check-now-freshness / validate / check / check-linked-issue), and it never auto-reseals -- refreezing stays an explicit reviewed step (`python repro/numerics/nmse_gf16.py --seal` after updating FROZEN_HASH). Honesty: the job reports divergence, it does not fabricate or rewrite any seal. L6 gf16 SSOT untouched; catalog stays 83; no gen/ edits; ASCII-only added lines; no quality claim added. Closes #1099.
+- **Anchor**: phi^2 + phi^-2 = 3
+
+
 ## cast-width-correct -- width-correct Verilog cast lowering + cast-type validation (Closes #1098)
 
 - **WHERE**: `bootstrap/src/compiler.rs` (`parse_cast_target_type` base-type validation; `ExprCast` lowering rewrite in `gen_verilog_expr`; new `param_widths` map on `VerilogCodegen` populated in `gen_verilog_fn`; new tests `test_verilog_cast_width_correct` + `test_parser_rejects_unknown_cast_type`).


### PR DESCRIPTION
## Summary

Adds an **advisory, non-blocking** CI workflow that surfaces NMSE seal staleness at review time.

## Problem

The certifying NMSE manifest (`repro/numerics/nmse_manifest.json`) is sealed against `sha256(bootstrap/src/compiler.rs)` via `bootstrap/stage0/FROZEN_HASH` (see `compute_seal()` in `repro/numerics/nmse_gf16.py`). When the stage0 compiler changes, the manifest seal silently becomes stale -- the sealed numbers were certified against an older compiler -- with no CI signal.

## Changes

New workflow `.github/workflows/seal-staleness-warn.yml`. On PRs touching `compiler.rs`, `FROZEN_HASH`, or the manifest, it:

- recomputes `sha256(compiler.rs)`;
- compares it to the manifest `seal`;
- emits a GitHub `::warning::` annotation if they diverge (and a secondary warning if it also diverges from `FROZEN_HASH`);
- **always exits 0** -- never blocks merge, runs with `contents: read` only.

## Non-blocking by design

This job is **NOT** in the required-check set (`check-now-freshness` / `validate` / `check` / `check-linked-issue`). It never auto-reseals; refreezing remains an explicit reviewed step (`python repro/numerics/nmse_gf16.py --seal` after updating `FROZEN_HASH`). Honesty rule: it reports divergence, it does not fabricate or rewrite any seal.

L6 gf16 SSOT untouched; catalog stays 83; no `gen/` edits; ASCII-only added lines; no quality claim added.

Closes #1099
