### PR TITLE
build: add make verify -- single advisory pre-PR umbrella (Closes #1124)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 #
 # Anchor: phi^2 + phi^-2 = 3
 
-.PHONY: help seal-check seal install-hooks warnings-baseline
+.PHONY: help verify seal-check seal install-hooks warnings-baseline
 
 # Default target: list what is available.
 help:
@@ -20,6 +20,15 @@ help:
 	@echo "                      pre-push seal-staleness warning)."
 	@echo "  make warnings-baseline  Count non-test build warnings vs the recorded"
 	@echo "                      baseline and list the top files (advisory; #969)."
+	@echo "  make verify         Run all advisory pre-PR checks at once (seal-check"
+	@echo "                      + warnings-baseline + quick test); never blocks."
+
+# Advisory umbrella: run the seal-freshness, warnings-baseline, and a quick test
+# back-to-back and print one compact summary. Never edits code, never reseals,
+# always exits 0 -- a convenience entry point for a pre-PR glance. The real gate
+# stays the four required CI checks.
+verify:
+	@scripts/verify.sh
 
 # Advisory: report NMSE seal freshness. Exit 0 fresh / 2 stale / 3 unsealed.
 # Never reseals; refreezing stays an explicit reviewed step.

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,13 @@
 
 Last updated: 2026-06-14
 
+## make-verify-umbrella -- single advisory pre-PR umbrella (make verify) (Closes #1124)
+
+- **WHERE**: new `scripts/verify.sh` and the top-level `Makefile` (new `verify` target + `make help` entry).
+- **WHAT**: the repo has accumulated several small read-only developer checks, each with its own entry point -- the NMSE seal-freshness reporter (`make seal-check` / #1106), the #969 dead-code warning meter (`make warnings-baseline` / #1119), and the test suite. Before opening a PR a contributor wants to glance at all of them at once. `scripts/verify.sh` runs three best-effort sub-checks back-to-back -- (1) `scripts/reseal-check.sh --quiet` (seal freshness), (2) `scripts/warnings-baseline.sh --quiet` (#969 meter), (3) a quick `cargo test --bin t27c tests_compiler_rejects` (the negative-test gate from K/M/Q; `VERIFY_FULL_TEST=1` runs the whole suite, `VERIFY_SKIP_TEST=1` skips the test step) -- then prints one compact `verify: ...` summary line. Supports `--quiet`. A missing sub-script is reported as SKIP, never an error. A `verify` target wraps it (continuing the thin #1109 Makefile) and is listed in `make help`.
+- **Why** a memorable pre-PR convenience that surfaces all advisory checks in one place. It is advisory only -- never edits code, never reseals, and ALWAYS exits 0, so it is safe to wire into a pre-push habit without ever blocking a push; the actual gate stays the four required CI checks (check-now-freshness / validate / check / check-linked-issue). Verified: `make verify` runs all three sub-checks and prints a single summary (seal STALE advisory, warnings OK <= 655, test PASS) at exit 0; `scripts/verify.sh --quiet` prints only the summary line; `VERIFY_SKIP_TEST=1` and `VERIFY_FULL_TEST=1` behave as documented; `make help` lists the new target. L6 gf16 SSOT untouched; catalog stays 83; no gen/ edits; ASCII-only added lines; no quality claim added. Closes #1124.
+- **Anchor**: phi^2 + phi^-2 = 3
+
 ## decl-level-negative-tests -- extend the negative-test gate to module/declaration level (Closes #1123)
 
 - **WHERE**: `bootstrap/src/compiler.rs` (`mod tests_compiler_rejects`: new `assert_decl_dropped` helper + six tests).

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# verify.sh -- single advisory pre-PR umbrella for t27.
+#
+# The repo has accumulated several small, read-only developer checks, each with
+# its own entry point: the NMSE seal-freshness reporter (scripts/reseal-check.sh
+# / `make seal-check`, #1106), the #969 dead-code warning meter
+# (scripts/warnings-baseline.sh / `make warnings-baseline`, #1119), and the test
+# suite. Before opening a PR a contributor wants to glance at all of them at
+# once. This script runs them back-to-back and prints a single compact summary.
+#
+# It is ADVISORY ONLY. It never edits code, never reseals, never blocks: every
+# sub-check's outcome is reported and the umbrella ALWAYS exits 0 so it can be
+# dropped into a pre-push habit without ever failing a push. The actual gate
+# remains the four required CI checks (check-now-freshness / validate / check /
+# check-linked-issue); this is a local convenience, not a substitute.
+#
+# Sub-checks (each best-effort; a missing script is reported as SKIP):
+#   1. seal       -- scripts/reseal-check.sh --quiet  (NMSE seal freshness)
+#   2. warnings   -- scripts/warnings-baseline.sh --quiet  (#969 meter)
+#   3. test       -- a quick cargo test of the compiler reject/accept suite
+#                    (the negative-test gate from variants K/M/Q), unless
+#                    VERIFY_FULL_TEST=1 asks for the whole binary test run.
+#
+# Usage:
+#   scripts/verify.sh            # run all sub-checks, print summary, exit 0
+#   scripts/verify.sh --quiet    # print only the final one-line summary
+#   VERIFY_SKIP_TEST=1 scripts/verify.sh    # skip the (slow) test sub-check
+#   VERIFY_FULL_TEST=1 scripts/verify.sh    # run the full binary test suite
+#
+# Anchor: phi^2 + phi^-2 = 3
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+QUIET=0
+if [ "${1:-}" = "--quiet" ]; then QUIET=1; fi
+log() { if [ "$QUIET" -eq 0 ]; then echo "$@"; fi; }
+
+# Prefer an explicit cargo if present; fall back to PATH.
+CARGO_BIN="cargo"
+if [ -x "$HOME/.cargo/bin/cargo" ]; then CARGO_BIN="$HOME/.cargo/bin/cargo"; fi
+
+# Collected one-line verdicts for the final summary.
+SUMMARY=""
+add_summary() { SUMMARY="${SUMMARY}${SUMMARY:+ | }$1"; }
+
+log "================================================================"
+log " t27 pre-PR verify (advisory umbrella; never blocks)"
+log "================================================================"
+
+# ----------------------------------------------------------------------------
+# 1. NMSE seal freshness (read-only; reseal stays an explicit reviewed step).
+# ----------------------------------------------------------------------------
+if [ -x scripts/reseal-check.sh ]; then
+    SEAL_OUT="$(scripts/reseal-check.sh --quiet 2>/dev/null)"
+    SEAL_CODE=$?
+    case "$SEAL_CODE" in
+        0) SEAL_VERDICT="seal:FRESH" ;;
+        2) SEAL_VERDICT="seal:STALE (advisory; run 'make seal' if intended)" ;;
+        3) SEAL_VERDICT="seal:UNSEALED (advisory)" ;;
+        *) SEAL_VERDICT="seal:UNKNOWN (exit $SEAL_CODE)" ;;
+    esac
+    log " [1/3] seal-check  -> ${SEAL_OUT:-$SEAL_VERDICT}"
+else
+    SEAL_VERDICT="seal:SKIP (script missing)"
+    log " [1/3] seal-check  -> SKIP (scripts/reseal-check.sh not found)"
+fi
+add_summary "$SEAL_VERDICT"
+
+# ----------------------------------------------------------------------------
+# 2. #969 dead-code warning meter (read-only; builds with JSON diagnostics).
+# ----------------------------------------------------------------------------
+if [ -x scripts/warnings-baseline.sh ]; then
+    WARN_OUT="$(scripts/warnings-baseline.sh --quiet 2>/dev/null)"
+    WARN_CODE=$?
+    case "$WARN_CODE" in
+        0) WARN_VERDICT="warnings:OK" ;;
+        1) WARN_VERDICT="warnings:REGRESSED (advisory; above baseline)" ;;
+        2) WARN_VERDICT="warnings:BUILD-FAILED" ;;
+        *) WARN_VERDICT="warnings:UNKNOWN (exit $WARN_CODE)" ;;
+    esac
+    log " [2/3] warnings    -> ${WARN_OUT:-$WARN_VERDICT}"
+else
+    WARN_VERDICT="warnings:SKIP (script missing)"
+    log " [2/3] warnings    -> SKIP (scripts/warnings-baseline.sh not found)"
+fi
+add_summary "$WARN_VERDICT"
+
+# ----------------------------------------------------------------------------
+# 3. Quick test of the negative-test gate (variants K/M/Q) -- the fastest
+#    high-signal correctness check. Opt into the full suite with
+#    VERIFY_FULL_TEST=1, or skip tests entirely with VERIFY_SKIP_TEST=1.
+# ----------------------------------------------------------------------------
+if [ "${VERIFY_SKIP_TEST:-0}" = "1" ]; then
+    TEST_VERDICT="test:SKIP (VERIFY_SKIP_TEST=1)"
+    log " [3/3] test        -> SKIP (VERIFY_SKIP_TEST=1)"
+else
+    if [ "${VERIFY_FULL_TEST:-0}" = "1" ]; then
+        TEST_DESC="full binary test suite"
+        TEST_FILTER=""
+    else
+        TEST_DESC="compiler reject/accept gate"
+        TEST_FILTER="tests_compiler_rejects"
+    fi
+    if "$CARGO_BIN" test --bin t27c $TEST_FILTER >/dev/null 2>&1; then
+        TEST_VERDICT="test:PASS ($TEST_DESC)"
+        log " [3/3] test        -> PASS ($TEST_DESC)"
+    else
+        TEST_VERDICT="test:FAIL ($TEST_DESC) -- advisory, inspect with 'cargo test'"
+        log " [3/3] test        -> FAIL ($TEST_DESC) (advisory; re-run 'cargo test --bin t27c' for detail)"
+    fi
+fi
+add_summary "$TEST_VERDICT"
+
+log "----------------------------------------------------------------"
+log " advisory only: never edits code, never reseals, never gates CI."
+log " required CI checks remain: check-now-freshness / validate /"
+log " check / check-linked-issue."
+log "----------------------------------------------------------------"
+
+# Final compact summary. Always printed (even with --quiet) and we ALWAYS exit 0
+# so the umbrella is safe to wire into a pre-push habit without ever blocking.
+echo "verify: $SUMMARY"
+exit 0


### PR DESCRIPTION
## Variant R -- `make verify`: single advisory pre-PR umbrella

Adds one umbrella command that runs the repo's read-only developer checks
back-to-back and prints a single compact summary.

### What
- `scripts/verify.sh`: runs three best-effort sub-checks --
  1. `scripts/reseal-check.sh --quiet` (NMSE seal freshness, #1106),
  2. `scripts/warnings-baseline.sh --quiet` (#969 meter, #1119),
  3. quick `cargo test --bin t27c tests_compiler_rejects` (K/M/Q gate;
     `VERIFY_FULL_TEST=1` for the whole suite, `VERIFY_SKIP_TEST=1` to skip).
  Prints one `verify: ...` summary line; supports `--quiet`; a missing
  sub-script is reported SKIP, never an error.
- `verify` target in the `Makefile` (+ `make help` entry).

### Why
A memorable pre-PR convenience. Advisory only: never edits code, never reseals,
ALWAYS exits 0 -- safe to wire into a pre-push habit without ever blocking. The
real gate stays the four required CI checks.

### Verification
- `make verify` -> runs all three, single summary, exit 0.
- `scripts/verify.sh --quiet` -> summary line only, exit 0.
- `VERIFY_SKIP_TEST=1` / `VERIFY_FULL_TEST=1` behave as documented.
- `make help` lists the new target.

NOW.md updated.

Closes #1124
