### PR TITLE
compiler: per-enum allow(dead_code) for HIR/FPGA grammar enums (warnings 655->647). Closes #1129

### DIFF
--- a/bootstrap/src/compiler.rs
+++ b/bootstrap/src/compiler.rs
@@ -8096,6 +8096,17 @@ impl RustCodegen {
 // ============================================================================
 
 #[derive(Debug, Clone, PartialEq)]
+// Variant S (#969 dead-code audit, HIR/FPGA grammar layer): the Hardware IR
+// node-kind enums below model the full target HDL/FPGA grammar surface
+// (clock/reset kinds, edge sensitivity, always-block statement kinds, memory
+// kinds, clock-domain-crossing and FIFO strategies). Several variants are not
+// yet constructed by the current lowering passes, so each emits a
+// `never constructed` dead_code warning -- but they are an intentional,
+// spec-complete AST surface kept for the Phase-0 FPGA foundation, not dead
+// code. A targeted per-enum allow documents that without removing any variant
+// or weakening the type; same conservative annotate-not-delete pattern as the
+// #1111 / #1122 host slices. Scoped narrowly to these enums (NOT the file).
+#[allow(dead_code)]
 pub enum HwType {
     Bits(u32),
     UInt(u32),
@@ -8110,12 +8121,14 @@ pub enum HwType {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+#[allow(dead_code)]
 pub enum HwResetKind {
     Async,
     Sync,
 }
 
 #[derive(Debug, Clone, PartialEq)]
+#[allow(dead_code)]
 pub enum HwResetPolarity {
     ActiveHigh,
     ActiveLow,
@@ -8208,6 +8221,7 @@ pub struct HirAssign {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+#[allow(dead_code)]
 pub enum HwEdge {
     Posedge,
     Negedge,
@@ -8223,6 +8237,7 @@ pub struct HirAlwaysBlock {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+#[allow(dead_code)]
 pub enum HirAlwaysStmtKind {
     BlockingAssign,
     NonBlockingAssign,
@@ -8250,6 +8265,7 @@ pub struct HirInstance {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+#[allow(dead_code)]
 pub enum HwMemKind {
     Bram,
     Dram,
@@ -8429,6 +8445,7 @@ impl HirClockDomain {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+#[allow(dead_code)]
 pub enum HwCrossStrategy {
     TwoFlop,
     FifoAsync,
@@ -8444,6 +8461,7 @@ pub struct HirClockCrossing {
 }
 
 #[derive(Debug, Clone, PartialEq)]
+#[allow(dead_code)]
 pub enum HwFifoKind {
     Sync,
     Async,

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,13 @@
 
 Last updated: 2026-06-14
 
+## loop9-s-hir-deadcode-slice -- per-enum allow(dead_code) for HIR/FPGA grammar enums (Closes #1129)
+
+- **WHERE**: bootstrap/src/compiler.rs (HIR/FPGA grammar enums), scripts/warnings-baseline.sh.
+- **WHAT**: added a scoped #[allow(dead_code)] to 8 spec-complete HIR/FPGA grammar enums (HwType, HwResetKind, HwResetPolarity, HwEdge, HirAlwaysStmtKind, HwMemKind, HwCrossStrategy, HwFifoKind) and lowered the warnings baseline 655 -> 647.
+- **Why** a targeted #969 slice: these variants are an intentionally spec-complete AST surface, not accidental dead code; per-enum suppression (not file-level) keeps it reviewable, same pattern as #1111/#1122. L6 gf16 SSOT untouched; catalog stays 83; no gen/ edits; ASCII-only added lines; no quality claim added. Closes #1129.
+- **Anchor**: phi^2 + phi^-2 = 3
+
 ## make-verify-umbrella -- single advisory pre-PR umbrella (make verify) (Closes #1124)
 
 - **WHERE**: new `scripts/verify.sh` and the top-level `Makefile` (new `verify` target + `make help` entry).

--- a/scripts/warnings-baseline.sh
+++ b/scripts/warnings-baseline.sh
@@ -30,11 +30,11 @@ set -uo pipefail
 # (in the same PR) whenever a reviewed slice legitimately lowers it, so the
 # meter keeps tracking real progress. Measured precisely from the structured
 # JSON diagnostics on master. History: 683 after the host/mod.rs facade slice
-# (#1111); 655 after the host/errors.rs catalog slice (variant P, issue #1122)
-# annotated its 28 dead_code symbols. (Earlier NOW.md entries quoted ~685/726
-# from the cargo summary line, which rounds differently; this script's
-# primary-span count is the canonical meter.)
-BASELINE=655
+# (#1111); 655 after the host/errors.rs catalog slice (variant P, issue #1122);
+# 647 after the HIR/FPGA grammar-enum slice (variant S). (Earlier NOW.md entries
+# quoted ~685/726 from the cargo summary line, which rounds differently; this
+# script's primary-span count is the canonical meter.)
+BASELINE=647
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"


### PR DESCRIPTION
## Summary

Targeted dead-code slice (part of the #969 warnings-baseline effort): annotate the
spec-complete HIR/FPGA grammar enums in `bootstrap/src/compiler.rs` with a per-enum
`#[allow(dead_code)]` so the build stops emitting "variants never constructed" warnings
for an intentionally-broad AST surface, and lower the recorded warnings baseline 655 -> 647.

## Motivation

The "Hardware IR (HIR) -- Phase 0 FPGA foundation" section defines a deliberately
spec-complete set of grammar enums. Several of their variants are not yet constructed by
the current lowering path, which is expected at this phase -- the AST surface is intentionally
wider than today's consumers. These show up as 8 `dead_code` warnings that are pure noise:
they do not indicate a bug, and the variants are part of the documented spec, not accidental.

This is the same conservative, per-item pattern used in #1111 and #1122: we annotate the
specific enums (NOT the whole file, NOT a crate-level allow), with a comment explaining the
intent, so the suppression stays scoped and reviewable.

## Scope (exactly 8 enums, HIR/FPGA section)

`HwType`, `HwResetKind`, `HwResetPolarity`, `HwEdge`, `HirAlwaysStmtKind`, `HwMemKind`,
`HwCrossStrategy`, `HwFifoKind`.

Each gets a `#[allow(dead_code)]` between its `#[derive(...)]` and `pub enum` (valid Rust;
keeps the diff minimal). The first enum is preceded by a short comment block explaining this
is an intentionally spec-complete AST surface, annotated per-enum rather than file-level.

## Effect

- Build warnings: 655 -> 647 (8 `variants never constructed` warnings removed).
- `scripts/warnings-baseline.sh` baseline updated 655 -> 647 with a history note.
- No behavior change: `#[allow(dead_code)]` only suppresses the lint; no code is added,
  removed, or rewired. Full test suite unaffected.

## Verification

- `cargo build --bin t27c` -> 647 warnings (was 655).
- `make warnings-baseline` -> OK (647 <= 647).
- Full suite green, 0 regressions.

L6 gf16 SSOT untouched; catalog stays 83; no gen/ edits; ASCII-only added lines; no quality
claim added.
