### PR TITLE
test: extend tests_compiler_rejects beyond casts (Closes #1110)

### DIFF
--- a/bootstrap/src/compiler.rs
+++ b/bootstrap/src/compiler.rs
@@ -19759,6 +19759,114 @@ mod tests_compiler_rejects {
             v
         );
     }
+
+    // -----------------------------------------------------------------------
+    // Variant K: extend the contract beyond casts. The parser/codegen reacts to
+    // malformed input in three distinct, empirically-observed ways; each is
+    // pinned here so a future change that alters the behavior fails loudly.
+    //
+    //   (a) DROP-TO-TODO   -- an expression that fails mid-parse triggers
+    //                         statement-level recovery; the statement is dropped
+    //                         and the body is left `// TODO: implement`.
+    //   (b) HARD ERROR     -- a malformation the *module* parser cannot recover
+    //                         from (unterminated module, value-less const)
+    //                         aborts the whole compile with Err.
+    //   (c) SILENT LEAK    -- a stray token that still lexes as an identifier is
+    //                         accepted as a bare no-op statement and leaks into
+    //                         codegen. This is a KNOWN GAP, not a guarantee; the
+    //                         test characterizes the current behavior so the gap
+    //                         is visible and a future fix is detected.
+    // -----------------------------------------------------------------------
+
+    /// Helper: compile and return Ok(verilog) or the Err string, without
+    /// panicking, so module-level hard errors can be asserted directly.
+    fn try_emit(src: &str) -> Result<String, String> {
+        Compiler::compile_verilog(src)
+    }
+
+    // (a) Unclosed parenthesis in a return expression -> drop-to-TODO.
+    #[test]
+    fn rejects_unclosed_paren() {
+        let v = emit(
+            r#"module RejUnclosedParen {
+    pub fn f(x: u8) -> u8 {
+        return (x + 1
+    }
+}"#,
+        );
+        assert_dropped(&v, "f", &[]);
+    }
+
+    // (a) Malformed binary expression (`x + * 2`) -> drop-to-TODO.
+    #[test]
+    fn rejects_malformed_binop() {
+        let v = emit(
+            r#"module RejBadBinop {
+    pub fn g(x: u8) -> u8 {
+        return x + * 2
+    }
+}"#,
+        );
+        assert_dropped(&v, "g", &[]);
+    }
+
+    // (b) Unterminated module (missing closing brace) -> HARD compile error.
+    #[test]
+    fn rejects_unterminated_module() {
+        let r = try_emit(
+            r#"module RejUnterminated {
+    pub fn f(x: u8) -> u8 {
+        return x
+    }"#,
+        );
+        assert!(
+            r.is_err(),
+            "an unterminated module must fail to compile, got Ok:\n{:?}",
+            r
+        );
+    }
+
+    // (b) Const declaration with no value (`const W : u32 =`) -> HARD error.
+    #[test]
+    fn rejects_const_without_value() {
+        let r = try_emit(r#"module RejBadConst { pub const W : u32 = }"#);
+        assert!(
+            r.is_err(),
+            "a value-less const must fail to compile, got Ok:\n{:?}",
+            r
+        );
+    }
+
+    // (c) KNOWN GAP characterization: a stray token that still lexes as an
+    // identifier (`frobnicate`) is currently accepted as a bare no-op statement
+    // and LEAKS into codegen as `frobnicate;`, and the following `return` still
+    // lowers. This is NOT the desired contract -- it is pinned so the leak is
+    // visible and any future hardening of the parser is detected by this test
+    // failing (at which point it should be converted to an `assert_dropped`).
+    #[test]
+    fn characterizes_stray_ident_leak_known_gap() {
+        let v = emit(
+            r#"module GapStrayIdent {
+    pub fn k(x: u8) -> u8 {
+        frobnicate x
+        return x
+    }
+}"#,
+        );
+        // Current (undesired) behavior: the stray identifier leaks as a no-op
+        // statement and the body is NOT dropped.
+        assert!(
+            v.contains("frobnicate;"),
+            "KNOWN GAP changed: stray ident no longer leaks as `frobnicate;`. \
+             If the parser now rejects it, convert this test to assert_dropped. Got:\n{}",
+            v
+        );
+        assert!(
+            !v.contains("// TODO: implement"),
+            "KNOWN GAP changed: body is now dropped; update this characterization. Got:\n{}",
+            v
+        );
+    }
 }
 
 #[cfg(test)]

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,14 @@
 
 Last updated: 2026-06-14
 
+## compiler-negative-tests-ext -- extend the parser negative-tests gate beyond casts (Closes #1110)
+
+- **WHERE**: `bootstrap/src/compiler.rs` (`#[cfg(test)] mod tests_compiler_rejects`: new helper `try_emit` + five tests appended after `accepts_valid_cast_as_control`).
+- **WHAT**: #1104 added the negative-tests gate but it only covered `as`-casts. This pass extends it with cases empirically grouped by the three distinct, observed reactions to malformed input. (a) DROP-TO-TODO: an unclosed paren in a return expr (`return (x + 1`) and a malformed binop (`x + * 2`) trigger statement-level recovery -- the statement is dropped and the body left `// TODO: implement` (asserted via `assert_dropped`). (b) HARD ERROR: an unterminated module (missing closing brace) and a value-less const (`const W : u32 =`) abort the whole compile with `Err` (asserted via the new `try_emit` helper + `.is_err()`). (c) KNOWN GAP characterization: a stray token that still lexes as an identifier (`frobnicate x`) currently LEAKS into codegen as `frobnicate;` and does NOT drop the body -- pinned as a characterization test, honestly documented as undesired current behavior, so the gap is visible and any future hardening of the parser is detected (at which point it is converted to an `assert_dropped`).
+- **Why** statement-level recovery is deliberate but makes parser rejections invisible, and a single cast-only gate under-specifies the contract; pinning all three observed outcome classes (including the honest gap) means a future change that lets malformed input leak into Verilog, or that silently changes recovery behavior, fails loudly. Tests-only, no production code change. Full suite passes with the five new tests (`tests_compiler_rejects` module: 10 passed / 0 failed), 0 regressions. L6 gf16 SSOT untouched; catalog stays 83; no gen/ edits; ASCII-only added lines; no quality claim added. Closes #1110.
+- **Anchor**: phi^2 + phi^-2 = 3
+
+
 ## seal-pre-push-hook -- advisory seal-staleness check at push time + make seal-check (Closes #1109)
 
 - **WHERE**: new top-level `Makefile` and `scripts/install-git-hooks.sh` (the installed L4 pre-push hook).


### PR DESCRIPTION
## Variant K -- extend the negative-tests gate beyond casts

#1104 added `tests_compiler_rejects` covering only `as`-casts. The parser/codegen reacts to other malformed input in distinct ways that are currently untested.

### Proposed
Extend the module with cases empirically grouped by observed outcome:
- (a) DROP-TO-TODO: unclosed paren in a return expr; malformed binop (`x + * 2`) -- statement dropped, body left `// TODO: implement`.
- (b) HARD ERROR: unterminated module (missing brace); value-less const (`const W : u32 =`) -- whole compile fails with Err.
- (c) KNOWN GAP (characterization): a stray token that still lexes as an identifier (`frobnicate x`) currently LEAKS into codegen as `frobnicate;` and does NOT drop the body. Pin this as a characterization test so the gap is visible and any future hardening is detected (then converted to a rejection assertion).

Honest framing: (c) is documented as a current-behavior gap, not a guarantee. Tests-only.
