### PR TITLE
verify.sh: add [5/5] reseal-prev advisory sub-check (seal-state vs PR diff). Closes #1136

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,10 @@ help:
 	@echo "  make warnings-baseline  Count non-test build warnings vs the recorded"
 	@echo "                      baseline and list the top files (advisory; #969)."
 	@echo "  make verify         Run all advisory pre-PR checks at once (seal-check"
-	@echo "                      + warnings-baseline + quick test + gate-preview);"
-	@echo "                      never blocks. VERIFY_SKIP_GATES=1 skips the"
-	@echo "                      gate-preview; VERIFY_SKIP_TEST=1 skips the test."
+	@echo "                      + warnings-baseline + quick test + gate-preview"
+	@echo "                      + reseal-preview); never blocks. Skip flags:"
+	@echo "                      VERIFY_SKIP_TEST / VERIFY_SKIP_GATES /"
+	@echo "                      VERIFY_SKIP_RESEAL =1."
 
 # Advisory umbrella: run the seal-freshness, warnings-baseline, and a quick test
 # back-to-back and print one compact summary. Never edits code, never reseals,

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,13 @@
 
 Last updated: 2026-06-14
 
+## verify-reseal-prev -- add [5/5] reseal-prev advisory sub-check to verify.sh (Closes #1136)
+
+- **WHERE**: scripts/verify.sh, Makefile
+- **WHAT**: Extended `make verify` from 4 to 5 advisory sub-checks; renumbered [1/4..4/4] -> [1/5..4/5] and added [5/5] reseal-prev, which reuses the [1/5] seal verdict and diffs the base ref for bootstrap/src/compiler.rs: OK if compiler.rs not in diff or seal fresh, REMINDER (exit 0) if compiler.rs changed while seal stale/unsealed. VERIFY_SKIP_RESEAL=1 disables it.
+- **Why**: gives a local heads-up to re-seal IF a compiler.rs edit was numeric, without judging whether the edit is numeric and without ever resealing or gating CI; advisory only, exit 0. L6 gf16 SSOT untouched; catalog stays 83; no gen/ edits; ASCII-only added lines; no quality claim added. Closes #1136.
+- **Anchor**: phi^2 + phi^-2 = 3
+
 ## host-dma-protocol-deadcode -- module-scoped allow(dead_code) on host/dma.rs + host/protocol.rs (Closes #1135)
 
 - **WHERE**: bootstrap/src/host/dma.rs, bootstrap/src/host/protocol.rs, scripts/warnings-baseline.sh

--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -16,17 +16,23 @@
 # check-linked-issue); this is a local convenience, not a substitute.
 #
 # Sub-checks (each best-effort; a missing script is reported as SKIP):
-#   1. seal       -- scripts/reseal-check.sh --quiet  (NMSE seal freshness)
-#   2. warnings   -- scripts/warnings-baseline.sh --quiet  (#969 meter)
-#   3. test       -- a quick cargo test of the compiler reject/accept suite
-#                    (the negative-test gate from variants K/M/Q), unless
-#                    VERIFY_FULL_TEST=1 asks for the whole binary test run.
+#   1. seal         -- scripts/reseal-check.sh --quiet  (NMSE seal freshness)
+#   2. warnings     -- scripts/warnings-baseline.sh --quiet  (#969 meter)
+#   3. test         -- a quick cargo test of the compiler reject/accept suite
+#                      (the negative-test gate from variants K/M/Q), unless
+#                      VERIFY_FULL_TEST=1 asks for the whole binary test run.
+#   4. gate-preview -- local preview of the NOW-sync + L3 PURITY CI gates
+#                      against the base ref (variant U).
+#   5. reseal-prev  -- ties the seal state to the current PR diff: warns only if
+#                      this PR edits the sealed compiler.rs (variant W).
 #
 # Usage:
 #   scripts/verify.sh            # run all sub-checks, print summary, exit 0
 #   scripts/verify.sh --quiet    # print only the final one-line summary
 #   VERIFY_SKIP_TEST=1 scripts/verify.sh    # skip the (slow) test sub-check
 #   VERIFY_FULL_TEST=1 scripts/verify.sh    # run the full binary test suite
+#   VERIFY_SKIP_GATES=1 scripts/verify.sh   # skip the gate-preview sub-check
+#   VERIFY_SKIP_RESEAL=1 scripts/verify.sh  # skip the reseal-preview sub-check
 #
 # Anchor: phi^2 + phi^-2 = 3
 
@@ -64,10 +70,10 @@ if [ -x scripts/reseal-check.sh ]; then
         3) SEAL_VERDICT="seal:UNSEALED (advisory)" ;;
         *) SEAL_VERDICT="seal:UNKNOWN (exit $SEAL_CODE)" ;;
     esac
-    log " [1/4] seal-check  -> ${SEAL_OUT:-$SEAL_VERDICT}"
+    log " [1/5] seal-check  -> ${SEAL_OUT:-$SEAL_VERDICT}"
 else
     SEAL_VERDICT="seal:SKIP (script missing)"
-    log " [1/4] seal-check  -> SKIP (scripts/reseal-check.sh not found)"
+    log " [1/5] seal-check  -> SKIP (scripts/reseal-check.sh not found)"
 fi
 add_summary "$SEAL_VERDICT"
 
@@ -83,10 +89,10 @@ if [ -x scripts/warnings-baseline.sh ]; then
         2) WARN_VERDICT="warnings:BUILD-FAILED" ;;
         *) WARN_VERDICT="warnings:UNKNOWN (exit $WARN_CODE)" ;;
     esac
-    log " [2/4] warnings    -> ${WARN_OUT:-$WARN_VERDICT}"
+    log " [2/5] warnings    -> ${WARN_OUT:-$WARN_VERDICT}"
 else
     WARN_VERDICT="warnings:SKIP (script missing)"
-    log " [2/4] warnings    -> SKIP (scripts/warnings-baseline.sh not found)"
+    log " [2/5] warnings    -> SKIP (scripts/warnings-baseline.sh not found)"
 fi
 add_summary "$WARN_VERDICT"
 
@@ -97,7 +103,7 @@ add_summary "$WARN_VERDICT"
 # ----------------------------------------------------------------------------
 if [ "${VERIFY_SKIP_TEST:-0}" = "1" ]; then
     TEST_VERDICT="test:SKIP (VERIFY_SKIP_TEST=1)"
-    log " [3/4] test        -> SKIP (VERIFY_SKIP_TEST=1)"
+    log " [3/5] test        -> SKIP (VERIFY_SKIP_TEST=1)"
 else
     if [ "${VERIFY_FULL_TEST:-0}" = "1" ]; then
         TEST_DESC="full binary test suite"
@@ -108,10 +114,10 @@ else
     fi
     if "$CARGO_BIN" test --bin t27c $TEST_FILTER >/dev/null 2>&1; then
         TEST_VERDICT="test:PASS ($TEST_DESC)"
-        log " [3/4] test        -> PASS ($TEST_DESC)"
+        log " [3/5] test        -> PASS ($TEST_DESC)"
     else
         TEST_VERDICT="test:FAIL ($TEST_DESC) -- advisory, inspect with 'cargo test'"
-        log " [3/4] test        -> FAIL ($TEST_DESC) (advisory; re-run 'cargo test --bin t27c' for detail)"
+        log " [3/5] test        -> FAIL ($TEST_DESC) (advisory; re-run 'cargo test --bin t27c' for detail)"
     fi
 fi
 add_summary "$TEST_VERDICT"
@@ -129,10 +135,10 @@ add_summary "$TEST_VERDICT"
 # ----------------------------------------------------------------------------
 if [ "${VERIFY_SKIP_GATES:-0}" = "1" ]; then
     GATES_VERDICT="gates:SKIP (VERIFY_SKIP_GATES=1)"
-    log " [4/4] gate-preview-> SKIP (VERIFY_SKIP_GATES=1)"
+    log " [4/5] gate-preview-> SKIP (VERIFY_SKIP_GATES=1)"
 elif ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     GATES_VERDICT="gates:SKIP (not a git work tree)"
-    log " [4/4] gate-preview-> SKIP (not a git work tree)"
+    log " [4/5] gate-preview-> SKIP (not a git work tree)"
 else
     # Pick a base ref to diff against: prefer origin/master, fall back to master.
     BASE_REF=""
@@ -143,7 +149,7 @@ else
     fi
     if [ -z "$BASE_REF" ]; then
         GATES_VERDICT="gates:SKIP (no master base ref; fetch first)"
-        log " [4/4] gate-preview-> SKIP (no origin/master or master ref found)"
+        log " [4/5] gate-preview-> SKIP (no origin/master or master ref found)"
     else
         GATE_ISSUES=""
         # (a) NOW.md present in the diff vs base.
@@ -173,10 +179,10 @@ else
         fi
         if [ -z "$GATE_ISSUES" ]; then
             GATES_VERDICT="gates:OK ($NOW_IN_DIFF, $NOW_DATE, $ASCII)"
-            log " [4/4] gate-preview-> OK ($NOW_IN_DIFF | $NOW_DATE | $ASCII) [base $BASE_REF]"
+            log " [4/5] gate-preview-> OK ($NOW_IN_DIFF | $NOW_DATE | $ASCII) [base $BASE_REF]"
         else
             GATES_VERDICT="gates:WARN ($NOW_IN_DIFF, $NOW_DATE, $ASCII) -- advisory"
-            log " [4/4] gate-preview-> WARN [base $BASE_REF]:"
+            log " [4/5] gate-preview-> WARN [base $BASE_REF]:"
             log "        $NOW_IN_DIFF | $NOW_DATE | $ASCII"
             log "        likely CI-gate issue(s):$GATE_ISSUES (advisory; fix before push)"
             if [ -n "$NONASCII" ]; then
@@ -187,6 +193,73 @@ else
     fi
 fi
 add_summary "$GATES_VERDICT"
+
+# ----------------------------------------------------------------------------
+# 5. Reseal preview (variant W). The NMSE certification is sealed against
+#    sha256(bootstrap/src/compiler.rs) (see scripts/reseal-check.sh). Sub-check
+#    [1/5] reports the ABSOLUTE seal state; this one ties that state to the
+#    CURRENT PR DIFF and answers the only question a contributor actually has:
+#    "does THIS change need a reseal?"
+#      - diff does NOT touch compiler.rs  -> seal state is irrelevant to this PR
+#        (any pre-existing staleness is unrelated); report OK.
+#      - diff DOES touch compiler.rs AND seal is stale/unsealed -> remind that a
+#        reseal MAY be needed IF the edit changed numerics; a non-numeric edit
+#        (an allow(), a comment, a test) legitimately leaves the seal as-is.
+#        This is a REMINDER, never a verdict on whether the edit is numeric.
+#    Best-effort and advisory: reuses [1/5]'s seal exit code, diffs the local
+#    base ref, never reseals, never blocks. Skipped outside a git work tree, with
+#    no base ref, or with VERIFY_SKIP_RESEAL=1.
+# ----------------------------------------------------------------------------
+SEALED_SRC="bootstrap/src/compiler.rs"
+if [ "${VERIFY_SKIP_RESEAL:-0}" = "1" ]; then
+    RESEAL_VERDICT="reseal:SKIP (VERIFY_SKIP_RESEAL=1)"
+    log " [5/5] reseal-prev -> SKIP (VERIFY_SKIP_RESEAL=1)"
+elif ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    RESEAL_VERDICT="reseal:SKIP (not a git work tree)"
+    log " [5/5] reseal-prev -> SKIP (not a git work tree)"
+else
+    # Reuse the same base ref discovery as [4/5].
+    RBASE=""
+    if git rev-parse --verify -q origin/master >/dev/null 2>&1; then
+        RBASE="origin/master"
+    elif git rev-parse --verify -q master >/dev/null 2>&1; then
+        RBASE="master"
+    fi
+    if [ -z "$RBASE" ]; then
+        RESEAL_VERDICT="reseal:SKIP (no master base ref; fetch first)"
+        log " [5/5] reseal-prev -> SKIP (no origin/master or master ref found)"
+    else
+        if git diff --name-only "$RBASE"...HEAD 2>/dev/null | grep -qx "$SEALED_SRC"; then
+            SRC_TOUCHED=1
+        else
+            SRC_TOUCHED=0
+        fi
+        # Map [1/5]'s verdict into a coarse seal state without re-running it.
+        case "$SEAL_VERDICT" in
+            seal:FRESH*)    SEAL_STATE="fresh" ;;
+            seal:STALE*)    SEAL_STATE="stale" ;;
+            seal:UNSEALED*) SEAL_STATE="unsealed" ;;
+            *)              SEAL_STATE="unknown" ;;
+        esac
+        if [ "$SRC_TOUCHED" -eq 0 ]; then
+            RESEAL_VERDICT="reseal:OK (compiler.rs not in diff; seal state irrelevant to this PR)"
+            log " [5/5] reseal-prev -> OK (compiler.rs not in diff; seal state irrelevant) [base $RBASE]"
+        elif [ "$SEAL_STATE" = "fresh" ]; then
+            RESEAL_VERDICT="reseal:OK (compiler.rs in diff; seal fresh)"
+            log " [5/5] reseal-prev -> OK (compiler.rs in diff; seal fresh) [base $RBASE]"
+        else
+            RESEAL_VERDICT="reseal:REMINDER (compiler.rs in diff; seal $SEAL_STATE) -- advisory"
+            log " [5/5] reseal-prev -> REMINDER [base $RBASE]:"
+            log "        this PR edits $SEALED_SRC and the seal is $SEAL_STATE."
+            log "        IF your edit changed numerics, reseal explicitly:"
+            log "          make seal   (or: python repro/numerics/nmse_gf16.py --seal)"
+            log "        IF it did NOT (an allow(), a comment, a test), the existing"
+            log "        seal state is fine and no reseal is needed. This is a"
+            log "        reminder only -- it does NOT judge whether your edit is numeric."
+        fi
+    fi
+fi
+add_summary "$RESEAL_VERDICT"
 
 log "----------------------------------------------------------------"
 log " advisory only: never edits code, never reseals, never gates CI."


### PR DESCRIPTION
## Summary

Extend the advisory `scripts/verify.sh` umbrella (#1124 / #1127, then #1134) with a 5th
sub-check, `[5/5] reseal-prev`, that ties the NMSE seal state to the CURRENT PR DIFF, and
update the `make help` text. Advisory only -- always exits 0, never reseals, never blocks.

## Motivation

Sub-check `[1/5]` already reports the ABSOLUTE seal state (fresh / stale / unsealed), but on
its own that is noisy: the seal is frequently stale on master for reasons unrelated to a
given PR, so a contributor cannot tell whether THEIR change needs a reseal. The only question
that actually matters before a push is: "does this PR touch the sealed compiler, and if so,
is the seal current?"

`[5/5]` answers exactly that by combining `[1/5]`'s seal verdict with a diff of the PR:

- diff does NOT touch `bootstrap/src/compiler.rs` -> seal state is irrelevant to this PR; any
  pre-existing staleness is unrelated. Reports `OK`.
- diff DOES touch `compiler.rs` AND the seal is fresh -> `OK`.
- diff DOES touch `compiler.rs` AND the seal is stale/unsealed -> prints a `REMINDER`: IF the
  edit changed numerics, reseal explicitly (`make seal`); IF it did not (an `allow()`, a
  comment, a test), the existing seal state is fine. It is explicitly a reminder, NOT a
  verdict on whether the edit is numeric -- the script never inspects semantics.

## Guarantees (consistent with #1127 / #1134)

- **Always exits 0.** It is a preview/reminder, not a gate; the four required CI checks
  remain the real gate.
- Best-effort: reuses `[1/5]`'s seal exit code and diffs the local base ref
  (`origin/master`, falling back to `master`); only as fresh as the last `git fetch`.
- Skips automatically outside a git work tree or when no base ref is found.
- `VERIFY_SKIP_RESEAL=1` disables just this sub-check; the other skip flags
  (`VERIFY_SKIP_TEST`, `VERIFY_SKIP_GATES`) are unchanged.

## Files

- `scripts/verify.sh`: add `[5/5] reseal-prev`, renumber `[1/4..4/4]` -> `[1/5..4/5]`, refresh
  the header sub-check list and usage block.
- `Makefile`: update `make help` to mention reseal-preview and the `VERIFY_SKIP_RESEAL` flag.

## Verification

- `bash -n scripts/verify.sh` clean; `make verify` runs all 5 sub-checks and exits 0.
- On a clean tree `[5/5]` reports `OK` (compiler.rs not in diff).
- With a committed `compiler.rs` edit and a stale seal, `[5/5]` prints the `REMINDER` and
  still exits 0.
- `VERIFY_SKIP_RESEAL=1` correctly skips `[5/5]`.

L6 gf16 SSOT untouched; catalog stays 83; no gen/ edits; ASCII-only added lines; no quality
claim added.
