### PR TITLE
build: make seal-check + advisory pre-push seal-staleness warning (Closes #1109)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+# Minimal top-level convenience targets for t27.
+#
+# This Makefile is intentionally thin: it only wraps existing scripts so common
+# developer checks have a memorable entry point. It is NOT wired into CI (the
+# required checks remain check-now-freshness / validate / check /
+# check-linked-issue) and adds no build logic of its own.
+#
+# Anchor: phi^2 + phi^-2 = 3
+
+.PHONY: help seal-check install-hooks
+
+# Default target: list what is available.
+help:
+	@echo "t27 convenience targets:"
+	@echo "  make seal-check     Report whether the NMSE manifest seal is fresh"
+	@echo "                      vs sha256(bootstrap/src/compiler.rs) (advisory)."
+	@echo "  make install-hooks  Install the local git hooks (incl. the advisory"
+	@echo "                      pre-push seal-staleness warning)."
+
+# Advisory: report NMSE seal freshness. Exit 0 fresh / 2 stale / 3 unsealed.
+# Never reseals; refreezing stays an explicit reviewed step.
+seal-check:
+	@scripts/reseal-check.sh
+
+# Install the local git hooks (advisory pre-push includes the seal check).
+install-hooks:
+	@scripts/install-git-hooks.sh

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,14 @@
 
 Last updated: 2026-06-14
 
+## seal-pre-push-hook -- advisory seal-staleness check at push time + make seal-check (Closes #1109)
+
+- **WHERE**: new top-level `Makefile` and `scripts/install-git-hooks.sh` (the installed L4 pre-push hook).
+- **WHAT**: #1103 added `scripts/reseal-check.sh` and a dashboard badge, but the reporter was still manual with no memorable entry point and nothing surfaced seal staleness at push time. Two thin additions. (a) A minimal top-level `Makefile` with `make seal-check` (wraps `scripts/reseal-check.sh`), `make install-hooks` (wraps `scripts/install-git-hooks.sh`), and a `help` default that lists them. It is intentionally thin -- it only wraps existing scripts, adds no build logic, and is NOT wired into CI (required checks stay check-now-freshness / validate / check / check-linked-issue). (b) The advisory pre-push hook installed by `scripts/install-git-hooks.sh` now also runs `reseal-check.sh --quiet` and prints a YELLOW warning when the seal is stale or unsealed vs `compiler.rs`. It always falls through to `exit 0` -- it NEVER blocks the push and NEVER reseals.
+- **Why** the seal model is honest-by-construction but staleness was only visible via the manual reporter or a transient CI annotation; this gives a memorable local entry point and a push-time nudge without ever gating work or auto-resealing -- refreezing stays an explicit reviewed step. Hook verified `bash -n` clean and `make seal-check` reports STALE (exit 2) as expected. L6 gf16 SSOT untouched; catalog stays 83; no gen/ edits; ASCII-only added lines; no quality claim added. Closes #1109.
+- **Anchor**: phi^2 + phi^-2 = 3
+
+
 ## deadcode-annotate-host-api -- #969 next layer: annotate intentional host/manifest public API (Closes #1105)
 
 - **WHERE**: `bootstrap/src/host/weight_loader.rs` (`encode_words`, `encode_with_crc`) and `bootstrap/src/tt_manifest.rs` (`TtChip::submodule_path`).

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -112,6 +112,18 @@ if [ -n "$T27_FILES" ]; then
     echo "$T27_FILES"
 fi
 
+# Advisory NMSE seal-staleness check (variant J). Non-blocking: if the
+# committed NMSE manifest was certified against an older compiler.rs, warn the
+# author at push time. Mirrors scripts/reseal-check.sh and seal-staleness-warn.yml.
+# It NEVER reseals and NEVER blocks the push (always falls through to exit 0).
+ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+if [ -x "$ROOT_DIR/scripts/reseal-check.sh" ]; then
+    if ! "$ROOT_DIR/scripts/reseal-check.sh" --quiet >/dev/null 2>&1; then
+        echo -e "${YELLOW}WARNING: NMSE seal is stale or unsealed vs compiler.rs (advisory).${NC}"
+        echo "Run 'scripts/reseal-check.sh' for the reseal command. Push not blocked."
+    fi
+fi
+
 exit 0
 EOF
 


### PR DESCRIPTION
## Variant J -- advisory seal-staleness check at push time + make seal-check

#1103 added `scripts/reseal-check.sh` and a dashboard badge, but the check is still manual. There is no memorable entry point and nothing surfaces seal staleness at push time.

### Proposed
- Add a minimal top-level `Makefile` with `make seal-check` (wraps `scripts/reseal-check.sh`) and `make install-hooks`, plus a `help` default. NOT wired into CI -- required checks stay check-now-freshness / validate / check / check-linked-issue.
- Extend the advisory pre-push hook installed by `scripts/install-git-hooks.sh` to also run `reseal-check.sh --quiet` and print a warning when the seal is stale/unsealed. It must NEVER block the push (always exit 0) and NEVER reseal.

Advisory only; refreezing stays an explicit reviewed step.
