### PR TITLE
fix: reject stray token after bare expression statement (Closes #1115)

### DIFF
--- a/bootstrap/src/compiler.rs
+++ b/bootstrap/src/compiler.rs
@@ -1745,9 +1745,31 @@ impl Parser {
             return Ok(assign);
         }
 
-        // Bare expression statement
-        if self.current.kind == TokenKind::Semicolon {
-            self.advance();
+        // Bare expression statement. A well-formed bare expression is
+        // terminated by a semicolon, or sits as the final expression directly
+        // before the block's closing brace (or EOF). Any OTHER token here means
+        // the statement did not end where it should -- e.g. `frobnicate x`,
+        // where `frobnicate` parses as a bare ident expression and the stray
+        // `x` is left dangling. Previously such a leftover token was silently
+        // ignored and the bare expression accepted, letting malformed input
+        // leak into codegen (the #1110 known-gap characterization). Treat the
+        // dangling token as a syntax error so the caller's statement-level
+        // recovery (`recover_to_stmt_boundary`) drops the malformed statement,
+        // consistent with how other malformed statements are handled.
+        match self.current.kind {
+            TokenKind::Semicolon => {
+                self.advance();
+            }
+            TokenKind::RBrace | TokenKind::Eof => {
+                // Final expression of a block, or end of input: no terminator
+                // required.
+            }
+            _ => {
+                return Err(format!(
+                    "unexpected token after expression statement: {:?}",
+                    self.current.kind
+                ));
+            }
         }
         let mut stmt = Node::new(NodeKind::StmtExpr);
         stmt.children.push(expr);
@@ -19837,14 +19859,16 @@ mod tests_compiler_rejects {
         );
     }
 
-    // (c) KNOWN GAP characterization: a stray token that still lexes as an
-    // identifier (`frobnicate`) is currently accepted as a bare no-op statement
-    // and LEAKS into codegen as `frobnicate;`, and the following `return` still
-    // lowers. This is NOT the desired contract -- it is pinned so the leak is
-    // visible and any future hardening of the parser is detected by this test
-    // failing (at which point it should be converted to an `assert_dropped`).
+    // (c) GAP CLOSED (#1110 -> #1115): a stray token that still lexes as an
+    // identifier (`frobnicate x`) used to be accepted as a bare no-op statement
+    // and LEAK into codegen as `frobnicate;`. The bare-expression branch in
+    // `parse_body_stmt` now rejects a dangling token after an expression, so the
+    // malformed statement triggers statement-level recovery and the body is
+    // dropped to `// TODO: implement` -- the bogus `frobnicate` never reaches
+    // codegen. This was a characterization test for the known gap; with the gap
+    // closed it is now a rejection assertion (renamed accordingly).
     #[test]
-    fn characterizes_stray_ident_leak_known_gap() {
+    fn rejects_stray_ident() {
         let v = emit(
             r#"module GapStrayIdent {
     pub fn k(x: u8) -> u8 {
@@ -19853,19 +19877,8 @@ mod tests_compiler_rejects {
     }
 }"#,
         );
-        // Current (undesired) behavior: the stray identifier leaks as a no-op
-        // statement and the body is NOT dropped.
-        assert!(
-            v.contains("frobnicate;"),
-            "KNOWN GAP changed: stray ident no longer leaks as `frobnicate;`. \
-             If the parser now rejects it, convert this test to assert_dropped. Got:\n{}",
-            v
-        );
-        assert!(
-            !v.contains("// TODO: implement"),
-            "KNOWN GAP changed: body is now dropped; update this characterization. Got:\n{}",
-            v
-        );
+        // The malformed statement is dropped; the bogus ident never leaks.
+        assert_dropped(&v, "k", &["frobnicate"]);
     }
 }
 

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,14 @@
 
 Last updated: 2026-06-14
 
+## fix-stray-ident-leak -- close the stray-identifier parser leak (#1110 known-gap -> fix) (Closes #1115)
+
+- **WHERE**: `bootstrap/src/compiler.rs` (`parse_body_stmt` bare-expression branch; the #1110 characterization test renamed `characterizes_stray_ident_leak_known_gap` -> `rejects_stray_ident` and switched to `assert_dropped`).
+- **WHAT**: #1110 pinned a known gap -- a stray token that still lexes as an identifier (`frobnicate x`) was accepted as a bare no-op statement and LEAKED into codegen as `frobnicate;`, body NOT dropped. Root cause: after parsing a bare expression, `parse_body_stmt` silently ignored whatever token followed, leaving the dangling `x` for the next loop iteration instead of rejecting the malformed statement. Fix: after a bare expression the next token must be a valid statement boundary -- `;` (consumed), or `}` / EOF (final expression of a block); any other token is now a syntax error, so the malformed statement triggers the existing statement-level recovery (`recover_to_stmt_boundary`) and the body is dropped to `// TODO: implement`, consistent with how unclosed parens and malformed binops are already handled. The bogus ident never reaches codegen. The characterization test is promoted to a rejection assertion.
+- **Why** this is a real production-parser change (stricter), so it was validated against the full suite: 1452 passed / 0 failed / 2 ignored, 0 regressions -- confirming the previous lenient behavior was a genuine gap, not relied upon by any test or fixture. The honest #1110 framing pays off: the documented gap is now closed and the test converted exactly as that entry promised. L6 gf16 SSOT untouched; catalog stays 83; no gen/ edits; ASCII-only added lines; no quality claim added. Closes #1115.
+- **Anchor**: phi^2 + phi^-2 = 3
+
+
 ## deadcode-annotate-host-mod -- #969 next layer: annotate the host/mod.rs re-export facade (Closes #1111)
 
 - **WHERE**: `bootstrap/src/host/mod.rs` (one module-scoped inner attribute + explanatory comment, after the header comment, before the `pub mod` declarations).


### PR DESCRIPTION
## Variant M -- close the stray-identifier leak (promote the #1110 known-gap to a fix)

#1110 added a characterization test (`characterizes_stray_ident_leak_known_gap`) documenting that a stray token which still lexes as an identifier (`frobnicate x`) was accepted as a bare no-op statement and LEAKED into codegen as `frobnicate;`, with the body NOT dropped. This is undesired behavior, pinned only so the gap was visible.

### Root cause
In `parse_body_stmt` (`bootstrap/src/compiler.rs`), the "bare expression statement" fall-through parses `frobnicate` as an expression, then silently ignores whatever token follows. The dangling `x` was left for the next loop iteration, so the malformed statement was accepted instead of rejected.

### Proposed
After parsing a bare expression, require that the next token is a valid statement boundary -- `;` (consumed), or `}` / EOF (final expression of a block). Any other token is a syntax error, so the malformed statement triggers the existing statement-level recovery (`recover_to_stmt_boundary`) and the body is dropped to `// TODO: implement` -- consistent with how unclosed parens and malformed binops are already handled (#1110 group (a)). The bogus ident never reaches codegen.

Then promote the characterization test: rename `characterizes_stray_ident_leak_known_gap` -> `rejects_stray_ident` and switch it to `assert_dropped`.

Honest framing: this is a real production-parser behavior change (stricter), so it must pass the full suite with zero regressions -- confirming the previous lenient behavior was a genuine gap, not relied upon.
