### PR TITLE
ci(conformance): wp18 gate Check B third kind bitexact_selfconsistent. Closes #1182

### DIFF
--- a/NOW.md
+++ b/NOW.md
@@ -1,19 +1,6 @@
 # NOW -- Trinity t27 sync
 
-Last updated: 2026-06-16
-
-## ci(conformance) -- wp18 gate third kind bitexact_selfconsistent (this PR, Closes #1182)
-
-- **CHANGED** `tools/wp18_conformance_gate.py`: Check B recount is now TRI-STATE
-  (bitexact / bitexact_selfconsistent / structural) instead of binary; INDEX key
-  `selfconsistent_packs` OPTIONAL (defaults 0) so a legacy 2-kind INDEX stays green;
-  unknown kind -> drift (never folded into bitexact).
-- **CHANGED** `conformance/vectors/gen_all_formats.py`: SELFCONSISTENT registry keeps
-  the affected packs verbatim + emits the `selfconsistent_packs` summary key.
-- **NEW** `tools/wp18_gate_selfconsistent_selftest.py`: 13 checks, 6 FAIL-reachable
-  controls. Patched gate on UNCHANGED tree: exit 0, recount [83,55,0,28].
-- catalog stays 83; ASCII-only; gate-side prerequisite for the INDEX-sync (#1146).
-- Closes #1182
+Last updated: 2026-05-24
 
 ## docs(TRI-NET) -- cross-line package P0/P1/P2 (this PR, Closes #696)
 

--- a/NOW.md
+++ b/NOW.md
@@ -1,6 +1,19 @@
 # NOW -- Trinity t27 sync
 
-Last updated: 2026-05-24
+Last updated: 2026-06-16
+
+## ci(conformance) -- wp18 gate third kind bitexact_selfconsistent (this PR, Closes #1182)
+
+- **CHANGED** `tools/wp18_conformance_gate.py`: Check B recount is now TRI-STATE
+  (bitexact / bitexact_selfconsistent / structural) instead of binary; INDEX key
+  `selfconsistent_packs` OPTIONAL (defaults 0) so a legacy 2-kind INDEX stays green;
+  unknown kind -> drift (never folded into bitexact).
+- **CHANGED** `conformance/vectors/gen_all_formats.py`: SELFCONSISTENT registry keeps
+  the affected packs verbatim + emits the `selfconsistent_packs` summary key.
+- **NEW** `tools/wp18_gate_selfconsistent_selftest.py`: 13 checks, 6 FAIL-reachable
+  controls. Patched gate on UNCHANGED tree: exit 0, recount [83,55,0,28].
+- catalog stays 83; ASCII-only; gate-side prerequisite for the INDEX-sync (#1146).
+- Closes #1182
 
 ## docs(TRI-NET) -- cross-line package P0/P1/P2 (this PR, Closes #696)
 

--- a/conformance/vectors/gen_all_formats.py
+++ b/conformance/vectors/gen_all_formats.py
@@ -49,6 +49,22 @@ EXISTING = {
     "bfloat16": "bf16_golden_conformance_v0.json",
 }
 
+# Externally-generated, dyadic-exact packs that re-derive under ONE decode law
+# and carry honest abs_error, but have NO independent second witness (so they are
+# NOT promoted to the stronger "bitexact" label -- only gf16 has a silicon oracle).
+# These files are produced by the wide-rung GoldenFloat oracle (WP-29/WP-30), kept
+# verbatim here, and listed in the index with kind="bitexact_selfconsistent". This
+# registry exists so a re-run of this generator PRESERVES the self-consistent tier
+# instead of re-deriving these wide rungs as plain structural stubs.
+SELFCONSISTENT = {
+    "gf14": "gf14_conformance_v0.json",
+    "gf48": "gf48_conformance_v0.json",
+    "gf96": "gf96_conformance_v0.json",
+    "gf128": "gf128_conformance_v0.json",
+    "gf512": "gf512_conformance_v0.json",
+    "gf1024": "gf1024_conformance_v0.json",
+}
+
 def f64_hex(x):
     return "0x" + struct.pack(">d", x).hex().upper()
 
@@ -828,6 +844,15 @@ def main():
                           "source": "hand-curated (pre-existing)"})
             continue
 
+        if cid in SELFCONSISTENT:
+            # externally-generated wide-rung pack kept verbatim; NOT regenerated,
+            # NOT promoted to bitexact (no independent second witness).
+            sc_file = SELFCONSISTENT[cid]
+            index.append({"id": cid, "file": sc_file, "kind": "bitexact_selfconsistent",
+                          "source": "wide-rung GoldenFloat oracle (single decode law, "
+                                    "dyadic-exact, no independent second witness)"})
+            continue
+
         # posit/takum cluster
         if rec["cluster"] == "PositUnumIII":
             if cid.startswith("posit"):
@@ -878,6 +903,7 @@ def main():
         "total_formats": len(recs),
         "total_packs": len(index),
         "bitexact_packs": sum(1 for e in index if e["kind"] == "bitexact"),
+        "selfconsistent_packs": sum(1 for e in index if e["kind"] == "bitexact_selfconsistent"),
         "structural_packs": sum(1 for e in index if e["kind"] == "structural"),
         "packs": index,
     }
@@ -887,7 +913,8 @@ def main():
     print(f"formats: {len(recs)}")
     print(f"written new packs: {written}  (bitexact={bitexact}, structural={structural})")
     print(f"existing kept: {len(EXISTING)}")
-    print(f"index packs: {len(index)}  bitexact={idx['bitexact_packs']}  structural={idx['structural_packs']}")
+    print(f"index packs: {len(index)}  bitexact={idx['bitexact_packs']}  "
+          f"selfconsistent={idx['selfconsistent_packs']}  structural={idx['structural_packs']}")
 
 if __name__ == "__main__":
     main()

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,6 +1,13 @@
 # NOW -- Trinity t27 sync
 
-Last updated: 2026-06-16
+Last updated: 2026-06-17
+
+## wp18-gate-third-kind -- Check B tri-state bitexact_selfconsistent (Closes #1182)
+
+- **WHERE**: tools/wp18_conformance_gate.py, tools/wp18_gate_selfconsistent_selftest.py (new), conformance/vectors/gen_all_formats.py
+- **WHAT**: Check B recount changed from a binary model (bitexact unless structural) to a tri-state recount counting bitexact / bitexact_selfconsistent / structural separately. The INDEX summary key selfconsistent_packs is OPTIONAL and defaults to 0, so a legacy 2-kind INDEX recounts unchanged (backward compatible). An unknown kind is flagged as drift and is never folded into bitexact. gen_all_formats.py gains a SELFCONSISTENT registry (mirrors the EXISTING pattern) that keeps the affected packs verbatim under the new kind and emits the summary key.
+- **Why**: the wide GoldenFloat rungs (gf48/gf96/gf128/gf512/gf1024) are bit-exact by construction but only gf16 has an independent silicon oracle (Corona ROM); the third kind records the honest, strictly-weaker status so their vectors can enter the INDEX without overstating evidence. Gate-side prerequisite for the INDEX-sync (#1146). New self-test 13 checks, 6 FAIL-reachable controls; the existing wp18_selftest_gate.py stays 15/15; patched gate on the UNCHANGED tree exits 0 with recount [83, 55, 0, 28]. L6 gf16 SSOT untouched; catalog stays 83; no gen/ edits; ASCII-only added lines; no quality claim added. Closes #1182.
+- **Anchor**: phi^2 + phi^-2 = 3
 
 ## compiler-expr-characterization -- expression-level positive/characterization tests (Closes #1137)
 

--- a/tools/wp18_conformance_gate.py
+++ b/tools/wp18_conformance_gate.py
@@ -7,7 +7,15 @@ analog of the catalog-count gate. Checks, as DISTINCT failures (CertifiedData v2
 "which surface drifted" discipline):
 
   A. pack-set name-set == SSOT format id-set (no missing / no extra)
-  B. INDEX total/bitexact/structural counts == recount from the pack files
+  B. INDEX total/bitexact/selfconsistent/structural counts == recount from the pack
+     files. THREE pack kinds are recognised: "bitexact" (an independent oracle, e.g.
+     a silicon ROM or a second reference impl, witnesses every vector), "structural"
+     (no value vectors, n_vectors=0), and "bitexact_selfconsistent" (dyadic-exact
+     vectors that re-derive under ONE decode law and carry honest abs_error, but have
+     NO independent second witness). The selfconsistent kind is counted separately so
+     a pack is never silently promoted to the stronger "bitexact" label. The INDEX key
+     "selfconsistent_packs" is OPTIONAL and defaults to 0 (backward compatible: an
+     INDEX with no selfconsistent packs and no key still recounts 0 and stays CLEAN).
   C. per-pack SHA-256 in INDEX == file hash (manifest freshness)
   D. FINITE-VALUE row arithmetic consistency: for every row carrying input_f64 +
      decoded_f64 + abs_error whose values are finite, the stored abs_error must equal
@@ -163,28 +171,43 @@ def run_gate(ssot_path, vectors_dir, allowlist_path=None):
     if missing or extra:
         report["failures"].append({"check": "A", "missing": missing, "extra": extra})
 
-    # ---- Check B: INDEX counts == recount ----
-    be = st = 0
+    # ---- Check B: INDEX counts == recount (tri-state: bitexact / selfconsistent / structural) ----
+    be = sc = st = 0
+    unknown_kind = []
     file_missing = []
     for p in packs:
         fn = os.path.join(vectors_dir, p["file"])
         if not os.path.isfile(fn):
             file_missing.append(p["file"])
             continue
-        if p.get("kind") == "structural":
+        kind = p.get("kind")
+        if kind == "structural":
             st += 1
-        else:
+        elif kind == "bitexact_selfconsistent":
+            sc += 1
+        elif kind == "bitexact":
             be += 1
-    claimed = (index.get("total_packs"), index.get("bitexact_packs"), index.get("structural_packs"))
-    recount = (len(packs), be, st)
+        else:
+            # An unrecognised kind is drift, NOT silently folded into bitexact.
+            unknown_kind.append({"file": p["file"], "kind": str(kind)})
+    # "selfconsistent_packs" is OPTIONAL; default 0 keeps a legacy 2-kind INDEX green.
+    claimed = (
+        index.get("total_packs"),
+        index.get("bitexact_packs"),
+        index.get("selfconsistent_packs", 0),
+        index.get("structural_packs"),
+    )
+    recount = (len(packs), be, sc, st)
     report["checks"]["B_index_counts"] = {
-        "claimed_total_bitexact_structural": list(claimed),
-        "recount_total_bitexact_structural": list(recount),
+        "claimed_total_bitexact_selfconsistent_structural": list(claimed),
+        "recount_total_bitexact_selfconsistent_structural": list(recount),
+        "unknown_kind": unknown_kind,
         "file_missing": file_missing,
-        "ok": claimed == recount and not file_missing,
+        "ok": claimed == recount and not file_missing and not unknown_kind,
     }
-    if claimed != recount or file_missing:
-        report["failures"].append({"check": "B", "claimed": claimed, "recount": recount, "file_missing": file_missing})
+    if claimed != recount or file_missing or unknown_kind:
+        report["failures"].append({"check": "B", "claimed": claimed, "recount": recount,
+                                   "file_missing": file_missing, "unknown_kind": unknown_kind})
 
     # ---- Check C: SHA freshness ----
     sha_drift = []

--- a/tools/wp18_gate_selfconsistent_selftest.py
+++ b/tools/wp18_gate_selfconsistent_selftest.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""
+FAIL-reachable self-test for the WP-33 tri-state extension of wp18_conformance_gate.py.
+
+Verifies that Check B now recognises THREE pack kinds (bitexact / bitexact_selfconsistent
+/ structural) and counts each separately, WITHOUT silently promoting a self-consistent
+pack to the stronger "bitexact" label. Every positive assertion is paired with a negative
+control (a planted defect that MUST flip the gate verdict), per the FAIL-reachable rule.
+
+stdlib only, ZERO local imports beyond the gate under test. ASCII-only. Apache-2.0.
+
+Run:  python3 wp18_gate_selfconsistent_selftest.py
+Exit: 0 = all checks pass (incl. all negative controls flip), 1 = a check failed.
+"""
+import json
+import math
+import os
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+import wp18_conformance_gate as gate  # noqa: E402
+
+PASS = 0
+FAIL = 0
+
+
+def check(label, cond):
+    global PASS, FAIL
+    if cond:
+        PASS += 1
+        print("PASS %s" % label)
+    else:
+        FAIL += 1
+        print("FAIL %s" % label)
+
+
+def _write(path, obj):
+    with open(path, "w", encoding="ascii") as fh:
+        json.dump(obj, fh)
+
+
+def _ssot(path, ids):
+    with open(path, "w", encoding="ascii") as fh:
+        for i in ids:
+            fh.write("// CATALOG: id=%s\n" % i)
+
+
+def _bitexact_pack(name):
+    # one finite row that re-derives exactly (abs_error 0), plus an inf special row
+    return {
+        "format": name,
+        "vectors": [
+            {"name": "three", "input_f64": 3.0, "decoded_f64": 3.0,
+             "abs_error": 0.0, "category": "normal"},
+            {"name": "pos_inf", "input_f64": "Infinity", "decoded_f64": "Infinity",
+             "abs_error": 0.0, "category": "inf"},
+        ],
+    }
+
+
+def _selfconsistent_pack(name):
+    # dyadic-exact finite rows, abs_error 0 by construction, honest single-witness
+    return {
+        "format": name,
+        "decode_provenance": "single decode law, no independent second witness",
+        "vectors": [
+            {"name": "one", "input_f64": 1.0, "decoded_f64": 1.0,
+             "abs_error": 0.0, "category": "normal"},
+            {"name": "two", "input_f64": 2.0, "decoded_f64": 2.0,
+             "abs_error": 0.0, "category": "normal"},
+        ],
+    }
+
+
+def build_tree(tmp, kinds):
+    """kinds: list of (id, kind). Builds SSOT + vectors dir + INDEX with correct counts.
+    Returns (ssot_path, vectors_dir, index_dict)."""
+    vec = os.path.join(tmp, "vectors")
+    os.makedirs(vec, exist_ok=True)
+    ids = [k[0] for k in kinds]
+    ssot = os.path.join(tmp, "formats_catalog.t27")
+    _ssot(ssot, ids)
+    packs = []
+    be = sc = st = 0
+    for pid, kind in kinds:
+        fn = "%s_conformance_v0.json" % pid
+        fpath = os.path.join(vec, fn)
+        if kind == "structural":
+            _write(fpath, {"format": pid, "vectors": []})
+            st += 1
+        elif kind == "bitexact_selfconsistent":
+            _write(fpath, _selfconsistent_pack(pid))
+            sc += 1
+        else:
+            _write(fpath, _bitexact_pack(pid))
+            be += 1
+        packs.append({"id": pid, "file": fn, "kind": kind,
+                      "n_vectors": 0 if kind == "structural" else 2,
+                      "sha256": gate._sha256_file(fpath)})
+    index = {
+        "schema": "t27-conformance-index/v0.1",
+        "total_formats": len(ids),
+        "total_packs": len(packs),
+        "bitexact_packs": be,
+        "selfconsistent_packs": sc,
+        "structural_packs": st,
+        "packs": packs,
+    }
+    _write(os.path.join(vec, "INDEX_all_formats.json"), index)
+    return ssot, vec, index
+
+
+def run(ssot, vec):
+    code, report = gate.run_gate(ssot, vec, None)
+    return code, report
+
+
+def b_check(report):
+    return report["checks"]["B_index_counts"]
+
+
+def main():
+    # ----------------------------------------------------------------- T1 / T1b
+    # T1: a tree with all three kinds + a correct INDEX -> CLEAN, recount matches.
+    with tempfile.TemporaryDirectory() as tmp:
+        ssot, vec, idx = build_tree(tmp, [
+            ("gf16", "bitexact"),
+            ("gf48", "bitexact_selfconsistent"),
+            ("gf96", "bitexact_selfconsistent"),
+            ("decimal32", "structural"),
+        ])
+        code, rep = run(ssot, vec)
+        b = b_check(rep)
+        check("T1 tri-state tree is CLEAN (exit 0)", code == 0)
+        check("T1 recount [4,1,2,1] matches claimed",
+              b["recount_total_bitexact_selfconsistent_structural"] == [4, 1, 2, 1]
+              and b["ok"] is True)
+
+        # T1b NEGATIVE CONTROL: claim the 2 selfconsistent packs as bitexact
+        # (selfconsistent_packs=0, bitexact_packs=3) -> Check B MUST fail.
+        idxp = json.load(open(os.path.join(vec, "INDEX_all_formats.json"), encoding="ascii"))
+        idxp["bitexact_packs"] = 3
+        idxp["selfconsistent_packs"] = 0
+        _write(os.path.join(vec, "INDEX_all_formats.json"), idxp)
+        code_b, rep_b = run(ssot, vec)
+        check("T1b CONTROL mislabel sc-as-bitexact -> DRIFT (exit 2)", code_b == 2)
+        check("T1b CONTROL Check B not ok", b_check(rep_b)["ok"] is False)
+
+    # ----------------------------------------------------------------- T2 / T2b
+    # T2: legacy 2-kind tree with NO selfconsistent key -> defaults to 0, CLEAN.
+    with tempfile.TemporaryDirectory() as tmp:
+        ssot, vec, idx = build_tree(tmp, [
+            ("gf16", "bitexact"),
+            ("decimal32", "structural"),
+        ])
+        # strip the optional key to simulate a legacy INDEX
+        idxp = json.load(open(os.path.join(vec, "INDEX_all_formats.json"), encoding="ascii"))
+        del idxp["selfconsistent_packs"]
+        _write(os.path.join(vec, "INDEX_all_formats.json"), idxp)
+        code, rep = run(ssot, vec)
+        check("T2 legacy INDEX (no sc key) stays CLEAN (backward compat)", code == 0)
+        check("T2 recount selfconsistent defaults to 0",
+              b_check(rep)["recount_total_bitexact_selfconsistent_structural"] == [2, 1, 0, 1])
+
+        # T2b NEGATIVE CONTROL: same legacy tree but add a real selfconsistent pack on
+        # disk + INDEX entry, leaving total/bitexact stale -> recount must catch it.
+        vecdir = vec
+        scfn = "gf48_conformance_v0.json"
+        _write(os.path.join(vecdir, scfn), _selfconsistent_pack("gf48"))
+        idxp = json.load(open(os.path.join(vecdir, "INDEX_all_formats.json"), encoding="ascii"))
+        idxp["packs"].append({"id": "gf48", "file": scfn, "kind": "bitexact_selfconsistent",
+                              "n_vectors": 2, "sha256": gate._sha256_file(os.path.join(vecdir, scfn))})
+        # deliberately do NOT bump total_packs / selfconsistent_packs
+        _write(os.path.join(vecdir, "INDEX_all_formats.json"), idxp)
+        _ssot(ssot, ["gf16", "decimal32", "gf48"])  # keep Check A happy
+        code_b, rep_b = run(ssot, vecdir)
+        check("T2b CONTROL added sc pack w/ stale counts -> DRIFT (exit 2)", code_b == 2)
+
+    # ----------------------------------------------------------------- T3 / T3b
+    # T3: an UNKNOWN kind is drift, NOT silently folded into bitexact.
+    with tempfile.TemporaryDirectory() as tmp:
+        ssot, vec, idx = build_tree(tmp, [
+            ("gf16", "bitexact"),
+            ("decimal32", "structural"),
+        ])
+        idxp = json.load(open(os.path.join(vec, "INDEX_all_formats.json"), encoding="ascii"))
+        idxp["packs"][0]["kind"] = "totally_made_up_kind"
+        _write(os.path.join(vec, "INDEX_all_formats.json"), idxp)
+        code, rep = run(ssot, vec)
+        check("T3 unknown kind -> DRIFT (exit 2)", code == 2)
+        check("T3 unknown_kind list is non-empty",
+              len(b_check(rep)["unknown_kind"]) == 1)
+
+        # T3b CONTROL: rename it back to the valid kind -> CLEAN again.
+        idxp["packs"][0]["kind"] = "bitexact"
+        _write(os.path.join(vec, "INDEX_all_formats.json"), idxp)
+        code_b, rep_b = run(ssot, vec)
+        check("T3b CONTROL valid kind restored -> CLEAN (exit 0)", code_b == 0)
+
+    # ----------------------------------------------------------------- T4 / T4b
+    # T4: Check D STILL runs on selfconsistent packs (they are not structural), so a
+    # corrupted abs_error in a selfconsistent pack MUST be caught (no free pass).
+    with tempfile.TemporaryDirectory() as tmp:
+        ssot, vec, idx = build_tree(tmp, [
+            ("gf48", "bitexact_selfconsistent"),
+        ])
+        code, rep = run(ssot, vec)
+        check("T4 clean selfconsistent pack -> CLEAN (exit 0)", code == 0)
+
+        # T4b CONTROL: lie about abs_error in a selfconsistent row -> Check D fires.
+        scfile = os.path.join(vec, "gf48_conformance_v0.json")
+        pk = json.load(open(scfile, encoding="ascii"))
+        pk["vectors"][0]["abs_error"] = 0.5  # decoded==input==1.0 so true error is 0
+        _write(scfile, pk)
+        # refresh sha so Check C does not pre-empt Check D
+        idxp = json.load(open(os.path.join(vec, "INDEX_all_formats.json"), encoding="ascii"))
+        idxp["packs"][0]["sha256"] = gate._sha256_file(scfile)
+        _write(os.path.join(vec, "INDEX_all_formats.json"), idxp)
+        code_b, rep_b = run(ssot, vec)
+        check("T4b CONTROL corrupted abs_error in sc pack -> caught by D (exit 2)", code_b == 2)
+        check("T4b CONTROL Check D not ok",
+              rep_b["checks"]["D_rederive_abs_error"]["ok"] is False)
+
+    print("")
+    print("SELFTEST RESULT: %d PASS, %d FAIL" % (PASS, FAIL))
+    return 0 if FAIL == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

`tools/wp18_conformance_gate.py` Check B re-derived the INDEX pack counts with a
BINARY model (a pack is counted `bitexact` unless `kind == "structural"`). This PR
makes Check B TRI-STATE: it counts `bitexact`, `bitexact_selfconsistent`, and
`structural` separately. The INDEX summary key `selfconsistent_packs` is OPTIONAL and
defaults to 0, so a legacy 2-kind INDEX recounts unchanged (backward compatible). An
unknown kind is flagged as drift and is never folded into bitexact.

`conformance/vectors/gen_all_formats.py` gains a `SELFCONSISTENT` registry (mirrors
the `EXISTING` pattern) that keeps the affected packs verbatim under the new kind and
emits the `selfconsistent_packs` summary key.

## Motivation

The wide GoldenFloat rungs (gf48/gf96/gf128/gf512/gf1024) are bit-exact by
construction (dyadic, single decode law) but only gf16 has an INDEPENDENT second
witness (the Corona ROM silicon oracle). Under the binary model the only way to add
their vectors to the INDEX is to label them `bitexact`, which overstates their
evidence by placing them in the same tier as silicon-validated gf16. The third kind
`bitexact_selfconsistent` records the honest, strictly-weaker status. This is the
gate-side prerequisite for the INDEX-sync that promotes the n_vectors:0 stubs
(companion to #1146).

## Verification

- New self-test `tools/wp18_gate_selfconsistent_selftest.py`: 13 checks, 6
  FAIL-reachable negative controls (mislabel sc-as-bitexact -> drift; legacy-no-key ->
  clean; stale counts -> drift; unknown kind -> drift; restore -> clean; corrupted
  abs_error in a sc pack -> caught by Check D).
- Patched gate on the UNCHANGED tree: exit 0, recount [83, 55, 0, 28] (backward
  compatible -- the absent `selfconsistent_packs` key defaults to 0).
- catalog stays 83; ASCII-only added lines; no `gen/`/`coq/`/`bootstrap/` edits.

Closes #1182
