### PR TITLE
host/dma.rs + host/protocol.rs: module-scoped allow(dead_code) (647->623, #969 slice). Closes #1135

### DIFF
--- a/bootstrap/src/host/dma.rs
+++ b/bootstrap/src/host/dma.rs
@@ -1,3 +1,17 @@
+// Variant V (#969 dead-code audit, host/dma.rs layer). This module is a
+// self-contained, intentional public API: a DMA-channel model (DmaError,
+// DmaState, DmaConfig, DmaReport, DmaChannel and its transfer/reset path, plus
+// the internal CRC32 helpers). It is fully exercised by this module's own test
+// suite (idle/busy state, length and checksum validation, copy/partial-copy,
+// cycle estimate, reset, builder) but is not yet wired into production host
+// code, so every symbol emits a `dead_code` warning (12 in total) in the
+// non-test build. These are deliberate public surface, not dead code -- a
+// single module-scoped allow documents that without removing or weakening any
+// symbol. Scoped to `not(test)` so the test build still flags genuinely unused
+// items, exactly as in the #1105 / #1111 / #1129 slices of this audit (same
+// pattern as the host/errors.rs slice in #1125).
+#![cfg_attr(not(test), allow(dead_code))]
+
 use super::csr_map;
 use super::mmio::Mmio;
 

--- a/bootstrap/src/host/protocol.rs
+++ b/bootstrap/src/host/protocol.rs
@@ -1,3 +1,18 @@
+// Variant V (#969 dead-code audit, host/protocol.rs layer). This module is a
+// self-contained, intentional public API: the host/device wire protocol (Cmd
+// and RespCode enums with from_u8/has_payload/expects_response/is_ok, the
+// CMD_HEADER_SIZE / RESP_HEADER_SIZE / PROTOCOL_VERSION constants, CmdPacket and
+// RespPacket with their encode/decode/builder methods, and ProtocolError). It
+// is fully exercised by this module's own test suite (opcode round-trip,
+// header sizing, packet encode/decode, error paths) but is not yet wired into
+// production host code, so every symbol emits a `dead_code` warning (12 in
+// total) in the non-test build. These are deliberate public surface, not dead
+// code -- a single module-scoped allow documents that without removing or
+// weakening any symbol. Scoped to `not(test)` so the test build still flags
+// genuinely unused items, exactly as in the #1105 / #1111 / #1129 slices of
+// this audit (same pattern as the host/errors.rs slice in #1125).
+#![cfg_attr(not(test), allow(dead_code))]
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum Cmd {

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,13 @@
 
 Last updated: 2026-06-14
 
+## host-dma-protocol-deadcode -- module-scoped allow(dead_code) on host/dma.rs + host/protocol.rs (Closes #1135)
+
+- **WHERE**: bootstrap/src/host/dma.rs, bootstrap/src/host/protocol.rs, scripts/warnings-baseline.sh
+- **WHAT**: Prepended one documented `#![cfg_attr(not(test), allow(dead_code))]` inner attribute to each host module (continuation of the #969 dead-code slice), removing 24 dead_code warnings total; lowered BASELINE 647 -> 623.
+- **Why**: continues the host-module slice started in #1125 (host/errors.rs); `not(test)` scoping keeps genuine unused symbols flagged in test builds; both modules have `#[cfg(test)] mod tests` exercising every symbol. L6 gf16 SSOT untouched; catalog stays 83; no gen/ edits; ASCII-only added lines; no quality claim added. Closes #1135.
+- **Anchor**: phi^2 + phi^-2 = 3
+
 ## loop9-u-gate-preview -- verify.sh [4/4] gate-preview advisory sub-check (Closes #1131)
 
 - **WHERE**: scripts/verify.sh (new [4/4] sub-check), Makefile (make help text).

--- a/scripts/warnings-baseline.sh
+++ b/scripts/warnings-baseline.sh
@@ -31,10 +31,11 @@ set -uo pipefail
 # meter keeps tracking real progress. Measured precisely from the structured
 # JSON diagnostics on master. History: 683 after the host/mod.rs facade slice
 # (#1111); 655 after the host/errors.rs catalog slice (variant P, issue #1122);
-# 647 after the HIR/FPGA grammar-enum slice (variant S). (Earlier NOW.md entries
+# 647 after the HIR/FPGA grammar-enum slice (variant S); 623 after the
+# host/dma.rs + host/protocol.rs slice (variant V). (Earlier NOW.md entries
 # quoted ~685/726 from the cargo summary line, which rounds differently; this
 # script's primary-span count is the canonical meter.)
-BASELINE=647
+BASELINE=623
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"


### PR DESCRIPTION
## Summary

Next slice of the #969 dead-code audit: annotate the spec-complete host-driver modules
`bootstrap/src/host/dma.rs` and `bootstrap/src/host/protocol.rs` with a single module-scoped
`#![cfg_attr(not(test), allow(dead_code))]` each, and lower the recorded warnings baseline
647 -> 623.

## Motivation

Both modules are self-contained, intentional public API surfaces that are fully exercised by
their own `#[cfg(test)]` test suites but are not yet wired into production host code:

- `dma.rs` -- a DMA-channel model (`DmaError`, `DmaState`, `DmaConfig`, `DmaReport`,
  `DmaChannel` and its transfer/reset path, plus internal CRC32 helpers). 20 tests.
- `protocol.rs` -- the host/device wire protocol (`Cmd`, `RespCode`, the header-size and
  `PROTOCOL_VERSION` constants, `CmdPacket` / `RespPacket` with encode/decode/builders,
  `ProtocolError`). 16 tests.

Because the symbols are used only from tests, the non-test build emits 12 `dead_code`
warnings per file (24 total). These are deliberate surface, not accidental dead code.

## Approach (same as #1125 host/errors.rs slice)

Each file gets one documented module-scoped inner attribute scoped to `not(test)`:

```rust
#![cfg_attr(not(test), allow(dead_code))]
```

Scoping to `not(test)` is deliberate: the test build still flags genuinely unused items, so
the suppression cannot hide a real regression. This mirrors the #1105 / #1111 / #1129 slices
and the exact pattern already used for `host/errors.rs` in #1125. No symbol is removed,
renamed, or weakened; only the lint is suppressed in the non-test build.

## Effect

- Build warnings: 647 -> 623 (24 `dead_code` warnings removed: 12 from each file).
- `scripts/warnings-baseline.sh` baseline updated 647 -> 623 with a history note.
- No behavior change; all 36 module tests still pass.

## Verification

- `cargo build --bin t27c` -> 623 warnings (was 647).
- `make warnings-baseline` -> OK (623 <= 623).
- Full suite green (1463 passed), 0 regressions; dma/protocol tests unaffected.

L6 gf16 SSOT untouched; catalog stays 83; no gen/ edits; ASCII-only added lines; no quality
claim added.
