### PR TITLE
docs(metrics): сводка ключевых метрик 83 числовых форматов (SSOT-derived)

### DIFF
--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,3 +1,19 @@
+# NOW — docs(metrics): сводка ключевых метрик 83 числовых форматов (2026-08-06)
+
+Last updated: 2026-08-06
+
+## docs(metrics): сводка ключевых метрик 83 числовых форматов (SSOT-derived) (Closes #1225)
+
+- Branch: `docs/metrics-83-compendium`
+
+### Что легло
+- `docs/metrics/NUMERIC_FORMATS_83_METRICS.md` — compendium of key metrics across all 83 numeric formats in the catalog.
+- `docs/metrics/numeric_formats_83_metrics.csv` — machine-readable table derived from SSOT (`specs/numeric/formats_catalog.t27`).
+- `docs/metrics/build_metrics.py` — generator from SSOT; SSOT itself is not touched.
+- Honesty: catalog = **83** formats (not 84; divergence from arXiv:2606.09686 is logged as erratum); HW tiry: decode-HW 4/83, compute-HW 2/83 (E/C), SW-bitexact 62/83.
+
+---
+
 # NOW — ring-105: ecosystem .tri rewrite (7 repos -> t27 SSOT) (2026-08-06)
 
 Last updated: 2026-08-06

--- a/docs/metrics/NUMERIC_FORMATS_83_METRICS.md
+++ b/docs/metrics/NUMERIC_FORMATS_83_METRICS.md
@@ -1,0 +1,228 @@
+# Ключевые метрики 83 числовых форматов каталога Trinity (t27)
+
+Сводка по единому источнику истины (SSOT) репозитория `gHashTag/t27`, ветка `master`.
+
+Дата сборки: 28.06.2026. Источники данных:
+- Метрики (биты, S/E/M, bias, кластер, статус, назначение): `gen/numeric/formats_catalog.json` (77 форматов) + `specs/numeric/gf{10,14,48,96,512,1024}.t27` (6 GF-форматов, отсутствующих в JSON-каталоге).
+- SW-conformance (kind, n_vectors): `conformance/vectors/INDEX_all_formats.json`.
+- HW-статус: реальные прогоны на плате AX7203 (XC7A200T) в сессии 28.06.2026.
+- Якорь тождества: φ² + φ⁻² = 3. Препринт: arXiv:2606.05017.
+
+> Производные величины (значащие десятичные цифры, динамический диапазон) посчитаны по IEEE-подобной модели нормальных чисел и являются [смоделировано: оценка], а не нормативными значениями из спецификации.
+
+---
+
+## 1. Сводка по столбцам (честный счёт)
+
+| Уровень доказательства | Счёт | Тег |
+|---|---|---|
+| **SW-bitexact** (независимый оракул, abs_error=0) | **62 / 83** | [смоделировано / verified в SW] |
+| SW self-consistent (encode↔decode roundtrip, без 2-го witness) | 6 / 83 | [слабее: требует внешнего оракула] |
+| SW structural (нет числовых векторов) | 15 / 83 | [открытая задача] |
+| **decode-HW** (bit-exact на AX7203) | **4 / 83** — `bfloat16`, `int8`, `nf4`, `fp8_e4m3` | [измерено на железе; 3 из 4 exhaustive] |
+| **compute-HW** (bit-exact на AX7203) | **2 / 83** — `gf6`, `gf8` (ADD) | [измерено на железе: 512/512 bit-exact каждый] |
+
+Всего SW-векторов в каталоге: **2493**. Всего форматов: **83** (22 GoldenFloat + 61 внешних/референсных). Итого HW-ячеек за сессию 28.06.2026: **6** (0→6).
+
+> ⚠️ encoding ≠ compute ≠ FPGA. SW-bitexact = модель сравнивается с моделью. HW-ячейка = реальные LUT/DSP на кристалле Artix-7 выдали бит-в-бит ожидаемое. Это разные уровни доказательства — не смешивать.
+>
+> ⚠️ **Два тира доказательств HW** (в таблице помечены): **E** = полная цепь доказательств опубликована на #199 (CI run + SHA + flash/UART-лог): `gf8`, `gf6`, `bfloat16`. **C** = self-report локального агента + дизайн на main, но UART-лог ещё НЕ опубликован на #199: `int8`, `nf4`, `fp8_e4m3`. Рекомендация: попросить локального агента отправить UART-логи этих трёх на #199 для перевода C→E.
+>
+> ⚠️ Покрытие: `int8`/`nf4`/`fp8_e4m3` — **exhaustive** (256/256, 16/16, 256/256, весь код-пространство); `bfloat16` — 8 corner-кодов; `gf8`/`gf6` compute — 512 векторов §3.5 (репрезентативно, НЕ exhaustive 65536).
+
+---
+
+## 2. Приоритизация следующих HW-ячеек (по «доказательному весу»)
+
+Критерий: широта применения (актуальность для ML/индустрии) × простота переноса (малые биты, готовый RTL-декодер/clean-ядро, уже пройден 2-oracle SW). Шаблон переноса проверен и воспроизводим: single-decoder/compute-дизайн → CI synth → `gh api .../artifacts/{id}/zip` → openocd flash (AL321, IDCODE 0x13636093) → UART verify (CP2102N @160000).
+
+Статус на конец сессии: decode-HW уже 4/83 (bf16+int8+nf4+fp8), compute-HW 2/83 (gf6+gf8). Ниже — следующие кандидаты.
+
+### Ближайший шаг (уже почти готово)
+
+| Приоритет | Столбец | Формат | Состояние |
+|---|---|---|---|
+| 1 | decode-HW | `posit8` | bitstream готов, скачан; прошивка зависла после 6 быстрых циклов JTAG → нужен reset/power-cycle платы → `--fmt 4` → decode-HW 4→5 |
+
+### decode-HW: следующие после posit8
+
+| Приоритет | Формат | Бит | Почему высокий вес |
+|---|---|--:|---|
+| 1 | `fp8_e5m2` | 8 | Второй FP8-вариант (широкий диапазон, activations) — парный к fp8_e4m3 |
+| 2 | `fp4_e2m1` | 4 | Extreme-quant инференс; самый узкий → простой exhaustive (16 кодов) |
+| 3 | `mxfp4` / `mxfp8` | 4/8 | Microscaling (ally) — OCP-стандарт, растёт в индустрии |
+
+### compute-HW: 3 следующих ячейки
+
+| Приоритет | Формат | Бит | Состояние / почему |
+|---|---|--:|---|
+| 1 | `gf16` | 16 | Production-ядро Trinity; clean-дизайн на pre-fix коммите 5d572ccdd — нужен re-trigger CI |
+| 2 | `gf12` | 12 | Mid-range; clean-дизайн/workflow НЕ существует — надо создать `gf12_clean_ax7203.v` |
+| 3 | `gf4` | 4 | Вырожденный край (bias=0) — отдельное ядро; exhaustive 256 кодов тривиален |
+
+**Рекомендация:** (1) сначала добить **posit8** (reset платы → decode-HW 5/83) — битстрим уже готов; (2) параллельно попросить локального агента опубликовать UART-логи int8/nf4/fp8 на #199 (C→E); (3) затем **gf16 compute** (re-trigger CI) — флагманский GF-формат даёт максимум веса.
+
+---
+
+## 3. Полная таблица метрик (83 формата, по кластерам)
+
+Колонки: `Бит` — разрядность; `S/E/M` — знак/экспонента/мантисса; `Знач. цифр` — оценка десятичной точности [смоделировано]; `Дин. диап. (дек)` — десятичные порядки нормальных чисел [смоделировано]; `φ-расст.` — близость к φ-выравниванию (из каталога); `SW-conf.` — уровень софт-conformance из SSOT; `n_vec` — число conformance-векторов; `decode-HW`/`compute-HW` — реально измерено на AX7203.
+
+### GoldenFloat (Trinity) (22)
+
+| Формат | Бит | S/E/M | Bias | Знач. цифр | Дин. диап. (дек) | φ-расст. | SW-conf. | n_vec | decode-HW | compute-HW | Назначение |
+|---|--:|---|--:|--:|--:|--:|---|--:|---|---|---|
+| `gfternary` | 2 | 1/0/2 | 0 | 0.9 | — | 0.0 | bitexact | 4 | 0 | 0 | bulk layers (hybrid) |
+| `gf4` | 4 | 1/1/2 | 0 | 0.9 | -0.1 | 0.118 | bitexact | 16 | 0 | 0 | proof-of-concept |
+| `mxgf4` | 4 | 1/1/2 | 0 | 0.9 | -0.1 | 0.118 | bitexact | 16 | 0 | 0 | OPEN R&D: phi-aligned MX-4 candidate |
+| `gf6` | 6 | 1/2/3 | 1 | 1.2 | 0.6 | 0.05 | bitexact | 64 | 0 | **1**  [измерено: 512/512 bit-exact; E:#199 artifact 7931202948] | OPEN R&D: bridge GF4-GF8; FP6 E2M3 hint |
+| `mxgf6` | 6 | 1/2/3 | 1 | 1.2 | 0.6 | 0.05 | bitexact | 64 | 0 | 0 | OPEN R&D: phi-aligned MX-6 candidate |
+| `gf8` | 8 | 1/3/4 | 3 | 1.5 | 1.8 | 0.132 | bitexact | 256 | 0 | **1**  [измерено: 512/512 bit-exact; E:#199 post-fix c0d24cac2] | edge / sensors |
+| `gf8_bfp` | 8 | 1/3/4 | 3 | 1.5 | 1.8 | 0.132 | bitexact | 256 | 0 | 0 | OPEN R&D: LLM-quantization-friendly GF8 |
+| `gf10` | 10 | 1/3/6 | 3 | 2.1 | 1.8 | — | bitexact | 8 | 0 | 0 | расширенный диапазон GF-семейства |
+| `gf12` | 12 | 1/4/7 | 7 | 2.4 | 4.2 | 0.047 | bitexact | 8 | 0 | 0 | mid-range / audio |
+| `gf14` | 14 | 1/5/8 | 15 | 2.7 | 9.0 | — | self-cons. | — | 0 | 0 | расширенный диапазон GF-семейства |
+| `gf16` | 16 | 1/6/9 | 31 | 3.0 | 18.7 | 0.049 | bitexact | — | 0 | 0 | training and inference (production) |
+| `gf_lns_hybrid` | 16 | 1/6/9 | 31 | 3.0 | 18.7 | 0.049 | bitexact | 8 | 0 | 0 | OPEN R&D: dual-space arithmetic |
+| `gf20` | 20 | 1/7/12 | 63 | 3.9 | 37.9 | 0.035 | bitexact | 8 | 0 | 0 | high-precision edge |
+| `gf24` | 24 | 1/9/14 | 255 | 4.5 | 153.5 | 0.025 | bitexact | 8 | 0 | 0 | server inference |
+| `gf32` | 32 | 1/12/19 | 2047 | 6.0 | 1232.1 | 0.014 | bitexact | 8 | 0 | 0 | fp32 drop-in |
+| `gf48` | 48 | 1/18/29 | 131071 | 9.0 | 78912.3 | — | self-cons. | — | 0 | 0 | расширенный диапазон GF-семейства |
+| `gf64` | 64 | 1/24/39 | 8388607 | 12.0 | 5050444.4 | 0.003 | bitexact | 8 | 0 | 0 | scientific / double |
+| `gf96` | 96 | 1/36/59 | 34359738367 | 18.1 | 20686623783.0 | — | self-cons. | — | 0 | 0 | расширенный диапазон GF-семейства |
+| `gf128` | 128 | 1/48/79 | 0 | 24.1 | 84732411018727.1 | 0.008 | self-cons. | — | 0 | 0 | OPEN R&D: phi-aligned binary128 alternative |
+| `gf256` | 256 | 1/97/158 | 0 | 47.9 | 4.770010683626838e+28 | 0.005 | structural | 0 | 0 | 0 | OPEN R&D: phi-aligned binary256 alternative |
+| `gf512` | 512 | 1/195/316 | 25108406941546723055343157692830665664409421777856138051583 | 95.4 | 1.511676726548657e+58 | — | self-cons. | — | 0 | 0 | расширенный диапазон GF-семейства |
+| `gf1024` | 1024 | 1/391/632 | 2521728396569246669585858566409191283525103313309788586748690777871726193375821479130513040312634601011624191379636223 | 190.6 | 1.5182317765699572e+117 | — | self-cons. | — | 0 | 0 | расширенный диапазон GF-семейства |
+
+### IEEE-754 binary (5)
+
+| Формат | Бит | S/E/M | Bias | Знач. цифр | Дин. диап. (дек) | φ-расст. | SW-conf. | n_vec | decode-HW | compute-HW | Назначение |
+|---|--:|---|--:|--:|--:|--:|---|--:|---|---|---|
+| `binary16` | 16 | 1/5/10 | 15 | 3.3 | 9.0 | 0.118 | bitexact | 8 | 0 | 0 | GPU activations, inference |
+| `binary32` | 32 | 1/8/23 | 127 | 7.2 | 76.5 | 0.27 | bitexact | 8 | 0 | 0 | industry default |
+| `binary64` | 64 | 1/11/52 | 1023 | 16.0 | 615.9 | 0.406 | bitexact | 8 | 0 | 0 | scientific computing |
+| `binary128` | 128 | 1/15/112 | 16383 | 34.0 | 9863.2 | 0.484 | bitexact | 8 | 0 | 0 | high-precision simulations |
+| `binary256` | 256 | 1/19/236 | 262143 | 71.3 | 157825.5 | 0.538 | bitexact | 8 | 0 | 0 | astronomy, cryptography |
+
+### ML low-precision (7)
+
+| Формат | Бит | S/E/M | Bias | Знач. цифр | Дин. диап. (дек) | φ-расст. | SW-conf. | n_vec | decode-HW | compute-HW | Назначение |
+|---|--:|---|--:|--:|--:|--:|---|--:|---|---|---|
+| `fp4_e2m1` | 4 | 1/2/1 | 1 | 0.6 | 0.5 | 1.382 | bitexact | 16 | 0 | 0 | extreme quant inference |
+| `fp6_e2m3` | 6 | 1/2/3 | 1 | 1.2 | 0.6 | 0.049 | bitexact | 64 | 0 | 0 | mantissa-heavy quant |
+| `fp6_e3m2` | 6 | 1/3/2 | 3 | 0.9 | 1.7 | 0.882 | bitexact | 64 | 0 | 0 | aggressive quant inference |
+| `fp8_e4m3` | 8 | 1/4/3 | 7 | 1.2 | 4.2 | 0.715 | bitexact | — | **1**  [измерено: 256/256 exhaustive; C:design on main, log≠#199] | 0 | inference, gradient ranges |
+| `fp8_e5m2` | 8 | 1/5/2 | 15 | 0.9 | 9.0 | 1.882 | bitexact | — | 0 | 0 | activations, wide range |
+| `bfloat16` | 16 | 1/8/7 | 127 | 2.4 | 76.5 | 0.525 | bitexact | — | **1**  [измерено: 8/8 corner; E:#199 run 28326217079] | 0 | training (range > precision) |
+| `tf32` | 19 | 1/8/10 | 127 | 3.3 | 76.5 | 0.27 | bitexact | 8 | 0 | 0 | A100/H100 mixed precision |
+
+### Microscaling (MX) (3)
+
+| Формат | Бит | S/E/M | Bias | Знач. цифр | Дин. диап. (дек) | φ-расст. | SW-conf. | n_vec | decode-HW | compute-HW | Назначение |
+|---|--:|---|--:|--:|--:|--:|---|--:|---|---|---|
+| `mxfp4` | 4 | 1/2/1 | 1 | 0.6 | 0.5 | 1.382 | bitexact | — | 0 | 0 | extreme quant |
+| `mxfp6` | 6 | 1/3/2 | 3 | 0.9 | 1.7 | 0.882 | bitexact | 64 | 0 | 0 | aggressive inference |
+| `mxfp8` | 8 | 1/4/3 | 7 | 1.2 | 4.2 | 0.715 | bitexact | 256 | 0 | 0 | LLM inference |
+
+### Квантование (tuned) (2)
+
+| Формат | Бит | S/E/M | Bias | Знач. цифр | Дин. диап. (дек) | φ-расст. | SW-conf. | n_vec | decode-HW | compute-HW | Назначение |
+|---|--:|---|--:|--:|--:|--:|---|--:|---|---|---|
+| `nf4` | 4 | 0/0/4 | 0 | 1.5 | — | -1.0 | bitexact | 16 | **1**  [измерено: 16/16 exhaustive; C:design on main, log≠#199] | 0 | LLM weight quantization (quantile-based on N(0 |
+| `afp` | 16 | 1/8/7 | 127 | 2.4 | 76.5 | -1.0 | structural | 0 | 0 | 0 | efficient training |
+
+### Posit / Unum III (8)
+
+| Формат | Бит | S/E/M | Bias | Знач. цифр | Дин. диап. (дек) | φ-расст. | SW-conf. | n_vec | decode-HW | compute-HW | Назначение |
+|---|--:|---|--:|--:|--:|--:|---|--:|---|---|---|
+| `posit8` | 8 | 1/2/0 | 0 | 0.3 | 0.3 | -1.0 | bitexact | 256 | 0 | 0 | inference |
+| `takum8` | 8 | 1/0/0 | 0 | 0.3 | — | -1.0 | bitexact | 256 | 0 | 0 | IEEE-754 backward-compatible tapered |
+| `posit16` | 16 | 1/2/0 | 0 | 0.3 | 0.3 | -1.0 | bitexact | 8 | 0 | 0 | mixed-precision training |
+| `takum16` | 16 | 1/0/0 | 0 | 0.3 | — | -1.0 | structural | 0 | 0 | 0 | single-rule ladder counterexample |
+| `posit32` | 32 | 1/2/0 | 0 | 0.3 | 0.3 | -1.0 | bitexact | 8 | 0 | 0 | f32 replacement |
+| `takum32` | 32 | 1/0/0 | 0 | 0.3 | — | -1.0 | structural | 0 | 0 | 0 | tapered fp32-class |
+| `posit64` | 64 | 1/2/0 | 0 | 0.3 | 0.3 | -1.0 | bitexact | 8 | 0 | 0 | f64 replacement |
+| `takum64` | 64 | 1/0/0 | 0 | 0.3 | — | -1.0 | structural | 0 | 0 | 0 | tapered fp64-class |
+
+### Логарифмические (LNS) (4)
+
+| Формат | Бит | S/E/M | Bias | Знач. цифр | Дин. диап. (дек) | φ-расст. | SW-conf. | n_vec | decode-HW | compute-HW | Назначение |
+|---|--:|---|--:|--:|--:|--:|---|--:|---|---|---|
+| `lns8` | 8 | 1/7/0 | 0 | 0.3 | 37.6 | -1.0 | bitexact | 256 | 0 | 0 | DSP, signal processing |
+| `lns16` | 16 | 1/15/0 | 0 | 0.3 | 9863.2 | -1.0 | bitexact | 5 | 0 | 0 | log-domain training (mul -> add) |
+| `lns32` | 32 | 1/31/0 | 0 | 0.3 | 646456992.3 | -1.0 | bitexact | 5 | 0 | 0 | log-domain DSP |
+| `lns64` | 64 | 1/63/0 | 0 | 0.3 | 2.7765116442616786e+18 | -1.0 | bitexact | 5 | 0 | 0 | scientific log-domain |
+
+### Расширенные float (3)
+
+| Формат | Бит | S/E/M | Bias | Знач. цифр | Дин. диап. (дек) | φ-расст. | SW-conf. | n_vec | decode-HW | compute-HW | Назначение |
+|---|--:|---|--:|--:|--:|--:|---|--:|---|---|---|
+| `x87_fp80` | 80 | 1/15/64 | 16383 | 19.6 | 9863.2 | -1.0 | bitexact | 8 | 0 | 0 | legacy long double on x86 |
+| `double_double` | 128 | 2/22/104 | 0 | 31.6 | 1262610.4 | -1.0 | bitexact | 8 | 0 | 0 | software extended precision |
+| `quad_double` | 256 | 4/44/208 | 0 | 62.9 | 5295775688669.6 | -1.0 | bitexact | 8 | 0 | 0 | astrophysics, quad-precision sims |
+
+### IEEE-754 decimal (3)
+
+| Формат | Бит | S/E/M | Bias | Знач. цифр | Дин. диап. (дек) | φ-расст. | SW-conf. | n_vec | decode-HW | compute-HW | Назначение |
+|---|--:|---|--:|--:|--:|--:|---|--:|---|---|---|
+| `decimal32` | 32 | 1/11/20 | 101 | 6.3 | 615.6 | -1.0 | bitexact | 7 | 0 | 0 | banking, GAAP |
+| `decimal64` | 64 | 1/13/50 | 398 | 15.4 | 2465.1 | -1.0 | bitexact | 7 | 0 | 0 | financial databases |
+| `decimal128` | 128 | 1/17/110 | 6176 | 33.4 | 39455.7 | -1.0 | bitexact | 8 | 0 | 0 | audit ledgers |
+
+### Integer / fixed-point (8)
+
+| Формат | Бит | S/E/M | Bias | Знач. цифр | Дин. диап. (дек) | φ-расст. | SW-conf. | n_vec | decode-HW | compute-HW | Назначение |
+|---|--:|---|--:|--:|--:|--:|---|--:|---|---|---|
+| `bcd` | 0 | 0/0/0 | 0 | 0.3 | — | -1.0 | structural | 0 | 0 | 0 | calculators, GAAP |
+| `q_format` | 0 | 1/0/0 | 0 | 0.3 | — | -1.0 | structural | 0 | 0 | 0 | audio DSP, fixed-point ML |
+| `int4` | 4 | 1/0/3 | 0 | 1.2 | — | -1.0 | bitexact | 16 | 0 | 0 | aggressive quantization |
+| `int8` | 8 | 1/0/7 | 0 | 2.4 | — | -1.0 | bitexact | 256 | **1**  [измерено: 256/256 exhaustive; C:design on main, log≠#199] | 0 | INT8 inference, per-channel scale |
+| `int16` | 16 | 1/0/15 | 0 | 4.8 | — | -1.0 | bitexact | 7 | 0 | 0 | DSP, embedded ML |
+| `int32` | 32 | 1/0/31 | 0 | 9.6 | — | -1.0 | bitexact | 7 | 0 | 0 | general CPU integer |
+| `int64` | 64 | 1/0/63 | 0 | 19.3 | — | -1.0 | bitexact | 7 | 0 | 0 | databases, timestamps |
+| `int128` | 128 | 1/0/127 | 0 | 38.5 | — | -1.0 | bitexact | 7 | 0 | 0 | crypto, big-int |
+
+### Исторические/вендорные (10)
+
+| Формат | Бит | S/E/M | Bias | Знач. цифр | Дин. диап. (дек) | φ-расст. | SW-conf. | n_vec | decode-HW | compute-HW | Назначение |
+|---|--:|---|--:|--:|--:|--:|---|--:|---|---|---|
+| `ibm_hfp32` | 32 | 1/7/24 | 64 | 7.5 | 37.9 | -1.0 | bitexact | 8 | 0 | 0 | legacy mainframe |
+| `ms_mbf32` | 32 | 1/8/23 | 129 | 7.2 | 76.5 | -1.0 | bitexact | 8 | 0 | 0 | MS BASIC legacy |
+| `vax_f` | 32 | 1/8/23 | 128 | 7.2 | 76.5 | -1.0 | bitexact | 8 | 0 | 0 | DEC legacy |
+| `cray_float` | 64 | 1/15/48 | 16384 | 14.8 | 9863.2 | -1.0 | bitexact | 8 | 0 | 0 | Cray legacy |
+| `ibm_hfp64` | 64 | 1/7/56 | 64 | 17.2 | 37.9 | -1.0 | bitexact | 8 | 0 | 0 | legacy mainframe |
+| `ms_mbf64` | 64 | 1/8/55 | 129 | 16.9 | 76.5 | -1.0 | bitexact | 8 | 0 | 0 | MS BASIC legacy |
+| `vax_d` | 64 | 1/8/55 | 128 | 16.9 | 76.5 | -1.0 | bitexact | 8 | 0 | 0 | DEC legacy double |
+| `vax_g` | 64 | 1/11/52 | 1024 | 16.0 | 615.9 | -1.0 | bitexact | 8 | 0 | 0 | DEC legacy |
+| `ibm_hfp128` | 128 | 1/7/120 | 64 | 36.4 | 37.9 | -1.0 | bitexact | 8 | 0 | 0 | legacy mainframe |
+| `vax_h` | 128 | 1/15/112 | 16384 | 34.0 | 9863.2 | -1.0 | bitexact | 8 | 0 | 0 | DEC quad |
+
+### Сжатие (4)
+
+| Формат | Бит | S/E/M | Bias | Знач. цифр | Дин. диап. (дек) | φ-расст. | SW-conf. | n_vec | decode-HW | compute-HW | Назначение |
+|---|--:|---|--:|--:|--:|--:|---|--:|---|---|---|
+| `block_fp` | 0 | 0/0/0 | 0 | 0.3 | — | -1.0 | structural | 0 | 0 | 0 | per-tile shared exponent |
+| `shared_exp` | 0 | 0/0/0 | 0 | 0.3 | — | -1.0 | structural | 0 | 0 | 0 | LLM quantization |
+| `stochastic_rounding` | 0 | 0/0/0 | 0 | 0.3 | — | -1.0 | structural | 0 | 0 | 0 | training small networks at low precision |
+| `per_channel_scale` | 8 | 1/0/7 | 0 | 2.4 | — | -1.0 | structural | 0 | 0 | 0 | standard quant inference |
+
+### Теоретические (4)
+
+| Формат | Бит | S/E/M | Bias | Знач. цифр | Дин. диап. (дек) | φ-расст. | SW-conf. | n_vec | decode-HW | compute-HW | Назначение |
+|---|--:|---|--:|--:|--:|--:|---|--:|---|---|---|
+| `minifloat` | 0 | 1/0/0 | 0 | 0.3 | — | -1.0 | structural | 0 | 0 | 0 | design space of GF4/GF8/GF12/GF16 |
+| `tapered_fp` | 0 | 1/0/0 | 0 | 0.3 | — | -1.0 | structural | 0 | 0 | 0 | variable mantissa via regime bits |
+| `unum_i` | 0 | 1/0/0 | 0 | 0.3 | — | -1.0 | structural | 0 | 0 | 0 | interval arithmetic |
+| `unum_ii` | 0 | 0/0/0 | 0 | 0.3 | — | -1.0 | structural | 0 | 0 | 0 | lookup-table real arithmetic; not GF-comparabl |
+
+---
+
+## 4. Известные оговорки честности
+
+- `gf128`, `gf256` показывают `bias=0` — это значение из текущих экспериментальных спецификаций SSOT (не финализированы), а не «отсутствие смещения». Помечены статусом Experimental.
+- `gf256` — единственный GoldenFloat со статусом `structural` (нет числовых векторов); остальные крупные GF (`gf14/48/96/512/1024`) — `self-consistent` (слабее bitexact).
+- Все 22 формата кластера GoldenFloat имеют `gf_relation: self`; 61 внешний формат — референсные (competitor/ally/orthogonal) для сравнения, не часть собственной архитектуры Trinity.
+- Динамический диапазон для gf512/gf1024 посчитан в log-домене из-за переполнения double — порядок верен, последние цифры — оценка.
+
+Источник истины: [t27 / FORMAT-SPEC-001.json](https://github.com/gHashTag/t27/blob/master/conformance/FORMAT-SPEC-001.json), [INDEX_all_formats.json](https://github.com/gHashTag/t27/blob/master/conformance/vectors/INDEX_all_formats.json), [gen/numeric/formats_catalog.json](https://github.com/gHashTag/t27/blob/master/gen/numeric/formats_catalog.json). HW-доказательства: [trinity-fpga #199](https://github.com/gHashTag/trinity-fpga/issues/199).

--- a/docs/metrics/build_metrics.py
+++ b/docs/metrics/build_metrics.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Свод ключевых метрик 83 числовых форматов каталога t27 (SSOT).
+Источники: gen/numeric/formats_catalog.json (77) + specs/numeric/gf*.t27 (6) +
+conformance/vectors/INDEX_all_formats.json (kind/n_vectors) + HW-статус сессии 28.06.2026.
+ЧЕСТНОСТЬ: HW = только реально измеренное на AX7203. Покрытие тегируется.
+"""
+import json, math, csv, re
+
+cat = json.load(open('/tmp/cat.json'))['formats']
+idx = json.load(open('/tmp/idx.json'))['packs']
+ix = {p['id']: p for p in idx}
+
+# --- 6 GF форматов, отсутствующих в catalog.json (взяты из specs/numeric/*.t27) ---
+gf_extra = {
+ 'gf10':  dict(bits=10,  s_bits=1, e_bits=3,  m_bits=6),
+ 'gf14':  dict(bits=14,  s_bits=1, e_bits=5,  m_bits=8),
+ 'gf48':  dict(bits=48,  s_bits=1, e_bits=18, m_bits=29),
+ 'gf96':  dict(bits=96,  s_bits=1, e_bits=36, m_bits=59),
+ 'gf512': dict(bits=512, s_bits=1, e_bits=195,m_bits=316),
+ 'gf1024':dict(bits=1024,s_bits=1, e_bits=391,m_bits=632),
+}
+for fid, g in gf_extra.items():
+    g.update(id=fid, name=f"GoldenFloat {fid.upper()} ({g['bits']}-bit)",
+             bias=(2**(g['e_bits']-1)-1) if g['e_bits'] else 0,
+             cluster='GoldenFloat', status='Experimental', standard='Trinity GoldenFloat',
+             use_case='расширенный диапазон GF-семейства', gf_relation='self',
+             source='specs/numeric/'+fid+'.t27', phi_distance=None, storage=f"u{g['bits']}")
+
+formats = {f['id']: f for f in cat}
+formats.update(gf_extra)
+
+# --- HW-статус (только измеренное на железе, сессия 28.06.2026) ---
+# E = полная цепь доказательств опубликована на #199 (CI run + SHA + flash log)
+# C = self-report локального агента + дизайн на main, UART-лог ещё не на #199
+HW = {
+ 'bfloat16':    dict(decode_hw='1 [измерено: 8/8 corner; E:#199 run 28326217079]'),
+ 'int8':        dict(decode_hw='1 [измерено: 256/256 exhaustive; C:design on main, log≠#199]'),
+ 'nf4':         dict(decode_hw='1 [измерено: 16/16 exhaustive; C:design on main, log≠#199]'),
+ 'fp8_e4m3':    dict(decode_hw='1 [измерено: 256/256 exhaustive; C:design on main, log≠#199]'),
+ 'gf6':         dict(compute_hw='1 [измерено: 512/512 bit-exact; E:#199 artifact 7931202948]'),
+ 'gf8':         dict(compute_hw='1 [измерено: 512/512 bit-exact; E:#199 post-fix c0d24cac2]'),
+}
+
+def dynamic_range_decades(e_bits, m_bits, bias):
+    """Грубая оценка десятичного динамического диапазона нормальных чисел."""
+    if not e_bits: return None
+    emax = (2**e_bits - 1) - 1 - bias  # минус 1 на Inf/NaN-кодировку (IEEE-like)
+    emin = 1 - bias
+    try:
+        hi = (2 - 2**-m_bits) * (2.0**emax)
+        lo = 2.0**emin
+        return round(math.log10(hi) - math.log10(lo), 1)
+    except (OverflowError, ValueError):
+        # для очень больших экспонент считаем в log-домене
+        return round((emax - emin) * math.log10(2), 1)
+
+def decimal_digits(m_bits):
+    if m_bits is None: return None
+    return round((m_bits + 1) * math.log10(2), 1)  # +1 implicit
+
+rows = []
+for fid, f in formats.items():
+    p = ix.get(fid, {})
+    e = f.get('e_bits'); m = f.get('m_bits'); bias = f.get('bias', 0)
+    hw = HW.get(fid, {})
+    rows.append(dict(
+        id=fid,
+        name=f.get('name', fid),
+        bits=f.get('bits'),
+        layout=f"{f.get('s_bits','?')}/{e if e is not None else '?'}/{m if m is not None else '?'}",
+        bias=bias,
+        decimal_digits=decimal_digits(m),
+        dyn_range_dec=dynamic_range_decades(e, m, bias) if e else None,
+        phi_distance=f.get('phi_distance'),
+        cluster=f.get('cluster','?'),
+        gf_relation=f.get('gf_relation','?'),
+        status=f.get('status','?'),
+        standard=f.get('standard','?'),
+        use_case=f.get('use_case','?'),
+        # conformance (SSOT INDEX)
+        sw_kind=p.get('kind','(нет в INDEX)'),
+        sw_vectors=p.get('n_vectors'),
+        # HW (только реально измеренное)
+        decode_hw=hw.get('decode_hw','0'),
+        compute_hw=hw.get('compute_hw','0'),
+        source=f.get('source','?'),
+    ))
+
+# сортировка: GoldenFloat сначала (по битам), потом по кластеру/битам
+cluster_order = ['GoldenFloat','Ieee754Binary','MlLowPrecision','Microscaling','QuantTuned',
+                 'PositUnumIII','Lns','ExtendedFloat','Ieee754Decimal','IntegerFixed',
+                 'HistoricalVendor','CompressionTrick','Theoretical']
+def sk(r):
+    c = r['cluster']
+    return (cluster_order.index(c) if c in cluster_order else 99, r['bits'] or 0, r['id'])
+rows.sort(key=sk)
+
+# --- CSV ---
+cols = ['id','name','bits','layout','bias','decimal_digits','dyn_range_dec','phi_distance',
+        'cluster','gf_relation','status','standard','use_case','sw_kind','sw_vectors',
+        'decode_hw','compute_hw','source']
+with open('/home/user/workspace/metrics_83/metrics_83_formats.csv','w',newline='',encoding='utf-8') as fh:
+    w = csv.DictWriter(fh, fieldnames=cols); w.writeheader()
+    for r in rows: w.writerow(r)
+
+json.dump(rows, open('/home/user/workspace/metrics_83/metrics_83.json','w'), ensure_ascii=False, indent=1)
+
+# --- сводка ---
+from collections import Counter
+print("ИТОГО форматов:", len(rows))
+print("По кластерам:", dict(Counter(r['cluster'] for r in rows)))
+print("SW kind:", dict(Counter(r['sw_kind'] for r in rows)))
+print("decode-HW >0:", [r['id'] for r in rows if r['decode_hw']!='0'])
+print("compute-HW >0:", [r['id'] for r in rows if r['compute_hw']!='0'])
+print("Σ SW vectors:", sum(r['sw_vectors'] or 0 for r in rows))

--- a/docs/metrics/numeric_formats_83_metrics.csv
+++ b/docs/metrics/numeric_formats_83_metrics.csv
@@ -1,0 +1,84 @@
+id,name,bits,layout,bias,decimal_digits,dyn_range_dec,phi_distance,cluster,gf_relation,status,standard,use_case,sw_kind,sw_vectors,decode_hw,compute_hw,source
+gfternary,GFTernary,2,1/0/2,0,0.9,,0.0,GoldenFloat,self,Verified,"this work; {-phi, 0, +phi}",bulk layers (hybrid),bitexact,4,0,0,BENCH-007
+gf4,GF4,4,1/1/2,0,0.9,-0.1,0.118,GoldenFloat,self,Experimental,this work; F0 minimal,proof-of-concept,bitexact,16,0,0,specs/numeric/gf4.t27
+mxgf4,MXGF4 (microscaling GF4),4,1/1/2,0,0.9,-0.1,0.118,GoldenFloat,experimental,Experimental,this work; OCP MX block + GF4,OPEN R&D: phi-aligned MX-4 candidate,bitexact,16,0,0,section12.5
+gf6,GF6 (predicted),6,1/2/3,1,1.2,0.6,0.05,GoldenFloat,experimental,Experimental,"this work; e=round(5/phi^2)=2, fills FP6 gap",OPEN R&D: bridge GF4-GF8; FP6 E2M3 hint,bitexact,64,0,1 [измерено: 512/512 bit-exact; E:#199 artifact 7931202948],section12.5
+mxgf6,MXGF6 (microscaling GF6),6,1/2/3,1,1.2,0.6,0.05,GoldenFloat,experimental,Experimental,this work; OCP MX block + GF6,OPEN R&D: phi-aligned MX-6 candidate,bitexact,64,0,0,section12.5
+gf8,GF8,8,1/3/4,3,1.5,1.8,0.132,GoldenFloat,self,Verified,this work; L1 Lucas,edge / sensors,bitexact,256,0,1 [измерено: 512/512 bit-exact; E:#199 post-fix c0d24cac2],BENCH-007 (specs/numeric/gf8.t27)
+gf8_bfp,GF8-BFP (block FP atop GF8),8,1/3/4,3,1.5,1.8,0.132,GoldenFloat,experimental,Experimental,this work; per-tile shared exponent,OPEN R&D: LLM-quantization-friendly GF8,bitexact,256,0,0,section12.5
+gf10,GoldenFloat GF10 (10-bit),10,1/3/6,3,2.1,1.8,,GoldenFloat,self,Experimental,Trinity GoldenFloat,расширенный диапазон GF-семейства,bitexact,8,0,0,specs/numeric/gf10.t27
+gf12,GF12,12,1/4/7,7,2.4,4.2,0.047,GoldenFloat,self,Verified,this work; L0/F3,mid-range / audio,bitexact,8,0,0,BENCH-007 (specs/numeric/gf12.t27)
+gf14,GoldenFloat GF14 (14-bit),14,1/5/8,15,2.7,9.0,,GoldenFloat,self,Experimental,Trinity GoldenFloat,расширенный диапазон GF-семейства,bitexact_selfconsistent,,0,0,specs/numeric/gf14.t27
+gf16,GF16,16,1/6/9,31,3.0,18.7,0.049,GoldenFloat,self,Verified,this work; PHI_BIAS=60; FPGA 35/35 at 323 MHz Artix-7,training and inference (production),bitexact,,0,0,specs/numeric/gf16.t27; zenodo 10.5281/zenodo.19227877 (HW archive)
+gf_lns_hybrid,GF + LNS hybrid (dual-space),16,1/6/9,31,3.0,18.7,0.049,GoldenFloat,experimental,Experimental,"this work; mul in log-space, accumulate Lucas-closed",OPEN R&D: dual-space arithmetic,bitexact,8,0,0,section12.5
+gf20,GF20,20,1/7/12,63,3.9,37.9,0.035,GoldenFloat,self,Experimental,this work; 17-squared empirical PHI_BIAS=289,high-precision edge,bitexact,8,0,0,specs/numeric/gf20.t27 (spec only)
+gf24,GF24,24,1/9/14,255,4.5,153.5,0.025,GoldenFloat,self,Experimental,this work; L15 PHI_BIAS=1364,server inference,bitexact,8,0,0,specs/numeric/gf24.t27 (spec only)
+gf32,GF32,32,1/12/19,2047,6.0,1232.1,0.014,GoldenFloat,self,Verified,this work; F0 resolved,fp32 drop-in,bitexact,8,0,0,BENCH-012 (specs/numeric/gf32.t27)
+gf48,GoldenFloat GF48 (48-bit),48,1/18/29,131071,9.0,78912.3,,GoldenFloat,self,Experimental,Trinity GoldenFloat,расширенный диапазон GF-семейства,bitexact_selfconsistent,,0,0,specs/numeric/gf48.t27
+gf64,GF64,64,1/24/39,8388607,12.0,5050444.4,0.003,GoldenFloat,self,Verified,this work; EXP_MAX - BIAS,scientific / double,bitexact,8,0,0,BENCH-007b (specs/numeric/gf64.t27)
+gf96,GoldenFloat GF96 (96-bit),96,1/36/59,34359738367,18.1,20686623783.0,,GoldenFloat,self,Experimental,Trinity GoldenFloat,расширенный диапазон GF-семейства,bitexact_selfconsistent,,0,0,specs/numeric/gf96.t27
+gf128,GF128 (predicted),128,1/48/79,0,24.1,84732411018727.1,0.008,GoldenFloat,experimental,Experimental,this work; e=round(127/phi^2)=48 (Open: bias TBD),OPEN R&D: phi-aligned binary128 alternative,bitexact_selfconsistent,,0,0,section12.5
+gf256,GF256 (predicted),256,1/97/158,0,47.9,4.770010683626838e+28,0.005,GoldenFloat,experimental,Experimental,this work; e=round(255/phi^2)=97 (Open: bias ~2^71 unconfirmed),OPEN R&D: phi-aligned binary256 alternative,structural,0,0,0,section12.5; bias Open per skill
+gf512,GoldenFloat GF512 (512-bit),512,1/195/316,25108406941546723055343157692830665664409421777856138051583,95.4,1.511676726548657e+58,,GoldenFloat,self,Experimental,Trinity GoldenFloat,расширенный диапазон GF-семейства,bitexact_selfconsistent,,0,0,specs/numeric/gf512.t27
+gf1024,GoldenFloat GF1024 (1024-bit),1024,1/391/632,2521728396569246669585858566409191283525103313309788586748690777871726193375821479130513040312634601011624191379636223,190.6,1.5182317765699572e+117,,GoldenFloat,self,Experimental,Trinity GoldenFloat,расширенный диапазон GF-семейства,bitexact_selfconsistent,,0,0,specs/numeric/gf1024.t27
+binary16,"binary16 (fp16, half)",16,1/5/10,15,3.3,9.0,0.118,Ieee754Binary,competitor,Verified,IEEE 754-2008,"GPU activations, inference",bitexact,8,0,0,IEEE 754-2008
+binary32,"binary32 (fp32, single)",32,1/8/23,127,7.2,76.5,0.27,Ieee754Binary,competitor,Verified,IEEE 754-1985,industry default,bitexact,8,0,0,IEEE 754-1985
+binary64,"binary64 (fp64, double)",64,1/11/52,1023,16.0,615.9,0.406,Ieee754Binary,competitor,Verified,IEEE 754-1985,scientific computing,bitexact,8,0,0,IEEE 754-1985
+binary128,"binary128 (fp128, quad)",128,1/15/112,16383,34.0,9863.2,0.484,Ieee754Binary,competitor,Verified,IEEE 754-2008,high-precision simulations,bitexact,8,0,0,IEEE 754-2008
+binary256,binary256 (octuple),256,1/19/236,262143,71.3,157825.5,0.538,Ieee754Binary,competitor,Verified,IEEE 754-2008,"astronomy, cryptography",bitexact,8,0,0,IEEE 754-2008
+fp4_e2m1,FP4 E2M1,4,1/2/1,1,0.6,0.5,1.382,MlLowPrecision,competitor,Verified,OCP MX,extreme quant inference,bitexact,16,0,0,OCP MX v1.0 (2023)
+fp6_e2m3,FP6 E2M3,6,1/2/3,1,1.2,0.6,0.049,MlLowPrecision,ally,Verified,OCP MX,mantissa-heavy quant,bitexact,64,0,0,OCP MX v1.0 (2023)
+fp6_e3m2,FP6 E3M2,6,1/3/2,3,0.9,1.7,0.882,MlLowPrecision,competitor,Verified,OCP MX,aggressive quant inference,bitexact,64,0,0,OCP MX v1.0 (2023)
+fp8_e4m3,FP8 E4M3,8,1/4/3,7,1.2,4.2,0.715,MlLowPrecision,competitor,Verified,OCP / NVIDIA / Arm / Intel,"inference, gradient ranges",bitexact,,"1 [измерено: 256/256 exhaustive; C:design on main, log≠#199]",0,Micikevicius 2022 (arXiv:2209.05433)
+fp8_e5m2,FP8 E5M2,8,1/5/2,15,0.9,9.0,1.882,MlLowPrecision,competitor,Verified,OCP / NVIDIA,"activations, wide range",bitexact,,0,0,Micikevicius 2022
+bfloat16,bfloat16 (BF16),16,1/8/7,127,2.4,76.5,0.525,MlLowPrecision,competitor,Verified,Google Brain,training (range > precision),bitexact,,1 [измерено: 8/8 corner; E:#199 run 28326217079],0,Wang-Kanwar 2019
+tf32,TensorFloat-32 (TF32),19,1/8/10,127,3.3,76.5,0.27,MlLowPrecision,competitor,Verified,NVIDIA Ampere,A100/H100 mixed precision,bitexact,8,0,0,NVIDIA Ampere whitepaper
+mxfp4,MXFP4,4,1/2/1,1,0.6,0.5,1.382,Microscaling,ally,Verified,OCP MX v1.0,extreme quant,bitexact,,0,0,Rouhani 2023
+mxfp6,MXFP6,6,1/3/2,3,0.9,1.7,0.882,Microscaling,ally,Verified,OCP MX v1.0,aggressive inference,bitexact,64,0,0,Rouhani 2023
+mxfp8,MXFP8,8,1/4/3,7,1.2,4.2,0.715,Microscaling,ally,Verified,OCP MX v1.0,LLM inference,bitexact,256,0,0,Rouhani 2023 (arXiv:2310.10537)
+nf4,NF4 (NormalFloat 4-bit),4,0/0/4,0,1.5,,-1.0,QuantTuned,orthogonal,Verified,Dettmers 2023 (QLoRA),"LLM weight quantization (quantile-based on N(0,1))",bitexact,16,"1 [измерено: 16/16 exhaustive; C:design on main, log≠#199]",0,Dettmers 2023 (arXiv:2305.14314)
+afp,AFP (Adaptive Floating-Point),16,1/8/7,127,2.4,76.5,-1.0,QuantTuned,orthogonal,Verified,Tambe 2020,efficient training,structural,0,0,0,Tambe 2020 (DAC)
+posit8,Posit8,8,1/2/0,0,0.3,0.3,-1.0,PositUnumIII,ally,Verified,Posit Standard 2022 (es=2),inference,bitexact,256,0,0,Posit Standard 2022 (posithub.org)
+takum8,takum8,8,1/0/0,0,0.3,,-1.0,PositUnumIII,ally,Verified,Hunhold 2024 (tapered-precision),IEEE-754 backward-compatible tapered,bitexact,256,0,0,Hunhold 2024 (arXiv:2412.20273)
+posit16,Posit16,16,1/2/0,0,0.3,0.3,-1.0,PositUnumIII,ally,Verified,Posit Standard 2022 (es=2),mixed-precision training,bitexact,8,0,0,Posit Standard 2022
+takum16,takum16,16,1/0/0,0,0.3,,-1.0,PositUnumIII,ally,Verified,Hunhold 2024,single-rule ladder counterexample,structural,0,0,0,Hunhold 2024 (arXiv:2412.20273)
+posit32,Posit32,32,1/2/0,0,0.3,0.3,-1.0,PositUnumIII,ally,Verified,Posit Standard 2022 (es=2),f32 replacement,bitexact,8,0,0,Posit Standard 2022
+takum32,takum32,32,1/0/0,0,0.3,,-1.0,PositUnumIII,ally,Verified,Hunhold 2024,tapered fp32-class,structural,0,0,0,Hunhold 2024
+posit64,Posit64,64,1/2/0,0,0.3,0.3,-1.0,PositUnumIII,ally,Verified,Posit Standard 2022 (es=2),f64 replacement,bitexact,8,0,0,Posit Standard 2022
+takum64,takum64,64,1/0/0,0,0.3,,-1.0,PositUnumIII,ally,Verified,Hunhold 2024,tapered fp64-class,structural,0,0,0,Hunhold 2024
+lns8,LNS-8,8,1/7/0,0,0.3,37.6,-1.0,Lns,orthogonal,Verified,Arnold 1990; LNS-Madam (2021),"DSP, signal processing",bitexact,256,0,0,Alam 2021 (arXiv:2106.13914)
+lns16,LNS-16,16,1/15/0,0,0.3,9863.2,-1.0,Lns,orthogonal,Verified,LNS-Madam (2021),log-domain training (mul -> add),bitexact,5,0,0,Alam 2021
+lns32,LNS-32,32,1/31/0,0,0.3,646456992.3,-1.0,Lns,orthogonal,Verified,LNS-Madam (2021),log-domain DSP,bitexact,5,0,0,Alam 2021
+lns64,LNS-64,64,1/63/0,0,0.3,2.7765116442616786e+18,-1.0,Lns,orthogonal,Verified,LNS-Madam (2021),scientific log-domain,bitexact,5,0,0,Alam 2021
+x87_fp80,x87 FP80,80,1/15/64,16383,19.6,9863.2,-1.0,ExtendedFloat,orthogonal,Historical,Intel x87 (explicit integer bit),legacy long double on x86,bitexact,8,0,0,Intel SDM
+double_double,double-double,128,2/22/104,0,31.6,1262610.4,-1.0,ExtendedFloat,orthogonal,Verified,Bailey/Hida (software),software extended precision,bitexact,8,0,0,Bailey-Hida 2001
+quad_double,quad-double,256,4/44/208,0,62.9,5295775688669.6,-1.0,ExtendedFloat,orthogonal,Verified,Bailey/Hida (software),"astrophysics, quad-precision sims",bitexact,8,0,0,Bailey-Hida 2001
+decimal32,decimal32,32,1/11/20,101,6.3,615.6,-1.0,Ieee754Decimal,orthogonal,Verified,IEEE 754-2008 (DPD/BID),"banking, GAAP",bitexact,7,0,0,IEEE 754-2008
+decimal64,decimal64,64,1/13/50,398,15.4,2465.1,-1.0,Ieee754Decimal,orthogonal,Verified,IEEE 754-2008,financial databases,bitexact,7,0,0,IEEE 754-2008
+decimal128,decimal128,128,1/17/110,6176,33.4,39455.7,-1.0,Ieee754Decimal,orthogonal,Verified,IEEE 754-2008,audit ledgers,bitexact,8,0,0,IEEE 754-2008
+bcd,BCD (binary-coded decimal),0,0/0/0,0,0.3,,-1.0,IntegerFixed,orthogonal,Historical,IBM 1959,"calculators, GAAP",structural,0,0,0,ISO/IEC 8859
+q_format,Q-format (Qm.n),0,1/0/0,0,0.3,,-1.0,IntegerFixed,orthogonal,Verified,TI fixed-point,"audio DSP, fixed-point ML",structural,0,0,0,TI SPRA704
+int4,INT4 / UINT4,4,1/0/3,0,1.2,,-1.0,IntegerFixed,competitor,Verified,two complement,aggressive quantization,bitexact,16,0,0,ISO/IEC 9899
+int8,INT8 / UINT8,8,1/0/7,0,2.4,,-1.0,IntegerFixed,competitor,Verified,two complement,"INT8 inference, per-channel scale",bitexact,256,"1 [измерено: 256/256 exhaustive; C:design on main, log≠#199]",0,ISO/IEC 9899
+int16,INT16 / UINT16,16,1/0/15,0,4.8,,-1.0,IntegerFixed,competitor,Verified,two complement,"DSP, embedded ML",bitexact,7,0,0,ISO/IEC 9899
+int32,INT32 / UINT32,32,1/0/31,0,9.6,,-1.0,IntegerFixed,competitor,Verified,two complement,general CPU integer,bitexact,7,0,0,ISO/IEC 9899
+int64,INT64 / UINT64,64,1/0/63,0,19.3,,-1.0,IntegerFixed,competitor,Verified,two complement,"databases, timestamps",bitexact,7,0,0,ISO/IEC 9899
+int128,INT128 / UINT128,128,1/0/127,0,38.5,,-1.0,IntegerFixed,competitor,Verified,two complement,"crypto, big-int",bitexact,7,0,0,Rust/Clang u128
+ibm_hfp32,IBM HFP (single),32,1/7/24,64,7.5,37.9,-1.0,HistoricalVendor,orthogonal,Historical,IBM System/360 (1964); base-16 exponent,legacy mainframe,bitexact,8,0,0,IBM POO
+ms_mbf32,Microsoft MBF (single),32,1/8/23,129,7.2,76.5,-1.0,HistoricalVendor,orthogonal,Historical,MS BASIC / MS-DOS (pre-IEEE),MS BASIC legacy,bitexact,8,0,0,MS-DOS docs
+vax_f,VAX F-float,32,1/8/23,128,7.2,76.5,-1.0,HistoricalVendor,orthogonal,Historical,DEC VAX,DEC legacy,bitexact,8,0,0,VAX Architecture Reference
+cray_float,Cray float,64,1/15/48,16384,14.8,9863.2,-1.0,HistoricalVendor,orthogonal,Historical,"Cray-1 (1976); no NaN/Inf, unrounded mul",Cray legacy,bitexact,8,0,0,Cray-1 Hardware Reference
+ibm_hfp64,IBM HFP (double),64,1/7/56,64,17.2,37.9,-1.0,HistoricalVendor,orthogonal,Historical,IBM System/360 (1964),legacy mainframe,bitexact,8,0,0,IBM POO
+ms_mbf64,Microsoft MBF (double),64,1/8/55,129,16.9,76.5,-1.0,HistoricalVendor,orthogonal,Historical,MS BASIC,MS BASIC legacy,bitexact,8,0,0,MS-DOS docs
+vax_d,VAX D-float,64,1/8/55,128,16.9,76.5,-1.0,HistoricalVendor,orthogonal,Historical,DEC VAX,DEC legacy double,bitexact,8,0,0,VAX Architecture Reference
+vax_g,VAX G-float,64,1/11/52,1024,16.0,615.9,-1.0,HistoricalVendor,orthogonal,Historical,DEC VAX (IEEE-like),DEC legacy,bitexact,8,0,0,VAX Architecture Reference
+ibm_hfp128,IBM HFP (extended),128,1/7/120,64,36.4,37.9,-1.0,HistoricalVendor,orthogonal,Historical,IBM z/Architecture,legacy mainframe,bitexact,8,0,0,IBM POO
+vax_h,VAX H-float,128,1/15/112,16384,34.0,9863.2,-1.0,HistoricalVendor,orthogonal,Historical,DEC VAX,DEC quad,bitexact,8,0,0,VAX Architecture Reference
+block_fp,block floating point (BFP),0,0/0/0,0,0.3,,-1.0,CompressionTrick,ally,Verified,Wilkinson 1965; modern revivals,per-tile shared exponent,structural,0,0,0,Darvish-Rouhani 2020
+shared_exp,shared-exponent formats,0,0/0/0,0,0.3,,-1.0,CompressionTrick,ally,Verified,generalised BFP,LLM quantization,structural,0,0,0,Darvish-Rouhani 2020
+stochastic_rounding,stochastic rounding (technique),0,0/0/0,0,0.3,,-1.0,CompressionTrick,ally,Verified,Gupta 2015,training small networks at low precision,structural,0,0,0,Gupta 2015 (ICML)
+per_channel_scale,INT8 with per-channel scale,8,1/0/7,0,2.4,,-1.0,CompressionTrick,competitor,Verified,Jacob 2018 (TFLite),standard quant inference,structural,0,0,0,Jacob 2018 (CVPR)
+minifloat,"minifloat (arbitrary E:M, <=16 bits)",0,1/0/0,0,0.3,,-1.0,Theoretical,ally,Experimental,parametric framework,design space of GF4/GF8/GF12/GF16,structural,0,0,0,Higham 1996
+tapered_fp,tapered floating point,0,1/0/0,0,0.3,,-1.0,Theoretical,ally,Experimental,Morris 1971; posit ancestor,variable mantissa via regime bits,structural,0,0,0,Morris 1971 (IEEE TC)
+unum_i,Unum I (tapered + ubound),0,1/0/0,0,0.3,,-1.0,Theoretical,ally,Experimental,Gustafson 2015 (predecessor to posit),interval arithmetic,structural,0,0,0,Gustafson 2015 (The End of Error)
+unum_ii,Unum II (SORN projective),0,0/0/0,0,0.3,,-1.0,Theoretical,orthogonal,Experimental,Gustafson 2016,lookup-table real arithmetic; not GF-comparable,structural,0,0,0,Gustafson 2016


### PR DESCRIPTION
## Что
Сводка ключевых метрик по всем 83 форматам каталога, производная от SSOT (`specs/numeric/formats_catalog.t27`). SSOT НЕ тронут.

## Файлы (docs/metrics/)
- `NUMERIC_FORMATS_83_METRICS.md` — компендиум метрик
- `numeric_formats_83_metrics.csv` — машиночитаемая таблица
- `build_metrics.py` — генератор из SSOT

## Honesty
- Каталог = **83** формата (не 84; расхождение с arXiv:2606.09686 = erratum).
- Тиры HW: decode-HW 4/83, compute-HW 2/83 (E/C), SW-bitexact 62/83.

Draft — на ревью. Слияние только по явному подтверждению.

Closes #1225