### PR TITLE
fix(codegen): iverilog-clean gen-verilog + BPSK modem spec

### DIFF
--- a/.trinity/seals/fpga_ZeroDSP_BPSK.json
+++ b/.trinity/seals/fpga_ZeroDSP_BPSK.json
@@ -1,0 +1,11 @@
+{
+  "gen_hash_c": "sha256:806c4431f9e62681a9b3ac524ea78e56805d2b3aedd65d7ecb63ed6a952dc051",
+  "gen_hash_rust": "sha256:36ad3d2afd297d74cda065fbeda4ba221a1b787a3a9eb5e272ba2722a5f8b94b",
+  "gen_hash_verilog": "sha256:a57097a6facd92b01f80b62670eac77f8e631b572684153e5b5665c31bde3d8c",
+  "gen_hash_zig": "sha256:4c3457a5566be651fd18e9c9d78132546c7bddd38ff9c483628efc97c66f365e",
+  "module": "ZeroDSP_BPSK",
+  "ring": 12,
+  "sealed_at": "2026-07-01T19:05:06Z",
+  "spec_hash": "sha256:c03511cef14c6a38652f65fdc0852cfc638dec039a96c9dc4cb6f04f49643228",
+  "spec_path": "specs/fpga/bpsk.t27"
+}

--- a/bootstrap/src/compiler.rs
+++ b/bootstrap/src/compiler.rs
@@ -1263,6 +1263,12 @@ impl Parser {
             {
                 self.skip_to_semicolon()?;
             }
+            // Consume trailing semicolon so the module-body loop is not left
+            // pointing at a stray ';' (which would error and skip subsequent
+            // const/var declarations via skip_to_next_top_level).
+            if self.current.kind == TokenKind::Semicolon {
+                self.advance();
+            }
             return Ok(decl);
         }
 
@@ -3848,8 +3854,26 @@ impl VerilogCodegen {
             self.write_line("// Registers (from struct declarations)");
             self.write_indent();
             self.write_line("// -------------------------------------------------------");
+            // Declare struct field regs under the module-level `var` name that
+            // holds the struct (e.g. `uart_state_status`), matching exactly what
+            // gen_verilog_expr emits for field access. Falling back to the struct
+            // type name (`uartstate_status`) leaves every field reference an
+            // undeclared identifier and breaks iverilog compilation.
+            let mut struct_var: std::collections::HashMap<String, String> =
+                std::collections::HashMap::new();
+            for c in &consts {
+                if c.extra_mutable && !c.extra_type.is_empty() {
+                    struct_var
+                        .entry(c.extra_type.clone())
+                        .or_insert_with(|| c.name.clone());
+                }
+            }
             for s in &structs {
-                self.gen_verilog_struct(s);
+                let prefix = struct_var
+                    .get(&s.name)
+                    .cloned()
+                    .unwrap_or_else(|| s.name.to_lowercase());
+                self.gen_verilog_struct(s, &prefix);
             }
             self.write_line("");
         }
@@ -4208,7 +4232,7 @@ impl VerilogCodegen {
         }
     }
 
-    fn gen_verilog_struct(&mut self, node: &Node) {
+    fn gen_verilog_struct(&mut self, node: &Node, reg_prefix: &str) {
         self.write_indent();
         self.write_line(&format!("// struct {}", node.name));
         for field in &node.children {
@@ -4237,7 +4261,7 @@ impl VerilogCodegen {
                 "reg {}{}{}_{}; // {}.{}{}",
                 signed_str,
                 range_str,
-                node.name.to_lowercase(),
+                reg_prefix,
                 field.name,
                 node.name,
                 field.name,
@@ -4312,18 +4336,26 @@ impl VerilogCodegen {
             };
             self.write_line(&format!("input {}{}{};", ps_str, pr_str, pname));
         }
+        // Verilog requires a function to have at least one input port. A
+        // zero-argument function reads module state and returns a value; give it
+        // an unused dummy input so iverilog/Yosys accept the declaration.
+        if node.params.is_empty() && node.extra_return_type != "void" {
+            self.write_indent();
+            self.write_line("input _unused;");
+        }
 
         // Emit body
         if node.children.is_empty() {
             self.write_indent();
             self.write_line("// TODO: implement");
         } else {
+            // Name the body block: Verilog-2001 forbids local declarations in an
+            // UNNAMED begin/end (a function that declares a local `reg` inside its
+            // body would need SystemVerilog otherwise).
             self.write_indent();
-            self.write_line("begin");
+            self.write_line(&format!("begin : {}_body", node.name));
             self.indent();
-            for stmt in &node.children {
-                self.gen_verilog_stmt(stmt);
-            }
+            self.gen_verilog_fn_body(&node.children);
             self.dedent();
             self.write_indent();
             self.write_line("end");
@@ -4340,6 +4372,45 @@ impl VerilogCodegen {
         }
         self.current_fn_name.clear();
         self.param_widths.clear();
+    }
+
+    /// Emit a Verilog function body statement list, rewriting the
+    /// `if (c) { return A }  <rest>` shape (guarded early return with no
+    /// else) into `if (c) begin ... end else begin <rest> end`. Because a
+    /// Verilog `return` is lowered to a blocking assignment to the function
+    /// name, a bare fall-through would let the trailing statements clobber
+    /// the guarded assignment (last write wins). Wrapping the remainder in an
+    /// else preserves the early-return semantics.
+    fn gen_verilog_fn_body(&mut self, stmts: &[Node]) {
+        for (idx, stmt) in stmts.iter().enumerate() {
+            let is_guarded_return = stmt.kind == NodeKind::StmtIf
+                && stmt.children.len() == 2 // [cond, then]; no else block
+                && stmt.children[1]
+                    .children
+                    .last()
+                    .map_or(false, |s| s.kind == NodeKind::ExprReturn);
+            if is_guarded_return && idx + 1 < stmts.len() {
+                // Emit: if (cond) begin <then> end else begin <rest> end
+                self.write_indent();
+                self.write("if (");
+                self.gen_verilog_expr(&stmt.children[0]);
+                self.write_line(") begin");
+                self.indent();
+                for s in &stmt.children[1].children {
+                    self.gen_verilog_stmt(s);
+                }
+                self.dedent();
+                self.write_indent();
+                self.write_line("end else begin");
+                self.indent();
+                self.gen_verilog_fn_body(&stmts[idx + 1..]);
+                self.dedent();
+                self.write_indent();
+                self.write_line("end");
+                return;
+            }
+            self.gen_verilog_stmt(stmt);
+        }
     }
 
     fn gen_verilog_test(&mut self, node: &Node) {
@@ -4658,15 +4729,27 @@ impl VerilogCodegen {
         match node.kind {
             NodeKind::ExprLiteral => {
                 let val = &node.value;
-                // Convert hex literals: 0xFF → 8'hFF
-                if val.starts_with("0x") || val.starts_with("0X") {
-                    let hex = &val[2..];
-                    let bits = hex.len() * 4;
-                    self.write(&format!("{}'h{}", bits, hex));
+                // Render integer literals as plain decimal (valid Verilog).
+                // Verilog rejects `0x..`/`0b..` and Rust-style `_` separators,
+                // so parse the numeric value and print it in base 10.
+                let clean: String = val.chars().filter(|&c| c != '_').collect();
+                if let Some(hex) = clean.strip_prefix("0x").or_else(|| clean.strip_prefix("0X")) {
+                    match u128::from_str_radix(hex, 16) {
+                        Ok(n) => self.write(&n.to_string()),
+                        Err(_) => self.write(val),
+                    }
+                } else if let Some(bin) = clean.strip_prefix("0b").or_else(|| clean.strip_prefix("0B")) {
+                    match u128::from_str_radix(bin, 2) {
+                        Ok(n) => self.write(&n.to_string()),
+                        Err(_) => self.write(val),
+                    }
                 } else if val == "true" {
                     self.write("1'b1");
                 } else if val == "false" {
                     self.write("1'b0");
+                } else if !clean.is_empty() && clean.chars().all(|c| c.is_ascii_digit()) {
+                    // Plain decimal, possibly with `_` separators — normalize.
+                    self.write(&clean);
                 } else {
                     self.write(val);
                 }

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,6 +1,12 @@
 # NOW -- Trinity t27 sync
 
-Last updated: 2026-07-01
+Last updated: 2026-07-02
+
+## gen-verilog-iverilog-clean -- fix backend lowering defects + BPSK modem spec (Closes #1245)
+
+- **WHERE** (compiler + fpga spec): `bootstrap/src/compiler.rs` gen-verilog/parser fixes so datapath specs emit iverilog-compilable RTL: (1) `parse_const_decl` consumes the trailing `;` so a run of consecutive const/var declarations is no longer dropped (uart went 1->8 localparams, 31->0 iverilog errors); (2) integer literals render as decimal (`0x`/`0b`/`_` -> valid Verilog); (3) a guarded early `return` in a function is rewritten to if/else (no last-write-wins clobber); (4) struct-field regs are declared under the holding `var` name (matching field access); (5) zero-argument functions get an unused dummy `input`; (6) function bodies use named `begin` blocks (Verilog-2001 forbids unnamed-block locals). The existing `ExprCast` cast handling is kept as-is. New `specs/fpga/bpsk.t27` (`ZeroDSP_BPSK`, the trios-mesh BPSK modem core) now **iverilog-compiles and simulates**: 13 embedded test assertions pass; hierarchical checks confirm correlate(Barker)=13, inversion=-13, sidelobes -5/+5, sync gate, frame=21. uart/mac now iverilog-clean too (fpga clean 1 -> 3 of 34).
+- **Why**: makes `.t27 -> Verilog RTL` synthesizable/simulatable for datapath specs instead of only structurally complete, on the path toward the Zynq/Artix FPGA carrying the trios-mesh radio. No numeric-format or L6 change. Committed seals for other specs whose Verilog changed will need a follow-up reseal sweep. Closes #1245.
+- **Anchor**: phi^2 + phi^-2 = 3
 
 ## fix-now-freshness-gate-utc-window -- widen NOW freshness window to accept east-of-UTC local dates (Closes #1234)
 

--- a/specs/fpga/bpsk.t27
+++ b/specs/fpga/bpsk.t27
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: Apache-2.0
+// t27/specs/fpga/bpsk.t27
+// ZeroDSP BPSK modem core (TRI-NET 5.8 GHz drone-mesh radio PHY).
+// Byte -> +/-1 BPSK serializer with a Barker-13 preamble, plus an integer
+// Barker-13 correlator + threshold for frame synchronization. Port of the
+// trios-mesh Rust modem's synthesizable core to the t27 spec-first language.
+// Datapath functions + state record only; clocking/ports are a backend concern.
+// phi^2 + 1/phi^2 = 3 | TRINITY
+
+module ZeroDSP_BPSK {
+    use base::types;
+
+    // Barker-13 chips packed into one 13-bit constant: bit k = chip k, with
+    // 1 => +1 symbol and 0 => -1 symbol, chip 0 in the LSB. The chip order is
+    // the transmit order [+1 +1 +1 +1 +1 -1 -1 +1 +1 -1 +1 -1 +1], matching the
+    // Rust modem's BARKER13. Packing as bits (not an array) keeps the whole
+    // module lowering to Verilog.
+    const BARKER13_BITS : u16 = 0b1010110011111;
+    const BARKER13_LEN  : usize = 13;
+    const WINDOW_MASK   : u16 = 0x1FFF;
+
+    // Perfect autocorrelation peak is 13; the strongest Barker-13 sidelobe is 1.
+    // Lock frame sync when the correlator sum crosses this coarse gate (the AEAD
+    // tag downstream is the real validator, as in the Rust modem).
+    const SYNC_THRESHOLD : i32 = 9;
+
+    // Serial-line symbol codes.
+    const SYM_POS : i8 = 1;
+    const SYM_NEG : i8 = -1;
+
+    // Frame layout in symbols: [preamble 13][length byte 8][payload len * 8].
+    const PREAMBLE_SYMS : u32 = 13;
+    const LENGTH_SYMS   : u32 = 8;
+    const BITS_PER_BYTE : u32 = 8;
+
+    // ---- Transmit serializer state ----
+    // Held as top-level scalar registers (not a struct): the Verilog backend
+    // names struct-field regs after the type but references them by the var
+    // name, so flat scalars keep the generated RTL referencing declared signals.
+    var tx_cur_byte   : u8   = 0;    // byte currently shifting out
+    var tx_bit_index  : u8   = 0;    // next bit position 0..7 (LSB first)
+    var tx_cur_symbol : i8   = 1;    // last emitted BPSK symbol (+1 / -1)
+    var tx_sending    : bool = false; // true while a byte is in flight
+
+    // ---- TX: one data bit -> one BPSK symbol (+1 / -1) ----
+    // NB: use if/ELSE with a single assignment per path. The Verilog backend
+    // lowers functions as sequential assignments (no early return), so a bare
+    // `if {..} return X` fall-through would always take the last statement.
+    fn bit_to_symbol(bit: u8) -> i8 {
+        if (bit == 1) {
+            return SYM_POS;
+        } else {
+            return SYM_NEG;
+        }
+    }
+
+    // Load a new byte into the serializer; refuses while a byte is in flight.
+    fn tx_load(byte: u8) -> bool {
+        if (tx_sending) {
+            return false;
+        } else {
+            tx_cur_byte  = byte;
+            tx_bit_index = 0;
+            tx_sending   = true;
+            return true;
+        }
+    }
+
+    // Emit the BPSK symbol for the current bit (LSB first) and advance.
+    fn tx_next_symbol() -> i8 {
+        if (!tx_sending) {
+            return SYM_POS;
+        } else {
+            tx_cur_symbol = bit_to_symbol((tx_cur_byte >> tx_bit_index) & 1);
+            tx_bit_index  = tx_bit_index + 1;
+            if (tx_bit_index >= 8) {
+                tx_sending = false;
+            }
+            return tx_cur_symbol;
+        }
+    }
+
+    // ---- RX: Barker-13 correlation ----
+    // Per-chip contribution: +1 when the window bit matches the Barker bit,
+    // -1 otherwise (equivalent to symbol * chip for +/-1 BPSK). Flat helper so
+    // no local temporaries are needed inside `correlate`.
+    fn chip_contrib(win: u16, k: usize) -> i32 {
+        if (((win >> k) & 1) == ((BARKER13_BITS >> k) & 1)) {
+            return 1;
+        } else {
+            return -1;
+        }
+    }
+
+    // Full 13-tap correlation, unrolled (a flat sum lowers cleanly to Verilog).
+    fn correlate(win: u16) -> i32 {
+        return chip_contrib(win, 0)
+             + chip_contrib(win, 1)
+             + chip_contrib(win, 2)
+             + chip_contrib(win, 3)
+             + chip_contrib(win, 4)
+             + chip_contrib(win, 5)
+             + chip_contrib(win, 6)
+             + chip_contrib(win, 7)
+             + chip_contrib(win, 8)
+             + chip_contrib(win, 9)
+             + chip_contrib(win, 10)
+             + chip_contrib(win, 11)
+             + chip_contrib(win, 12);
+    }
+
+    // Advance the sliding window by one hard-decided symbol bit (shift left,
+    // insert at LSB, keep 13 bits). Pure: takes the current window and returns
+    // the next one, so it lowers cleanly to combinational Verilog.
+    fn rx_push(win: u16, bit: u8) -> u16 {
+        return ((win << 1) | bit) & WINDOW_MASK;
+    }
+
+    // Frame sync locked when the correlator peak crosses the threshold.
+    fn sync_locked(sum: i32) -> bool {
+        return sum >= SYNC_THRESHOLD;
+    }
+
+    // Total symbols in a framed packet with `payload_len` payload bytes.
+    fn frame_symbol_count(payload_len: u32) -> u32 {
+        return PREAMBLE_SYMS + LENGTH_SYMS + payload_len * BITS_PER_BYTE;
+    }
+
+    // ---- TDD blocks (L4): mirror the Rust modem's unit tests ----
+
+    // Aligned preamble gives the perfect autocorrelation peak of 13.
+    test barker_autocorrelation_peak
+        given peak = correlate(BARKER13_BITS)
+        then peak == 13
+
+    // A 180-degree channel inversion flips every chip -> negative peak -13,
+    // which is how the modem detects and resolves phase inversion.
+    test inverted_barker_is_negative_peak
+        given anti = correlate((~BARKER13_BITS) & WINDOW_MASK)
+        then anti == -13
+
+    // Off-peak windows sit far below the peak (|value| <= 5 here).
+    test off_peak_all_zeros
+        given s = correlate(0)
+        then s == -5
+
+    test off_peak_all_ones
+        given s = correlate(WINDOW_MASK)
+        then s == 5
+
+    // BPSK bit -> symbol mapping.
+    test bit1_maps_to_plus_one
+        given s = bit_to_symbol(1)
+        then s == 1
+
+    test bit0_maps_to_minus_one
+        given s = bit_to_symbol(0)
+        then s == -1
+
+    // Serializer emits LSB first: 0x01 -> first symbol +1.
+    test tx_serializes_lsb_first
+        given tx_load(0x01)
+        and s = tx_next_symbol()
+        then s == 1
+
+    // 0x02: bit0=0 -> -1, bit1=1 -> +1.
+    test tx_second_bit_is_plus_one
+        given tx_load(0x02)
+        and tx_next_symbol()
+        and s = tx_next_symbol()
+        then s == 1
+
+    // Sliding window shifts a bit in at the LSB.
+    test rx_window_shifts_in
+        given w = rx_push(0, 1)
+        then w == 1
+
+    // Window keeps only 13 bits (the shifted-out bit is masked away).
+    test rx_window_keeps_13_bits
+        given w = rx_push(8191, 1)
+        then w == 8191
+
+    // Threshold gate.
+    test sync_locks_at_peak
+        given locked = sync_locked(13)
+        then locked == true
+
+    test sync_open_below_threshold
+        given locked = sync_locked(5)
+        then locked == false
+
+    // Smallest frame (empty payload) = 13 preamble + 8 length = 21 symbols.
+    test smallest_frame_is_21_symbols
+        given n = frame_symbol_count(0)
+        then n == 21
+
+    // ---- Invariants ----
+
+    // The lock gate must sit between the worst sidelobe (1) and the peak (13).
+    invariant threshold_within_peak
+        assert SYNC_THRESHOLD <= 13
+
+    invariant threshold_above_sidelobe
+        assert SYNC_THRESHOLD > 1
+
+    invariant barker_length_is_13
+        assert BARKER13_LEN == 13
+
+    invariant window_mask_covers_13_bits
+        assert WINDOW_MASK == 8191
+}


### PR DESCRIPTION
Closes #1245. Makes `t27c gen-verilog` emit iverilog-compilable, simulatable RTL for datapath specs, and adds the trios-mesh BPSK modem core as `specs/fpga/bpsk.t27`.

## Backend fixes (`bootstrap/src/compiler.rs`)
1. **const/var run drop** — `parse_const_decl` now consumes the trailing `;` (a stray `;` made the module-body loop skip subsequent decls). **uart: 1 -> 8 localparams, 31 -> 0 iverilog errors.**
2. **literals** — `0x`/`0b`/`_` integer literals render as decimal (valid Verilog).
3. **guarded early return** — rewritten to `if/else` so the return is not clobbered (last-write-wins).
4. **struct-field regs** — declared under the holding `var` name (matches field access).
5. **zero-arg functions** — get an unused dummy `input` (Verilog forbids port-less functions).
6. **named begin blocks** — Verilog-2001 forbids local decls in unnamed blocks.

Existing `ExprCast` cast handling kept as-is (master's validated version).

## New `specs/fpga/bpsk.t27` (`ZeroDSP_BPSK`)
BPSK serializer + Barker-13 preamble + integer correlator + threshold sync. **iverilog-compiles AND simulates**: 13 embedded test assertions pass; hierarchical checks give correlate(Barker)=13, inversion=-13, sidelobes -5/+5, sync gate, frame=21. uart/mac now iverilog-clean too (fpga clean 1 -> 3 of 34).

## Validation
- `suite`: parse / typecheck / gen(Zig/Rust/Verilog/C) **514/514**.
- No numeric/L6 change. **Follow-up:** committed seals for other specs whose Verilog changed need a reseal sweep (not included here to keep the diff focused).

phi^2 + phi^-2 = 3 | TRINITY