### PR TITLE
chore: annotate intentional host/manifest public API (dead_code #969) (Closes #1105)

### DIFF
--- a/bootstrap/src/host/weight_loader.rs
+++ b/bootstrap/src/host/weight_loader.rs
@@ -199,6 +199,14 @@ const fn make_table() -> [u32; 256] {
     t
 }
 
+/// Serialize host words to the little-endian byte stream the loader consumes.
+///
+/// Intentional public API and the exact inverse of [`load_words`]: it is the
+/// encode half of the loader's round-trip contract and is exercised by the
+/// round-trip tests below. Production only ever loads pre-built weight blobs,
+/// so the encoder is dead in non-test builds; the annotation documents that
+/// without removing the symbol or breaking the round-trip tests.
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn encode_words(words: &[u64]) -> Vec<u8> {
     let mut buf = Vec::with_capacity(words.len() * 8);
     for &word in words {
@@ -207,6 +215,11 @@ pub fn encode_words(words: &[u64]) -> Vec<u8> {
     buf
 }
 
+/// Serialize host words with a trailing CRC32, matching the loader's checksum
+/// format. Intentional public API: the CRC-aware inverse of [`load_words`]
+/// under [`LoadConfig::with_checksum`], exercised by the round-trip tests.
+/// Dead in non-test builds (production only loads); annotated, not removed.
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn encode_with_crc(words: &[u64]) -> Vec<u8> {
     let crc = crc32_checksum(words);
     let mut buf = encode_words(words);

--- a/bootstrap/src/tt_manifest.rs
+++ b/bootstrap/src/tt_manifest.rs
@@ -54,6 +54,12 @@ impl TtChip {
     }
 
     /// Submodule path under `chips/<slug>` in the t27 repo root.
+    ///
+    /// Intentional public API: exercised by `chip_submodule_path` and consumed
+    /// by tooling that resolves a chip to its repo subtree. Production paths do
+    /// not call it yet, so it is dead only in non-test builds; the annotation
+    /// keeps it warning-free without dropping the symbol.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn submodule_path(&self) -> String {
         format!("chips/{}", self.slug())
     }

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,14 @@
 
 Last updated: 2026-06-14
 
+## deadcode-annotate-host-api -- #969 next layer: annotate intentional host/manifest public API (Closes #1105)
+
+- **WHERE**: `bootstrap/src/host/weight_loader.rs` (`encode_words`, `encode_with_crc`) and `bootstrap/src/tt_manifest.rs` (`TtChip::submodule_path`).
+- **WHAT**: next conservative slice of the #969 dead-code audit. The non-test build emits ~730 warnings, most `dead_code`. Three named symbols are real, intentional public API exercised by tests but not yet wired into production: `encode_words`/`encode_with_crc` are the encode half of the weight-loader round-trip (`load_words` is the inverse; production only loads pre-built blobs, so the encoder is dead in non-test builds) and `submodule_path` is the chip -> repo-subtree helper exercised by `chip_submodule_path`. Each is annotated `#[cfg_attr(not(test), allow(dead_code))]` with a doc comment explaining the intent -- silencing the non-test warning WITHOUT removing the symbol or breaking the round-trip / path tests. Connect-or-annotate, not delete; only the three named symbols were touched this pass.
+- **Why** mass-suppression hides real defects (see #1097, where building dead code surfaced 7 latent errors), so the audit stays conservative and per-symbol: annotate only genuine public API, leave everything else for explicit follow-up. Non-test build warnings drop 732 -> 726 (the three definitions are clean; the broad `host/mod.rs` re-export hub stays untouched as out-of-scope this pass). Full suite 1447 passed / 0 failed / 2 ignored, 0 regressions. L6 gf16 SSOT untouched; catalog stays 83; no gen/ edits; ASCII-only added lines; no quality claim added. Closes #1105.
+- **Anchor**: phi^2 + phi^-2 = 3
+
+
 ## compiler-negative-tests -- dedicated negative-tests gate for the parser/cast contract (Closes #1104)
 
 - **WHERE**: `bootstrap/src/compiler.rs` (new `#[cfg(test)] mod tests_compiler_rejects` with helper `emit` + `assert_dropped` and five tests).


### PR DESCRIPTION
## Summary

Next conservative slice of the #969 dead-code audit. The non-test build emits ~730 warnings, most `dead_code`. Three named symbols are real, intentional public API exercised by tests but not yet wired into production:

- `host/weight_loader.rs`: `encode_words`, `encode_with_crc` -- the encode half of the loader round-trip (`load_words` is the inverse; production only loads pre-built blobs, so the encoder is dead in non-test builds), exercised by the round-trip tests.
- `tt_manifest.rs`: `TtChip::submodule_path` -- the chip -> repo-subtree helper, exercised by `chip_submodule_path`.

Each is annotated `#[cfg_attr(not(test), allow(dead_code))]` with a doc comment explaining the intent -- silencing the non-test warning WITHOUT removing the symbol or breaking the tests.

Connect-or-annotate, not delete. Only the three named symbols were touched; mass-suppression is avoided because building dead code has surfaced real defects before (#1097 found 7 latent errors). Non-test build warnings drop 732 -> 726; the broad `host/mod.rs` re-export hub is left as explicit out-of-scope follow-up. Full suite 1447 passed / 0 failed / 2 ignored, 0 regressions. ASCII-only added lines; catalog stays 83; no quality claim added.

Closes #1105
