### PR TITLE
fix(ci): widen NOW freshness gate to accept east-of-UTC local dates

### DIFF
--- a/.github/workflows/now-sync-gate.yml
+++ b/.github/workflows/now-sync-gate.yml
@@ -46,18 +46,33 @@ jobs:
         if: env.IS_BOT != 'true'
         run: |
           set -euo pipefail
+          # Window is [YESTERDAY_UTC .. TOMORROW_UTC]. TOMORROW is included so a
+          # contributor in an east-of-UTC timezone (e.g. UTC+07) who stamps NOW.md
+          # with their LOCAL calendar date is not rejected when UTC is still on the
+          # previous day. A date older than YESTERDAY (stale NOW.md) or newer than
+          # TOMORROW (typo far in the future) still fails. Closes #1031 follow-up.
           TODAY=$(date -u +%Y-%m-%d)
           YESTERDAY=$(date -u -d yesterday +%Y-%m-%d)
+          TOMORROW=$(date -u -d tomorrow +%Y-%m-%d)
           LINE=$(grep -m1 "Last updated:" docs/NOW.md || true)
           LAST=""
           if [ -n "$LINE" ]; then
             LAST=$(echo "$LINE" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | head -1 || true)
           fi
-          if [ "$LAST" != "$TODAY" ] && [ "$LAST" != "$YESTERDAY" ]; then
+          if [ -z "$LAST" ]; then
+            echo "::error file=docs/NOW.md::NOW.md is missing a 'Last updated: YYYY-MM-DD' line."
+            exit 1
+          fi
+          # String compares are valid for zero-padded ISO-8601 (YYYY-MM-DD) dates.
+          if [ "$LAST" \< "$YESTERDAY" ]; then
             echo "::error::NOW.md date ($LAST) is too old. Update to $TODAY (UTC)."
             exit 1
           fi
-          echo "✅ NOW.md freshness check passed: $LAST (UTC window: $YESTERDAY .. $TODAY)"
+          if [ "$LAST" \> "$TOMORROW" ]; then
+            echo "::error::NOW.md date ($LAST) is too far in the future (> $TOMORROW UTC). Check for a typo."
+            exit 1
+          fi
+          echo "NOW.md freshness check passed: $LAST (UTC window: $YESTERDAY .. $TOMORROW)"
 
       - name: Check agent sync JSON exists
         if: env.IS_BOT != 'true'

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,6 +1,13 @@
 # NOW -- Trinity t27 sync
 
-Last updated: 2026-06-28
+Last updated: 2026-07-01
+
+## fix-now-freshness-gate-utc-window -- widen NOW freshness window to accept east-of-UTC local dates (Closes #1234)
+
+- **WHERE**: .github/workflows/now-sync-gate.yml (job check-now-freshness, step "Validate NOW.md date is today or recent").
+- **WHAT**: the freshness gate validated the NOW.md "Last updated" date against the UTC window [YESTERDAY_UTC .. TODAY_UTC] (two days). Widened it to [YESTERDAY_UTC .. TOMORROW_UTC] so a contributor in an east-of-UTC timezone (maintainer is UTC+07) who stamps NOW.md with their LOCAL calendar date is not rejected while UTC is still on the previous day. Older-than-yesterday still FAILS (stale-NOW protection kept); newer-than-tomorrow still FAILS (typo-in-future protection); a missing "Last updated:" line now fails with a clear message. ISO-8601 zero-padded dates compare correctly as strings, so no date parsing is added.
+- **Why**: the gate produced a systematic false-negative -- any PR opened after ~17:00 UTC (= 00:00 UTC+07) failed with a misleading "too old" error even though the date was in the (UTC) future. Observed on PR #1231 (NOW.md=2026-07-01, UTC=2026-06-30) which BLOCKED the stacked conformance-promote chain #1231 -> #1233. CI/workflow-only change; no spec, no conformance vector, no catalog count touched (stays 83). Logic self-tested locally against six boundary dates (PASS for yesterday/today/tomorrow UTC, FAIL for older, FAIL for far-future, FAIL for missing). Closes #1234.
+- **Anchor**: phi^2 + phi^-2 = 3
 
 ## conformance-promote-takum8-bitexact -- promote takum8 to strict SW-bitexact + fix takum arXiv citation (61->62/83) (Closes #1223)
 


### PR DESCRIPTION
## Summary
The required NOW Sync Gate job `check-now-freshness` validated the `docs/NOW.md` `Last updated` date against the UTC window `[YESTERDAY_UTC .. TODAY_UTC]`. For an east-of-UTC contributor (maintainer is UTC+07) who stamps NOW.md with their LOCAL calendar date, this is a systematic false-negative: the local "today" is rejected as "too old" while UTC is still on the previous day.

Observed on PR #1231 (NOW.md=`2026-07-01`, UTC=`2026-06-30` -> `NOW.md date (2026-07-01) is too old`), which currently BLOCKS the stacked conformance-promote chain #1231 -> #1233.

## Change
Widen the accepted window to `[YESTERDAY_UTC .. TOMORROW_UTC]`:
- `TOMORROW_UTC` accepted -> any east-of-UTC local "today" passes.
- Older than `YESTERDAY_UTC` still FAILS (stale-NOW protection preserved).
- Newer than `TOMORROW_UTC` still FAILS (typo-far-in-future protection).
- A missing `Last updated:` line now fails with a clear message.

ISO-8601 zero-padded dates compare correctly as strings -> no date parsing added. CI/workflow-only change; catalog stays 83; no spec, no conformance vector, no count touched.

## Verification
Logic self-tested locally on boundary dates: yesterday/today/tomorrow UTC PASS; older FAIL(too-old); far-future FAIL(future); missing line FAIL(no-date). YAML lints clean; `date -u -d tomorrow` supported on ubuntu-latest.

Closes #1234
