### PR TITLE
ci: surface NMSE seal staleness in PR dashboard + local reseal-check.sh (Closes #1103)

### DIFF
--- a/.github/workflows/pr-dashboard.yml
+++ b/.github/workflows/pr-dashboard.yml
@@ -61,6 +61,32 @@ jobs:
           echo "| FAILING | $FAILING |" >> /tmp/pr_dashboard.md
           echo "| PENDING | $PENDING |" >> /tmp/pr_dashboard.md
 
+          # Seal Status (advisory, non-blocking). The certifying NMSE manifest is
+          # sealed against sha256(bootstrap/src/compiler.rs); when the compiler
+          # changes the committed numbers were certified against an older compiler.
+          # This mirrors scripts/reseal-check.sh and seal-staleness-warn.yml so the
+          # dashboard surfaces staleness without ever gating a merge.
+          echo "" >> /tmp/pr_dashboard.md
+          echo "## Seal Status" >> /tmp/pr_dashboard.md
+          echo "" >> /tmp/pr_dashboard.md
+          MANIFEST="repro/numerics/nmse_manifest.json"
+          SRC="bootstrap/src/compiler.rs"
+          if [ ! -f "$SRC" ]; then
+            echo "- :grey_question: seal source missing ($SRC); cannot verify." >> /tmp/pr_dashboard.md
+          else
+            LIVE=$(sha256sum "$SRC" | awk '{print $1}')
+            SEAL=$(python3 -c "import json; print(json.load(open('$MANIFEST')).get('seal',''))" 2>/dev/null || echo "")
+            if [ -z "$SEAL" ] || [ "$SEAL" = "unsealed" ]; then
+              echo "- :grey_question: **UNSEALED** -- manifest carries no seal; nothing to compare." >> /tmp/pr_dashboard.md
+            elif [ "$LIVE" = "$SEAL" ]; then
+              echo "- :white_check_mark: **fresh** -- sha256(compiler.rs)=\`${LIVE:0:12}\` matches the manifest seal. Certification is current." >> /tmp/pr_dashboard.md
+            else
+              echo "- :warning: **STALE** -- sha256(compiler.rs)=\`${LIVE:0:12}\` != manifest seal=\`${SEAL:0:12}\`." >> /tmp/pr_dashboard.md
+              echo "  The committed NMSE numbers were certified against an older compiler.rs." >> /tmp/pr_dashboard.md
+              echo "  Run \`scripts/reseal-check.sh\` locally for the two-step reseal command (advisory; not a merge gate)." >> /tmp/pr_dashboard.md
+            fi
+          fi
+
       - name: Post PR Comment
         if: github.event_name == 'pull_request'
         env:

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,14 @@
 
 Last updated: 2026-06-14
 
+## seal-dashboard -- surface NMSE seal staleness in the PR dashboard + local reseal-check.sh (Closes #1103)
+
+- **WHERE**: `.github/workflows/pr-dashboard.yml` (new `## Seal Status` section in the generated dashboard markdown) and `scripts/reseal-check.sh` (new read-only local reporter).
+- **WHAT**: follow-up to the advisory #1099 CI job, which only fires on PRs touching `compiler.rs`/`FROZEN_HASH`/manifest and only as a transient annotation. Two persistent surfaces added. (a) `pr-dashboard.yml` now recomputes `sha256(bootstrap/src/compiler.rs)`, reads the manifest `seal`, and renders a fresh / STALE / UNSEALED badge in the dashboard report (posted as a PR comment and on the hourly run); it mirrors the CI logic and is advisory only -- it does NOT gate a merge. (b) `scripts/reseal-check.sh` is a one-shot read-only reporter (exit 0 fresh / 2 stale / 3 unsealed, `--quiet` flag) that prints the live/seal/FROZEN digests and, when stale, the exact two-step reseal command; it never rewrites any seal.
+- **Why** the seal model is honest-by-construction (`compute_seal()` in `repro/numerics/nmse_gf16.py` seals only when `--seal` is passed AND the live compiler hashes to FROZEN_HASH), but staleness was only visible as a transient annotation. These two surfaces make it visible at review time and before push, without ever blocking work or auto-resealing -- refreezing stays an explicit reviewed step. L6 gf16 SSOT untouched; catalog stays 83; no gen/ edits; ASCII-only added lines; no quality claim added. Closes #1103.
+- **Anchor**: phi^2 + phi^-2 = 3
+
+
 ## seal-staleness-warn -- advisory CI warning when NMSE seal is stale vs compiler.rs (Closes #1099)
 
 - **WHERE**: `.github/workflows/seal-staleness-warn.yml` (new advisory, NON-blocking workflow).

--- a/scripts/reseal-check.sh
+++ b/scripts/reseal-check.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# reseal-check.sh -- local seal-staleness reporter for the NMSE certification.
+#
+# The certifying NMSE manifest (repro/numerics/nmse_manifest.json) is sealed
+# against sha256(bootstrap/src/compiler.rs) via bootstrap/stage0/FROZEN_HASH
+# (see compute_seal() in repro/numerics/nmse_gf16.py: a run is sealed only when
+# --seal is passed AND the live compiler hashes to exactly the FROZEN_HASH
+# digest). When compiler.rs changes, the manifest seal goes stale: the committed
+# NMSE numbers were certified against an older compiler.
+#
+# This script tells you, locally and before you submit a PR, whether the seal is
+# fresh and -- if stale -- prints the exact two-step reseal command. It NEVER
+# rewrites any seal itself; refreezing is always an explicit, reviewed action.
+# It mirrors the read-only logic of the .github/workflows/seal-staleness-warn.yml
+# advisory CI job, so "green locally" matches "no warning in CI".
+#
+# Usage:
+#   scripts/reseal-check.sh            # report; exit 0 fresh, 2 stale, 3 unsealed
+#   scripts/reseal-check.sh --quiet    # only print the one-line verdict
+#
+# Exit codes: 0 = fresh, 2 = stale (compiler.rs != seal), 3 = unsealed/missing.
+
+set -uo pipefail
+
+# Resolve repo root from this script's location so it works from any CWD.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+MANIFEST="repro/numerics/nmse_manifest.json"
+SRC="bootstrap/src/compiler.rs"
+FROZEN="bootstrap/stage0/FROZEN_HASH"
+
+QUIET=0
+if [ "${1:-}" = "--quiet" ]; then QUIET=1; fi
+
+log() { if [ "$QUIET" -eq 0 ]; then echo "$@"; fi; }
+
+# Live digest of the stage0 compiler on this working tree.
+if [ ! -f "$SRC" ]; then
+  echo "reseal-check: seal source missing ($SRC); cannot verify." >&2
+  exit 3
+fi
+LIVE="$(sha256sum "$SRC" | awk '{print $1}')"
+
+# Digest the certifying manifest was sealed with.
+SEAL="$(python3 -c "import json,sys; print(json.load(open('$MANIFEST')).get('seal',''))" 2>/dev/null || echo '')"
+
+# Digest pinned in FROZEN_HASH (the value compute_seal certifies to).
+FROZEN_DIGEST="$(awk '{print $1}' "$FROZEN" 2>/dev/null | head -n1)"
+
+log "live  sha256(compiler.rs) = $LIVE"
+log "manifest seal            = $SEAL"
+log "FROZEN_HASH digest       = $FROZEN_DIGEST"
+log ""
+
+if [ -z "$SEAL" ] || [ "$SEAL" = "unsealed" ]; then
+  echo "SEAL: UNSEALED -- manifest carries no seal; nothing to compare."
+  echo "  To seal: $ python repro/numerics/nmse_gf16.py --seal"
+  exit 3
+fi
+
+if [ "$LIVE" = "$SEAL" ]; then
+  echo "SEAL: FRESH -- sha256(compiler.rs) matches the manifest seal. Certification is current."
+  exit 0
+fi
+
+# Stale: the manifest was certified against a different compiler.
+echo "SEAL: STALE -- sha256(compiler.rs)=${LIVE:0:12} != manifest seal=${SEAL:0:12}."
+echo "  The committed NMSE numbers were certified against an older compiler.rs."
+echo ""
+echo "  To recertify against the current compiler (two explicit, reviewed steps):"
+echo "    1) refreeze the hash:"
+echo "       printf '%s  %s\\n' \"$LIVE\" \"$SRC\" > $FROZEN"
+echo "    2) regenerate the sealed manifests (protocol default 2M samples, seed 2718281):"
+echo "       python repro/numerics/nmse_gf16.py --seal"
+echo ""
+if [ -n "$FROZEN_DIGEST" ] && [ "$LIVE" != "$FROZEN_DIGEST" ]; then
+  echo "  NOTE: sha256(compiler.rs) also differs from FROZEN_HASH=${FROZEN_DIGEST:0:12};"
+  echo "        until FROZEN_HASH is updated, '--seal' will report 'unsealed'."
+fi
+exit 2


### PR DESCRIPTION
## Summary

Follow-up to #1099. Adds two persistent, advisory surfaces for NMSE seal staleness so a reviewer can see at a glance -- and a contributor can check before pushing -- whether the committed NMSE numbers are certified against the current compiler.

- `.github/workflows/pr-dashboard.yml`: new `## Seal Status` section that recomputes `sha256(bootstrap/src/compiler.rs)`, reads the manifest `seal`, and renders a fresh / STALE / UNSEALED badge in the dashboard markdown (PR comment + hourly run). Advisory only -- NOT a merge gate.
- `scripts/reseal-check.sh`: read-only one-shot reporter (exit 0 fresh / 2 stale / 3 unsealed, `--quiet`). Prints live/seal/FROZEN digests and, when stale, the exact two-step reseal command. Never rewrites any seal.

Honesty: reporting only; refreezing stays an explicit reviewed step (`python repro/numerics/nmse_gf16.py --seal` after updating FROZEN_HASH). Both mirror the existing CI logic so "green locally" matches "no warning in CI". L6 gf16 SSOT untouched; catalog stays 83; ASCII-only added lines; no quality claim added.

Closes #1103
