### PR TITLE
build: add make warnings-baseline advisory dead-code meter (Closes #1116)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 #
 # Anchor: phi^2 + phi^-2 = 3
 
-.PHONY: help seal-check install-hooks
+.PHONY: help seal-check install-hooks warnings-baseline
 
 # Default target: list what is available.
 help:
@@ -16,6 +16,8 @@ help:
 	@echo "                      vs sha256(bootstrap/src/compiler.rs) (advisory)."
 	@echo "  make install-hooks  Install the local git hooks (incl. the advisory"
 	@echo "                      pre-push seal-staleness warning)."
+	@echo "  make warnings-baseline  Count non-test build warnings vs the recorded"
+	@echo "                      baseline and list the top files (advisory; #969)."
 
 # Advisory: report NMSE seal freshness. Exit 0 fresh / 2 stale / 3 unsealed.
 # Never reseals; refreezing stays an explicit reviewed step.
@@ -25,3 +27,8 @@ seal-check:
 # Install the local git hooks (advisory pre-push includes the seal check).
 install-hooks:
 	@scripts/install-git-hooks.sh
+
+# Advisory: count non-test build warnings vs the recorded baseline and list the
+# top offending files, to track #969 dead-code progress. Never edits code.
+warnings-baseline:
+	@scripts/warnings-baseline.sh

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,14 @@
 
 Last updated: 2026-06-14
 
+## warnings-baseline-meter -- advisory non-test build-warning meter for the #969 audit (Closes #1116)
+
+- **WHERE**: new `scripts/warnings-baseline.sh` and the top-level `Makefile` (new `warnings-baseline` target).
+- **WHAT**: the #969 dead-code audit removes/annotates build warnings one conservative slice at a time (#1105, #1111, ...), but there was no memorable, repeatable way to see the current count or pick the next slice. `scripts/warnings-baseline.sh` builds the binary crate with `--message-format=json`, counts the non-test compiler warnings, compares the count to a recorded baseline, and prints the top offending source files; `--quiet` prints a one-line verdict. A `make warnings-baseline` target wraps it (continuing the thin #1109 Makefile). It is advisory only -- never edits code, never reseals, NOT wired into CI (required checks stay check-now-freshness / validate / check / check-linked-issue); informational exit codes (0 <= baseline, 1 > baseline, 2 build failed) are never used to fail a required check.
+- **Why** the audit needs a progress meter so each conservative slice is easy to pick and regressions are visible. Baseline correctness: the structured primary-span count on master is 683 (measured from the JSON diagnostics) -- earlier NOW.md entries quoted ~685/726 from the cargo summary line, which rounds differently, so the script documents that the JSON primary-span count is the canonical meter and pins BASELINE=683; it suggests updating BASELINE when a reviewed slice legitimately lowers it. Verified: `make warnings-baseline` reports 683 == baseline 683, verdict OK, exit 0, with the top files (compiler.rs 248, host/errors.rs 28, ...). L6 gf16 SSOT untouched; catalog stays 83; no gen/ edits; ASCII-only added lines; no quality claim added. Closes #1116.
+- **Anchor**: phi^2 + phi^-2 = 3
+
+
 ## fix-stray-ident-leak -- close the stray-identifier parser leak (#1110 known-gap -> fix) (Closes #1115)
 
 - **WHERE**: `bootstrap/src/compiler.rs` (`parse_body_stmt` bare-expression branch; the #1110 characterization test renamed `characterizes_stray_ident_leak_known_gap` -> `rejects_stray_ident` and switched to `assert_dropped`).

--- a/scripts/warnings-baseline.sh
+++ b/scripts/warnings-baseline.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+#
+# warnings-baseline.sh -- advisory non-test build-warning reporter for t27.
+#
+# The #969 dead-code audit removes or annotates build warnings one conservative
+# slice at a time (see docs/NOW.md). This script gives that effort a memorable,
+# read-only progress meter: it builds the binary crate with JSON diagnostics,
+# counts the non-test compiler warnings, compares the count to a recorded
+# baseline, and prints the top offending source files so the next slice is easy
+# to pick.
+#
+# It is ADVISORY ONLY: it never edits code, never reseals anything, and is NOT
+# wired into CI (the required checks stay check-now-freshness / validate /
+# check / check-linked-issue). The baseline is a soft reference, not a gate.
+#
+# Exit codes (informational, never used to fail a required check):
+#   0 = warning count <= baseline (no regression)
+#   1 = warning count  > baseline (more warnings than the recorded baseline)
+#   2 = build failed (could not produce diagnostics)
+#
+# Usage:
+#   scripts/warnings-baseline.sh             # full report + top modules
+#   scripts/warnings-baseline.sh --quiet     # one-line verdict only
+#
+# Anchor: phi^2 + phi^-2 = 3
+
+set -uo pipefail
+
+# Recorded baseline of non-test build warnings on master. Update this number
+# (in the same PR) whenever a reviewed slice legitimately lowers it, so the
+# meter keeps tracking real progress. Measured precisely from the structured
+# JSON diagnostics on master after the host/mod.rs facade slice (#1111): 683.
+# (Earlier NOW.md entries quoted ~685/726 from the cargo summary line, which
+# rounds differently; this script's primary-span count is the canonical meter.)
+BASELINE=683
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+QUIET=0
+if [ "${1:-}" = "--quiet" ]; then QUIET=1; fi
+log() { if [ "$QUIET" -eq 0 ]; then echo "$@"; fi; }
+
+# Prefer an explicit cargo if present; fall back to PATH.
+CARGO_BIN="cargo"
+if [ -x "$HOME/.cargo/bin/cargo" ]; then CARGO_BIN="$HOME/.cargo/bin/cargo"; fi
+
+# Capture JSON diagnostics. We do not redirect into the build target dir; the
+# caller's CARGO_TARGET_DIR (if any) is respected. stderr carries progress.
+JSON_OUT="$(mktemp)"
+trap 'rm -f "$JSON_OUT"' EXIT
+
+if ! "$CARGO_BIN" build --bin t27c --message-format=json >"$JSON_OUT" 2>/dev/null; then
+    log "warnings-baseline: BUILD FAILED -- cannot count warnings."
+    exit 2
+fi
+
+# Count non-test warnings and tally the top files using the structured output.
+# A small python helper keeps the JSON parsing robust and dependency-free.
+REPORT="$(python3 - "$JSON_OUT" <<'PY'
+import json, sys, collections
+path = sys.argv[1]
+counts = collections.Counter()
+total = 0
+with open(path, "r", encoding="utf-8", errors="replace") as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            m = json.loads(line)
+        except Exception:
+            continue
+        if m.get("reason") != "compiler-message":
+            continue
+        msg = m.get("message", {})
+        if msg.get("level") != "warning":
+            continue
+        text = msg.get("message", "")
+        # Skip the cargo summary line ("`t27c` generated N warnings").
+        if text.startswith("`t27c`"):
+            continue
+        total += 1
+        f = None
+        for s in msg.get("spans", []):
+            if s.get("is_primary"):
+                f = s.get("file_name")
+                break
+        if f is None:
+            spans = msg.get("spans", [])
+            if spans:
+                f = spans[0].get("file_name")
+        counts[f or "<unknown>"] += 1
+print(total)
+for f, n in counts.most_common(10):
+    print(f"{n}\t{f}")
+PY
+)"
+
+TOTAL="$(printf '%s\n' "$REPORT" | head -n 1)"
+TOPS="$(printf '%s\n' "$REPORT" | tail -n +2)"
+
+if ! printf '%s' "$TOTAL" | grep -qE '^[0-9]+$'; then
+    log "warnings-baseline: could not parse warning count."
+    exit 2
+fi
+
+if [ "$TOTAL" -gt "$BASELINE" ]; then
+    VERDICT="REGRESSED ($TOTAL > baseline $BASELINE)"
+    CODE=1
+else
+    VERDICT="OK ($TOTAL <= baseline $BASELINE)"
+    CODE=0
+fi
+
+if [ "$QUIET" -eq 1 ]; then
+    echo "warnings-baseline: $VERDICT"
+    exit "$CODE"
+fi
+
+echo "================================================================"
+echo " t27 non-test build warnings (advisory; #969 dead-code progress)"
+echo "================================================================"
+echo " count    : $TOTAL"
+echo " baseline : $BASELINE"
+echo " verdict  : $VERDICT"
+echo "----------------------------------------------------------------"
+echo " top files by warning count:"
+printf '%s\n' "$TOPS" | while IFS=$'\t' read -r n f; do
+    [ -n "$n" ] && printf '   %5s  %s\n' "$n" "$f"
+done
+echo "----------------------------------------------------------------"
+if [ "$CODE" -eq 0 ] && [ "$TOTAL" -lt "$BASELINE" ]; then
+    echo " note: count is BELOW baseline -- if a reviewed slice lowered it,"
+    echo "       update BASELINE in this script (currently $BASELINE) in the same PR."
+fi
+echo " advisory only: never edits code, never gates CI."
+exit "$CODE"


### PR DESCRIPTION
## Variant N -- make warnings-baseline: advisory non-test build-warning meter

The #969 dead-code audit removes/annotates build warnings one conservative slice at a time (#1105, #1111, ...). There is no memorable, repeatable way to see the current count or pick the next slice.

### Proposed
- Add `scripts/warnings-baseline.sh`: build the binary crate with `--message-format=json`, count the non-test compiler warnings, compare to a recorded baseline, and print the top offending source files. `--quiet` prints a one-line verdict. Advisory only -- never edits code, never reseals, NOT wired into CI (required checks stay check-now-freshness / validate / check / check-linked-issue).
- Add a `make warnings-baseline` target wrapping it (continuing the thin Makefile from #1109).

### Baseline correctness
The structured primary-span count on master is **683** (measured from the JSON diagnostics). Earlier NOW.md entries quoted ~685/726 from the cargo summary line, which rounds differently; the script documents that the JSON primary-span count is the canonical meter and pins BASELINE=683. The script flags a count above baseline (informational exit 1) and suggests updating BASELINE when a reviewed slice legitimately lowers it.
