### PR TITLE
compiler.rs: expression-level positive/characterization tests (tests_compiler_rejects 21->26). Closes #1137

### DIFF
--- a/bootstrap/src/compiler.rs
+++ b/bootstrap/src/compiler.rs
@@ -20119,6 +20119,85 @@ mod tests_compiler_rejects {
             v
         );
     }
+
+    // -----------------------------------------------------------------------
+    // Variant X (#969 audit, expression/cast layer). Where #1123 (Q) pinned
+    // declaration-level rejection and #1130 (T) pinned declaration-level
+    // acceptance, this set pins EXPRESSION-LEVEL lowering: the exact Verilog a
+    // valid return-expression lowers to. Each assertion was written by first
+    // observing the current generator output, then locking it in -- so a future
+    // change to expression codegen fails loudly rather than silently. These
+    // characterize CURRENT behavior, they do not endorse or prescribe it.
+    // -----------------------------------------------------------------------
+
+    // A single binary add lowers to a parenthesized Verilog expression.
+    #[test]
+    fn lowers_binop_add_characterization() {
+        let v = emit(r#"module XBin { pub fn add(x: u8) -> u8 { return x + 1 } }"#);
+        assert!(
+            v.contains("add = (x + 1);"),
+            "a binary add should lower to `add = (x + 1);`, got:\n{}",
+            v
+        );
+        assert!(
+            !v.contains("// TODO: implement"),
+            "a valid binop body must not be dropped, got:\n{}",
+            v
+        );
+    }
+
+    // A chained add is left-associative and fully parenthesized.
+    #[test]
+    fn lowers_chained_binop_left_assoc_characterization() {
+        let v = emit(r#"module XChain { pub fn f(x: u8) -> u8 { return x + 1 + 2 } }"#);
+        assert!(
+            v.contains("f = ((x + 1) + 2);"),
+            "a chained add should lower left-associatively to `((x + 1) + 2)`, got:\n{}",
+            v
+        );
+    }
+
+    // A redundant parenthesis around a bare operand is stripped on lowering.
+    #[test]
+    fn lowers_redundant_paren_to_operand_characterization() {
+        let v = emit(r#"module XParen { pub fn f(x: u8) -> u8 { return (x) } }"#);
+        assert!(
+            v.contains("f = x;"),
+            "`return (x)` should lower to the bare operand `f = x;`, got:\n{}",
+            v
+        );
+    }
+
+    // An identity-width cast (`x as u8` for a u8) lowers to the operand with no
+    // width-change machinery and no dropped body.
+    #[test]
+    fn lowers_identity_cast_to_operand_characterization() {
+        let v = emit(r#"module XIdc { pub fn f(x: u8) -> u8 { return x as u8 } }"#);
+        assert!(
+            v.contains("f = x;"),
+            "an identity cast should lower to the operand `f = x;`, got:\n{}",
+            v
+        );
+        assert!(
+            !v.contains("// TODO: implement"),
+            "an identity cast must not drop the body, got:\n{}",
+            v
+        );
+    }
+
+    // CHARACTERIZATION of a current GAP: a `let` binding before the return is
+    // not yet lowered -- the body falls back to the unimplemented stub. This is
+    // a known limitation pinned so the gap is visible; if `let` lowering is
+    // added later this test must be updated deliberately.
+    #[test]
+    fn let_binding_falls_back_to_todo_characterization() {
+        let v = emit(r#"module XLet { pub fn f(x: u8) -> u8 { let y = x return y } }"#);
+        assert!(
+            v.contains("// TODO: implement"),
+            "a `let` binding currently falls back to the unimplemented stub, got:\n{}",
+            v
+        );
+    }
 }
 
 #[cfg(test)]

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,13 @@
 
 Last updated: 2026-06-14
 
+## compiler-expr-characterization -- expression-level positive/characterization tests (Closes #1137)
+
+- **WHERE**: bootstrap/src/compiler.rs (mod tests_compiler_rejects)
+- **WHAT**: Added 5 expression-level characterization tests (tests_compiler_rejects 21 -> 26), each empirically observed before asserting: binop add lowering, left-assoc chained binop, redundant-paren-to-operand, identity-cast-to-operand, and the let-binding TODO fallback (documents a current GAP). Test-only block; build warnings unchanged at 623.
+- **Why**: mirrors the declaration-parser positive set in #1126/#1133 at the expression level, pinning current lowering behavior as a regression net; characterizations document current behavior, NOT an endorsement, and the let-binding test records an existing gap honestly. L6 gf16 SSOT untouched; catalog stays 83; no gen/ edits; ASCII-only added lines; no quality claim added. Closes #1137.
+- **Anchor**: phi^2 + phi^-2 = 3
+
 ## verify-reseal-prev -- add [5/5] reseal-prev advisory sub-check to verify.sh (Closes #1136)
 
 - **WHERE**: scripts/verify.sh, Makefile


### PR DESCRIPTION
## Summary

Add an expression-level positive-control / characterization test set to
`mod tests_compiler_rejects` in `bootstrap/src/compiler.rs`. Where #1123 (Q) pinned
declaration-level rejection and #1130 (T) pinned declaration-level acceptance, this set pins
EXPRESSION-LEVEL lowering: the exact Verilog a valid return-expression lowers to. Pure test
additions; no production code changes.

## Motivation

The reject/accept suite covers casts (#1123/#1130) and declaration shapes, but the precise
SHAPE of lowered expressions is not pinned. A refactor of the expression generator could
silently change associativity, parenthesization, or operand handling without any test
failing. This locks the current output so such a change is caught.

Per the project rule, each assertion was written by first observing the current generator
output, then locking it in. These characterize CURRENT behavior; they do not endorse or
prescribe it.

## New tests (5)

- `lowers_binop_add_characterization` -- `return x + 1` lowers to `add = (x + 1);` (no dropped
  body).
- `lowers_chained_binop_left_assoc_characterization` -- `return x + 1 + 2` lowers
  left-associatively to `f = ((x + 1) + 2);`.
- `lowers_redundant_paren_to_operand_characterization` -- `return (x)` strips the redundant
  parenthesis to `f = x;`.
- `lowers_identity_cast_to_operand_characterization` -- `return x as u8` (u8 fn) lowers to the
  operand `f = x;` with no dropped body.
- `let_binding_falls_back_to_todo_characterization` -- a `let` binding before the return is
  NOT yet lowered; the body falls back to the `// TODO: implement` stub. Pinned as a visible
  current GAP (named characterization), to be updated deliberately if `let` lowering is added.

## Verification

- `tests_compiler_rejects` count: 21 -> 26.
- Full suite: 1468 passed, 0 failed, 0 regressions.
- Build warnings unchanged (623; test-only additions).

L6 gf16 SSOT untouched; catalog stays 83; no gen/ edits; ASCII-only added lines; no quality
claim added.
