### PR TITLE
verify.sh: add [4/4] gate-preview (NOW-sync + ASCII) advisory sub-check. Closes #1131

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,9 @@ help:
 	@echo "  make warnings-baseline  Count non-test build warnings vs the recorded"
 	@echo "                      baseline and list the top files (advisory; #969)."
 	@echo "  make verify         Run all advisory pre-PR checks at once (seal-check"
-	@echo "                      + warnings-baseline + quick test); never blocks."
+	@echo "                      + warnings-baseline + quick test + gate-preview);"
+	@echo "                      never blocks. VERIFY_SKIP_GATES=1 skips the"
+	@echo "                      gate-preview; VERIFY_SKIP_TEST=1 skips the test."
 
 # Advisory umbrella: run the seal-freshness, warnings-baseline, and a quick test
 # back-to-back and print one compact summary. Never edits code, never reseals,

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,13 @@
 
 Last updated: 2026-06-14
 
+## loop9-u-gate-preview -- verify.sh [4/4] gate-preview advisory sub-check (Closes #1131)
+
+- **WHERE**: scripts/verify.sh (new [4/4] sub-check), Makefile (make help text).
+- **WHAT**: extended the advisory verify umbrella (#1124) with a 4th sub-check that locally previews the cheap parts of two required CI gates -- NOW Sync (docs/NOW.md present in diff + Last-updated date today/yesterday UTC) and L3 PURITY (added lines ASCII-only); renumbered [1/3..3/3] -> [1/4..4/4].
+- **Why** turn a push-wait-red-fix-repush loop into a one-line local glance; always exits 0, never edits code, never reseals, never blocks; the four required CI checks stay the real gate. Skips outside a git tree / with no base ref; VERIFY_SKIP_GATES=1 disables just this sub-check. L6 gf16 SSOT untouched; catalog stays 83; no gen/ edits; ASCII-only added lines; no quality claim added. Closes #1131.
+- **Anchor**: phi^2 + phi^-2 = 3
+
 ## loop9-t-decl-positive-tests -- positive-control tests for the declaration parser (Closes #1130)
 
 - **WHERE**: bootstrap/src/compiler.rs, mod tests_compiler_rejects (test-only additions).

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -64,10 +64,10 @@ if [ -x scripts/reseal-check.sh ]; then
         3) SEAL_VERDICT="seal:UNSEALED (advisory)" ;;
         *) SEAL_VERDICT="seal:UNKNOWN (exit $SEAL_CODE)" ;;
     esac
-    log " [1/3] seal-check  -> ${SEAL_OUT:-$SEAL_VERDICT}"
+    log " [1/4] seal-check  -> ${SEAL_OUT:-$SEAL_VERDICT}"
 else
     SEAL_VERDICT="seal:SKIP (script missing)"
-    log " [1/3] seal-check  -> SKIP (scripts/reseal-check.sh not found)"
+    log " [1/4] seal-check  -> SKIP (scripts/reseal-check.sh not found)"
 fi
 add_summary "$SEAL_VERDICT"
 
@@ -83,10 +83,10 @@ if [ -x scripts/warnings-baseline.sh ]; then
         2) WARN_VERDICT="warnings:BUILD-FAILED" ;;
         *) WARN_VERDICT="warnings:UNKNOWN (exit $WARN_CODE)" ;;
     esac
-    log " [2/3] warnings    -> ${WARN_OUT:-$WARN_VERDICT}"
+    log " [2/4] warnings    -> ${WARN_OUT:-$WARN_VERDICT}"
 else
     WARN_VERDICT="warnings:SKIP (script missing)"
-    log " [2/3] warnings    -> SKIP (scripts/warnings-baseline.sh not found)"
+    log " [2/4] warnings    -> SKIP (scripts/warnings-baseline.sh not found)"
 fi
 add_summary "$WARN_VERDICT"
 
@@ -97,7 +97,7 @@ add_summary "$WARN_VERDICT"
 # ----------------------------------------------------------------------------
 if [ "${VERIFY_SKIP_TEST:-0}" = "1" ]; then
     TEST_VERDICT="test:SKIP (VERIFY_SKIP_TEST=1)"
-    log " [3/3] test        -> SKIP (VERIFY_SKIP_TEST=1)"
+    log " [3/4] test        -> SKIP (VERIFY_SKIP_TEST=1)"
 else
     if [ "${VERIFY_FULL_TEST:-0}" = "1" ]; then
         TEST_DESC="full binary test suite"
@@ -108,13 +108,85 @@ else
     fi
     if "$CARGO_BIN" test --bin t27c $TEST_FILTER >/dev/null 2>&1; then
         TEST_VERDICT="test:PASS ($TEST_DESC)"
-        log " [3/3] test        -> PASS ($TEST_DESC)"
+        log " [3/4] test        -> PASS ($TEST_DESC)"
     else
         TEST_VERDICT="test:FAIL ($TEST_DESC) -- advisory, inspect with 'cargo test'"
-        log " [3/3] test        -> FAIL ($TEST_DESC) (advisory; re-run 'cargo test --bin t27c' for detail)"
+        log " [3/4] test        -> FAIL ($TEST_DESC) (advisory; re-run 'cargo test --bin t27c' for detail)"
     fi
 fi
 add_summary "$TEST_VERDICT"
+
+# ----------------------------------------------------------------------------
+# 4. Pre-PR gate preview (variant U). Locally reproduce the cheap parts of two
+#    required CI gates so the author sees a likely failure BEFORE pushing:
+#      - NOW Sync Gate: docs/NOW.md must appear in the diff vs master, and its
+#        `Last updated:` date must be today or yesterday (UTC).
+#      - L3 PURITY: added lines in the diff vs master must be ASCII-only.
+#    This is a best-effort PREVIEW, not the gate itself: it diffs against the
+#    local `origin/master` (or `master`) ref, so it is only as fresh as the
+#    last fetch, and it never blocks. Skipped automatically outside a git work
+#    tree or when no base ref is found. Disable with VERIFY_SKIP_GATES=1.
+# ----------------------------------------------------------------------------
+if [ "${VERIFY_SKIP_GATES:-0}" = "1" ]; then
+    GATES_VERDICT="gates:SKIP (VERIFY_SKIP_GATES=1)"
+    log " [4/4] gate-preview-> SKIP (VERIFY_SKIP_GATES=1)"
+elif ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    GATES_VERDICT="gates:SKIP (not a git work tree)"
+    log " [4/4] gate-preview-> SKIP (not a git work tree)"
+else
+    # Pick a base ref to diff against: prefer origin/master, fall back to master.
+    BASE_REF=""
+    if git rev-parse --verify -q origin/master >/dev/null 2>&1; then
+        BASE_REF="origin/master"
+    elif git rev-parse --verify -q master >/dev/null 2>&1; then
+        BASE_REF="master"
+    fi
+    if [ -z "$BASE_REF" ]; then
+        GATES_VERDICT="gates:SKIP (no master base ref; fetch first)"
+        log " [4/4] gate-preview-> SKIP (no origin/master or master ref found)"
+    else
+        GATE_ISSUES=""
+        # (a) NOW.md present in the diff vs base.
+        if git diff --name-only "$BASE_REF"...HEAD 2>/dev/null | grep -qx 'docs/NOW.md'; then
+            NOW_IN_DIFF="now-in-diff:yes"
+        else
+            NOW_IN_DIFF="now-in-diff:NO"
+            GATE_ISSUES="${GATE_ISSUES} NOW.md-not-in-diff"
+        fi
+        # (b) NOW.md `Last updated:` date is today or yesterday (UTC).
+        TODAY="$(date -u +%Y-%m-%d)"
+        YESTERDAY="$(date -u -d yesterday +%Y-%m-%d 2>/dev/null || true)"
+        LAST="$(grep -m1 'Last updated:' docs/NOW.md 2>/dev/null | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | head -1 || true)"
+        if [ "$LAST" = "$TODAY" ] || { [ -n "$YESTERDAY" ] && [ "$LAST" = "$YESTERDAY" ]; }; then
+            NOW_DATE="now-date:fresh ($LAST)"
+        else
+            NOW_DATE="now-date:STALE ($LAST)"
+            GATE_ISSUES="${GATE_ISSUES} NOW.md-date-stale"
+        fi
+        # (c) Added lines in the diff vs base are ASCII-only (L3 PURITY preview).
+        NONASCII="$(git diff "$BASE_REF"...HEAD 2>/dev/null | grep -n '^+' | grep -P '[^\x00-\x7F]' | head -5 || true)"
+        if [ -z "$NONASCII" ]; then
+            ASCII="ascii:clean"
+        else
+            ASCII="ascii:NON-ASCII-in-added-lines"
+            GATE_ISSUES="${GATE_ISSUES} non-ascii-added-lines"
+        fi
+        if [ -z "$GATE_ISSUES" ]; then
+            GATES_VERDICT="gates:OK ($NOW_IN_DIFF, $NOW_DATE, $ASCII)"
+            log " [4/4] gate-preview-> OK ($NOW_IN_DIFF | $NOW_DATE | $ASCII) [base $BASE_REF]"
+        else
+            GATES_VERDICT="gates:WARN ($NOW_IN_DIFF, $NOW_DATE, $ASCII) -- advisory"
+            log " [4/4] gate-preview-> WARN [base $BASE_REF]:"
+            log "        $NOW_IN_DIFF | $NOW_DATE | $ASCII"
+            log "        likely CI-gate issue(s):$GATE_ISSUES (advisory; fix before push)"
+            if [ -n "$NONASCII" ]; then
+                log "        first non-ASCII added line(s):"
+                printf '%s\n' "$NONASCII" | while IFS= read -r ln; do log "          $ln"; done
+            fi
+        fi
+    fi
+fi
+add_summary "$GATES_VERDICT"
 
 log "----------------------------------------------------------------"
 log " advisory only: never edits code, never reseals, never gates CI."


### PR DESCRIPTION
## Summary

Extend the advisory `scripts/verify.sh` umbrella (added in #1124 / variant R) with a 4th
sub-check, `[4/4] gate-preview`, that locally reproduces the *cheap* parts of two required
CI gates so the author sees a likely failure BEFORE pushing. Update the `make help` text to
match. Advisory only -- always exits 0, never edits code, never reseals, never blocks.

## Motivation

R's `verify.sh` covers seal-freshness, warnings-baseline, and a quick test, but it does not
preview the two gates that most often surprise authors on first push:

- **NOW Sync Gate** (`check-now-freshness`): `docs/NOW.md` must appear in the PR diff, and
  its `Last updated:` date must be today or yesterday (UTC).
- **L3 PURITY** (`l1-traceability`): added lines in the diff must be ASCII-only.

Reproducing the inexpensive parts of these locally turns a "push, wait ~85s, see red, fix,
re-push" loop into a one-line local glance.

## What `[4/4] gate-preview` checks

Against the local base ref (`origin/master`, falling back to `master`):

- (a) `docs/NOW.md` is present in the diff vs base.
- (b) NOW.md `Last updated:` date is today or yesterday (UTC).
- (c) added lines in the diff vs base are ASCII-only.

It prints `OK` / `WARN` with the specific issue(s) and the first offending non-ASCII line(s).

## Guarantees (consistent with R)

- **Always exits 0.** It is a preview, not the gate; the four required CI checks remain the
  real gate.
- Best-effort: only as fresh as the last `git fetch`; it diffs the local base ref.
- Skips automatically outside a git work tree or when no base ref is found.
- `VERIFY_SKIP_GATES=1` disables just this sub-check; `VERIFY_SKIP_TEST=1` still skips the
  test sub-check.

## Files

- `scripts/verify.sh`: add `[4/4] gate-preview`, renumber `[1/3..3/3]` -> `[1/4..4/4]`.
- `Makefile`: update `make help` to mention gate-preview and the two skip flags.

## Verification

- `bash -n scripts/verify.sh` clean; `make verify` runs all 4 sub-checks and exits 0.
- `VERIFY_SKIP_GATES=1` correctly skips `[4/4]`.
- On a clean tree it correctly WARNs (NOW.md not in diff) without blocking.

L6 gf16 SSOT untouched; catalog stays 83; no gen/ edits; ASCII-only added lines; no quality
claim added.
