### PR TITLE
build: #969 dead-code slice -- host/errors.rs catalog (Closes #1122)

### DIFF
--- a/bootstrap/src/host/errors.rs
+++ b/bootstrap/src/host/errors.rs
@@ -1,3 +1,16 @@
+// Variant P (#969 dead-code audit, host/errors.rs layer). This module is a
+// self-contained, intentional public API: a structured catalog of host-driver
+// error codes (Severity, ErrorDomain, ErrorCode, the ERR_* constants, and the
+// CATALOG lookup helpers). It is fully exercised by this module's own test
+// suite (domain decoding, raw round-trip, catalog lookup/filter, severity
+// ordering, display) but is not yet wired into production host code, so every
+// symbol emits a `dead_code` warning (28 in total) in the non-test build.
+// These are deliberate public surface, not dead code -- a single module-scoped
+// allow documents that without removing or weakening any symbol. Scoped to
+// `not(test)` so the test build still flags genuinely unused items, exactly as
+// in the #1105 / #1111 slices of this audit.
+#![cfg_attr(not(test), allow(dead_code))]
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Severity {
     Info = 0,

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,13 @@
 
 Last updated: 2026-06-14
 
+## deadcode-annotate-host-errors -- #969 next slice: annotate the host/errors.rs catalog (Closes #1122)
+
+- **WHERE**: `bootstrap/src/host/errors.rs` (new module-scoped inner attribute at the top of the file) and `scripts/warnings-baseline.sh` (BASELINE 683 -> 655 + history comment).
+- **WHAT**: continues the #969 dead-code audit one conservative slice at a time (after #1105 / #1111 host facade). The structured host-error catalog in `errors.rs` -- `Severity`, `ErrorDomain`, `ErrorCode`, the `ERR_*` consts, `CATALOG`, and the `lookup` / `by_domain` / `by_severity` accessors -- is intentional public API exercised by tests but not yet wired to a production caller, so it emitted 28 `dead_code` warnings in non-test builds. Adds `#![cfg_attr(not(test), allow(dead_code))]` as a module-scoped inner attribute at the top of the file with a comment explaining it is intentional public API kept for the host bring-up surface; same conservative annotate-not-delete pattern as the host facade slices. No code deleted, no public item removed. The advisory `warnings-baseline.sh` meter (#1116) is bumped 683 -> 655 in the same change so it keeps tracking real progress.
+- **Why** this removes 28 warnings with zero behavior change and zero deletion of the public catalog, the next safe step of #969. Verified: `cargo build --bin t27c` clean; non-test warning count 683 -> 655 (measured from JSON primary-span diagnostics); the 12 errors.rs unit tests still pass; `make warnings-baseline` reports OK (655 <= baseline 655). Advisory only; the four required CI checks remain the gate. L6 gf16 SSOT untouched; catalog stays 83; no gen/ edits; ASCII-only added lines; no quality claim added. Closes #1122.
+- **Anchor**: phi^2 + phi^-2 = 3
+
 ## reseal-apply-cmd -- explicit reviewed reseal entry point (make seal) (Closes #1117)
 
 - **WHERE**: new `scripts/reseal-apply.sh` and the top-level `Makefile` (new `seal` target).

--- a/scripts/warnings-baseline.sh
+++ b/scripts/warnings-baseline.sh
@@ -29,10 +29,12 @@ set -uo pipefail
 # Recorded baseline of non-test build warnings on master. Update this number
 # (in the same PR) whenever a reviewed slice legitimately lowers it, so the
 # meter keeps tracking real progress. Measured precisely from the structured
-# JSON diagnostics on master after the host/mod.rs facade slice (#1111): 683.
-# (Earlier NOW.md entries quoted ~685/726 from the cargo summary line, which
-# rounds differently; this script's primary-span count is the canonical meter.)
-BASELINE=683
+# JSON diagnostics on master. History: 683 after the host/mod.rs facade slice
+# (#1111); 655 after the host/errors.rs catalog slice (variant P, issue #1122)
+# annotated its 28 dead_code symbols. (Earlier NOW.md entries quoted ~685/726
+# from the cargo summary line, which rounds differently; this script's
+# primary-span count is the canonical meter.)
+BASELINE=655
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"


### PR DESCRIPTION
## Variant P -- #969 dead-code slice: host/errors.rs catalog

Annotates the intentional public host-error catalog in
`bootstrap/src/host/errors.rs` with a module-scoped
`#![cfg_attr(not(test), allow(dead_code))]` (plus an explanatory comment),
silencing 28 `dead_code` warnings without deleting any code -- the same
conservative pattern as the #1105 / #1111 host-facade slices. Bumps the
advisory baseline in `scripts/warnings-baseline.sh` from 683 to 655.

### Verification
- `cargo build --bin t27c` clean; non-test warning count 683 -> 655 (JSON
  primary-span count).
- 12 `errors.rs` unit tests still pass.
- `make warnings-baseline` -> `OK (655 <= baseline 655)`.

Advisory-only; the four required CI checks remain the gate. NOW.md updated.

Closes #1122
