### PR TITLE
test: extend negative-test gate to module/declaration level (Closes #1123)

### DIFF
--- a/bootstrap/src/compiler.rs
+++ b/bootstrap/src/compiler.rs
@@ -19880,6 +19880,128 @@ mod tests_compiler_rejects {
         // The malformed statement is dropped; the bogus ident never leaks.
         assert_dropped(&v, "k", &["frobnicate"]);
     }
+    // -----------------------------------------------------------------------
+    // Variant Q: extend the negative-test contract from the statement level
+    // (variants K/M, inside function bodies) UP to the module/declaration
+    // level. The top-level declaration parser reacts to malformed input in the
+    // SAME three empirically-observed ways as the statement parser, so the
+    // contract is symmetric and pinned here:
+    //
+    //   (a) DROP-RECOVERY  -- a malformed top-level item that still lexes as
+    //                         identifiers (an unknown leading token, or a `fn`
+    //                         with no body) is skipped by
+    //                         `skip_to_next_top_level()`; the parser RESYNCS to
+    //                         the next valid declaration and the module still
+    //                         compiles. The bogus tokens never reach codegen,
+    //                         and a VALID declaration that follows is still
+    //                         parsed -- proving recovery, not truncation.
+    //   (b) HARD ERROR     -- garbage that does NOT lex as a skippable
+    //                         declaration token (a stray `@` between decls)
+    //                         cannot be resynced; it propagates to the module's
+    //                         closing-brace expectation and aborts the whole
+    //                         compile with Err.
+    //   (c) PERMISSIVE     -- the declaration parser intentionally accepts some
+    //                         shapes WITHOUT error: an empty module body, and
+    //                         two modules that share a name (no dedup check).
+    //                         These are characterized, not asserted-against, so
+    //                         that if a future change adds rejection the test
+    //                         fails loudly and the decision is made on purpose.
+    //
+    // All outcomes below were observed empirically before being asserted.
+    // -----------------------------------------------------------------------
+
+    /// Helper: assert a bogus top-level token was dropped during recovery and
+    /// never leaked into codegen, while the module skeleton still emitted.
+    fn assert_decl_dropped(v: &str, module_name: &str, bogus_tokens: &[&str]) {
+        assert!(
+            v.contains(&format!("module {} (", module_name)),
+            "the module skeleton must still emit after declaration recovery, got:\n{}",
+            v
+        );
+        for tok in bogus_tokens {
+            assert!(
+                !v.contains(tok),
+                "bogus top-level token `{}` must never reach codegen, got:\n{}",
+                tok,
+                v
+            );
+        }
+    }
+
+    // (a) Unknown leading top-level token (`gibberish foo`) -> the declaration
+    // parser errors, `skip_to_next_top_level()` drops the bogus tokens, and the
+    // module still compiles. Neither bogus identifier reaches codegen.
+    #[test]
+    fn rejects_unknown_top_level_token() {
+        let v = emit(r#"module QUnknownDecl { gibberish foo }"#);
+        assert_decl_dropped(&v, "QUnknownDecl", &["gibberish", "foo"]);
+    }
+
+    // (a) DROP-RECOVERY that RESYNCS: a bogus leading token is dropped, then a
+    // VALID `const` declaration that follows it is still parsed and lowered.
+    // This proves `skip_to_next_top_level()` resynchronizes rather than aborts
+    // or truncates the rest of the module.
+    #[test]
+    fn recovers_to_next_decl_after_unknown_token() {
+        let v = emit(r#"module QResync { zzzbogus pub const KEEP : u32 = 99 }"#);
+        assert_decl_dropped(&v, "QResync", &["zzzbogus"]);
+        assert!(
+            v.contains("KEEP = 99"),
+            "the valid const after the dropped token must still lower, got:\n{}",
+            v
+        );
+    }
+
+    // (a) A `fn` declaration with no body (`pub fn f(x: u8) -> u8` with no
+    // `{ ... }`) is dropped at the declaration level; the function name never
+    // reaches codegen and the module skeleton still emits.
+    #[test]
+    fn rejects_fn_declaration_without_body() {
+        let v = emit(r#"module QNoBody { pub fn weirdfn(x: u8) -> u8 }"#);
+        assert_decl_dropped(&v, "QNoBody", &["weirdfn"]);
+    }
+
+    // (b) A stray token that does not lex as a skippable declaration start
+    // (`@` between two consts) cannot be resynced and aborts the whole compile
+    // with a HARD error -- the same class as an unterminated module.
+    #[test]
+    fn rejects_unrecoverable_garbage_between_decls() {
+        let r = try_emit(r#"module QGarbage { pub const A : u32 = 1 @ pub const B : u32 = 2 }"#);
+        assert!(
+            r.is_err(),
+            "unrecoverable garbage between declarations must fail to compile, got Ok:\n{:?}",
+            r
+        );
+    }
+
+    // (c) PERMISSIVE characterization: an empty module body compiles without
+    // error and emits a valid (port-only) skeleton. Pinned so that adding a
+    // "modules must be non-empty" rule later is a deliberate, test-visible
+    // decision rather than a silent change.
+    #[test]
+    fn accepts_empty_module_body_characterization() {
+        let v = emit(r#"module QEmpty { }"#);
+        assert!(
+            v.contains("module QEmpty ("),
+            "an empty module is currently accepted and must still emit, got:\n{}",
+            v
+        );
+    }
+
+    // (c) PERMISSIVE characterization: two modules sharing the same name are
+    // both accepted today (there is no duplicate-name check). Pinned as current
+    // behavior, not endorsed -- a future dedup pass should flip this test.
+    #[test]
+    fn accepts_duplicate_module_names_characterization() {
+        let r = try_emit(
+            r#"module QDup { pub const A : u32 = 1 } module QDup { pub const B : u32 = 2 }"#,
+        );
+        assert!(
+            r.is_ok(),
+            "duplicate module names are currently accepted (no dedup check), got Err:\n{:?}",
+            r
+        );
+    }
 }
 
 #[cfg(test)]

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,13 @@
 
 Last updated: 2026-06-14
 
+## decl-level-negative-tests -- extend the negative-test gate to module/declaration level (Closes #1123)
+
+- **WHERE**: `bootstrap/src/compiler.rs` (`mod tests_compiler_rejects`: new `assert_decl_dropped` helper + six tests).
+- **WHAT**: variants K (#1110) and M (#1115) pinned the negative-test contract for malformed input INSIDE function bodies (statement-level recovery, hard errors, a now-closed silent-leak gap). The top-level declaration parser (`parse_module_body` / `parse_top_level_decl` / `skip_to_next_top_level`) has the SAME three reaction classes but they were never pinned. This extends the contract UP to the module/declaration level, each outcome observed empirically with a temporary probe BEFORE being asserted: (a) DROP-RECOVERY -- an unknown leading top-level token (`gibberish foo`) and a `fn` declaration with no body are skipped by `skip_to_next_top_level()`; the module still compiles and the bogus tokens never reach codegen (`rejects_unknown_top_level_token`, `rejects_fn_declaration_without_body`), and `recovers_to_next_decl_after_unknown_token` proves recovery RESYNCS -- a valid `const KEEP = 99` after a dropped token is still parsed and lowered, not truncated. (b) HARD ERROR -- a stray `@` between declarations cannot be resynced and aborts the whole compile with Err, the same class as an unterminated module (`rejects_unrecoverable_garbage_between_decls`). (c) PERMISSIVE characterization -- an empty module body and two modules sharing a name are currently accepted with no error; pinned as current behavior so any future rejection is a deliberate, test-visible decision (`accepts_empty_module_body_characterization`, `accepts_duplicate_module_names_characterization`).
+- **Why** makes the parser's declaration-level error behavior an explicit, regression-safe contract symmetric with the statement-level gate -- honest empirical grouping (facts observed before asserted), no production behavior change (tests only). Verified: `cargo test --bin t27c tests_compiler_rejects` -> 16 passed (10 prior + 6 new); full suite 1458 passed / 0 failed / 2 ignored (was 1452), 0 regressions. L6 gf16 SSOT untouched; catalog stays 83; no gen/ edits; ASCII-only added lines; no quality claim added. Closes #1123.
+- **Anchor**: phi^2 + phi^-2 = 3
+
 ## deadcode-annotate-host-errors -- #969 next slice: annotate the host/errors.rs catalog (Closes #1122)
 
 - **WHERE**: `bootstrap/src/host/errors.rs` (new module-scoped inner attribute at the top of the file) and `scripts/warnings-baseline.sh` (BASELINE 683 -> 655 + history comment).


### PR DESCRIPTION
## Variant Q -- extend the negative-test gate to the module/declaration level

Extends the negative-test contract from the statement level (variants K #1110 /
M #1115, inside function bodies) UP to the module/declaration level. The
top-level declaration parser reacts to malformed input in the SAME three
empirically-observed ways, now pinned by six tests + an `assert_decl_dropped`
helper in `mod tests_compiler_rejects`:

- **(a) DROP-RECOVERY** -- unknown leading top-level token / `fn` with no body
  are skipped by `skip_to_next_top_level()`; module still compiles, bogus tokens
  never reach codegen; recovery RESYNCS (a valid `const` after the dropped token
  is still parsed). `rejects_unknown_top_level_token`,
  `rejects_fn_declaration_without_body`,
  `recovers_to_next_decl_after_unknown_token`.
- **(b) HARD ERROR** -- a stray `@` between decls cannot be resynced and aborts
  the compile. `rejects_unrecoverable_garbage_between_decls`.
- **(c) PERMISSIVE characterization** -- empty module body and duplicate module
  names are currently accepted; pinned as current behavior.
  `accepts_empty_module_body_characterization`,
  `accepts_duplicate_module_names_characterization`.

Each outcome was observed empirically with a temporary probe before being
asserted. Tests-only; no production behavior change.

### Verification
- `cargo test --bin t27c tests_compiler_rejects` -> 16 passed (10 prior + 6 new).
- Full suite: 1458 passed, 0 failed, 0 regressions (was 1452).

NOW.md updated.

Closes #1123
