### PR TITLE
feat(fpga): W396 SPI boot debug

### DIFF
--- a/.claude/plans/wave-loop-396.md
+++ b/.claude/plans/wave-loop-396.md
@@ -1,0 +1,73 @@
+# Wave Loop 396 — SPI boot debug: mode-pin cold-POR sampling + bitstream config audit
+
+**Issue:** #1292  
+**Branch target:** `trinity-rust-rings`  
+**Base:** `6382e54b8`  
+**Ring:** igla-race / fpga-openxc7
+
+## Goal
+
+Diagnose why the QMTech Wukong V1 / XC7A200T-FGG676-1 does not boot from Micron N25Q128 SPI flash after successful `openFPGALoader` write+verify. Focus on revised high-priority hypotheses; explicitly avoid the disproven package-mismatch theory.
+
+## Revised hypothesis priority
+
+1. **H1 (high)** — cold POR mode-pin sampling differs from JTAG-reset sampling.
+2. **H2 (high)** — bitstream config registers (`SPI_BUSWIDTH`, `CFGRATE`, `STARTUPCLK`) are incompatible with Master SPI x1 boot.
+3. **H3 (medium)** — round-trip mismatch between `.bit` file and flash dump.
+4. **H4 (low)** — chipdb package hygiene (FBG676 vs FGG676). Pinouts are identical per Xilinx; will not fix SPI boot. Not addressed in W396.
+
+## Physical experiments
+
+- **E1 (H1)**: Read STAT before and after JTAG-reset after a cold power-cycle; compare mode bits. Record timestamps and power state.
+- **E2 (H2)**: Write `scripts/dump_bit_config.py` to parse the `.bit` header and print `SPI_BUSWIDTH`, `CFGRATE`, `STARTUPCLK`, `COR0`, `COR1`, `TIMER_CFG`, `IDCODE`. Compare against UG470 Table 5-15.
+- **E3 (H3)**: Program raw `.bit` to flash, dump back, and `cmp` byte-by-byte. Also test default trimmed write and dump first 4 KB.
+- **E4**: Quad-mode enable/disable experiment: program with `--enable-quad --spi-buswidth 4`, power-cycle, capture STAT; then `--disable-quad --spi-buswidth 1`, power-cycle, capture STAT.
+
+## CLI hardening
+
+- `tri fpga stat --pre-jtag-reset` — read STAT without issuing a JTAG reset.
+- `tri fpga bit-config <bit>` — display parsed bitstream configuration registers.
+- `tri fpga round-trip-verify <bit>` — automated E3 raw round-trip test.
+
+## Implementation tasks
+
+1. Update `.trinity/current-issue.md` with #1292 and W396 plan. ✅
+2. Read current `cli/tri/src/fpga.rs` and `cli/tri/src/main.rs` to understand existing command structure.
+3. Implement `tri fpga stat --pre-jtag-reset`.
+4. Implement `tri fpga bit-config <bit>` (wrap `scripts/dump_bit_config.py` or embed parser in Rust).
+5. Implement `tri fpga round-trip-verify <bit>`.
+6. Write `scripts/dump_bit_config.py` bitstream header parser.
+7. Run physical experiments E1–E4 on connected board and capture evidence.
+8. Update `fpga/HARDWARE_SSOT.md` with FGG676=FBG676 pinout identity and revised boot hypotheses.
+9. Run `./scripts/tri test` and confirm 575/575 PASS.
+10. Write `docs/reports/FPGA_LOOP_EVIDENCE_2026-07-05.md` and `docs/reports/FPGA_LOOP_COOPERATION_2026-07-06.md`.
+11. Update `.trinity/experience.md` and memory index.
+12. Create PR #? and squash-merge to `trinity-rust-rings` with `Closes #1292`.
+
+## Acceptance criteria
+
+- Reach one of AC-1..AC-4:
+  - **AC-1**: E1 shows cold-POR vs JTAG-reset mode difference.
+  - **AC-2**: E2 shows bitstream config incompatible with Master SPI x1.
+  - **AC-3**: E3 shows round-trip mismatch.
+  - **AC-4**: E4 shows quad-mode boot succeeds.
+- If none reached, close W396 as honest diagnostic gathering and continue in W397.
+- 575/575 PASS maintained.
+- No IGLA/Lean growth in this hardware-debug cycle.
+
+## Cooperation variants for W397
+
+- **A (default, root-cause driven)**: Fix whichever H1/H2/H3 root cause W396 identified and achieve end-to-end boot-from-flash.
+- **B (bitstream-generation fix)**: If H2 is confirmed but openXC7 fasm-flow lacks the needed config-register controls, patch the wrapper or `.fasm` pre-processing.
+- **C (Vivado-in-Docker fallback)**: If openXC7 is found fundamentally unable to produce a bootable XC7A200T SPI bitstream, pivot to Vivado-in-Docker (requires user action on installer/token).
+
+## Files expected to change
+
+- `cli/tri/src/fpga.rs` — new options and subcommands.
+- `cli/tri/src/main.rs` — clap wiring.
+- `scripts/dump_bit_config.py` — new bitstream parser.
+- `fpga/HARDWARE_SSOT.md` — FGG676=FBG676 finding and revised hypotheses.
+- `docs/reports/FPGA_LOOP_EVIDENCE_2026-07-05.md` — W396 evidence.
+- `docs/reports/FPGA_LOOP_COOPERATION_2026-07-06.md` — W397 variants.
+- `.trinity/current-issue.md`, `.trinity/experience.md` — loop bookkeeping.
+- Memory file `wave-loop-396.md`.

--- a/.trinity/current-issue.md
+++ b/.trinity/current-issue.md
@@ -1,31 +1,37 @@
-# Current Issue: Wave Loop 394
+# Current Issue: Wave Loop 396
 
-**Issue:** #1290
-**Local branch:** `wave-loop-394` (branched from `trinity-rust-rings`)
-**Basis:** W393 close-out report and cooperation variants (`docs/reports/FPGA_LOOP_COOPERATION_2026-07-04.md`)
+**Issue:** #1292
+**Local branch:** `wave-loop-396` (branched from `trinity-rust-rings` @ `6382e54b8`)
+**Basis:** W395 close-out report and revised hypothesis priority (H1 cold-POR mode sampling, H2 bitstream config registers, H3 round-trip, H4 chipdb hygiene low priority)
 
 ## Goal
 
-Resolve or definitively diagnose why the QMTech Wukong V1 / XC7A200T-FGG676 board does not boot from SPI flash after a successful `tri fpga program-flash` write + verify.
+Diagnose why the QMTech Wukong V1 / XC7A200T-FGG676-1 does not boot from Micron N25Q128 SPI flash after successful write+verify, focusing on the revised high-priority hypotheses and avoiding the disproven package-mismatch theory.
 
 ## Selected variant
 
-**Variant A (recommended)** from W393 cooperation variants:
-- Add `--enable-quad` / `--disable-quad` / `--spi-buswidth` options to `tri fpga program-flash`.
-- Add `tri fpga flash-status` to read and decode the SPI flash status register.
-- Run a flash-boot experiment with quad-mode enabled and capture `STAT` after power-cycle.
-- Update `fpga/HARDWARE_SSOT.md` with quad-mode / `SPI_BUSWIDTH` guidance.
-- Maintain conformance at 575/575 PASS.
+**Variant A (root-cause driven)** from W395 cooperation variants, updated per W396 order:
+- Add `tri fpga stat --pre-jtag-reset` to read STAT without issuing a JTAG reset.
+- Add `tri fpga bit-config <bit>` to parse and display bitstream config registers.
+- Add `tri fpga round-trip-verify <bit>` to automate flash dump round-trip verification.
+- Run physical experiments E1–E4 and capture timestamped STAT values in multiple power states.
+- Update `fpga/HARDWARE_SSOT.md` with the FBG676 vs FGG676 pinout identity finding.
+- Maintain conformance at 575/575 PASS; no IGLA/Lean growth in this hardware-debug cycle.
 
 ## Acceptance criteria
 
-- `tri fpga program-flash` exposes `--enable-quad`, `--disable-quad`, and `--spi-buswidth`.
-- `tri fpga flash-status` reads and decodes the SPI flash status register.
-- Flash-boot experiment is documented with captured `STAT` values.
-- `fpga/HARDWARE_SSOT.md` covers quad-mode / SPI_BUSWIDTH.
+- One of AC-1..AC-4 reached:
+  - **AC-1**: E1 shows cold-POR STAT mode bits differ from post-JTAG-reset mode bits.
+  - **AC-2**: E2 shows bitstream config registers incompatible with Master SPI x1 boot.
+  - **AC-3**: E3 shows round-trip mismatch between .bit and flash dump.
+  - **AC-4**: E4 shows quad-mode boot succeeds (DONE=1).
+- If none reached, W396 closes as honest diagnostic gathering and W397 continues.
+- `tri fpga stat --pre-jtag-reset` implemented.
+- `tri fpga bit-config <bit>` implemented.
+- `tri fpga round-trip-verify <bit>` implemented.
 - `t27c suite --repo-root .` reports **575/575 PASS**.
-- Real W394 issue created and referenced in commit/PR (`Closes #1290`).
-- Close-out report and cooperation doc for W395 are written.
+- Real W396 issue created and referenced in commit/PR (`Closes #1292`).
+- Close-out report and cooperation doc for W397 are written.
 - Experience log and memory index updated.
 
 ---

--- a/.trinity/current_task/activity.md
+++ b/.trinity/current_task/activity.md
@@ -1316,3 +1316,7 @@
 - **Commit:** feat(fpga): tri fpga program-flash and dump-flash subcommands
 - **Files:** .claude/plans/wave-loop-394.md,.trinity/current-issue.md,.trinity/experience.md,cli/tri/src/fpga.rs,docs/reports/FPGA_LOOP_COOPERATION_2026-07-05.md,docs/reports/FPGA_LOOP_EVIDENCE_2026-07-04.md,docs/reports/FPGA_LOOP_EVIDENCE_2026-07-05.md,fpga/HARDWARE_SSOT.md
 
+## 2026-07-04T04:22:10Z — wave-loop-396
+- **Commit:** feat(fpga): quad-mode flash-boot diagnostics and tri CLI hardening
+- **Files:** .claude/plans/wave-loop-396.md,.trinity/current-issue.md,.trinity/experience.md,cli/tri/src/fpga.rs,docs/reports/FPGA_LOOP_COOPERATION_2026-07-06.md,docs/reports/FPGA_LOOP_EVIDENCE_2026-07-05.md,docs/reports/WAVE_LOOP_396_REPORT.md,fpga/HARDWARE_SSOT.md,scripts/dump_bit_config.py
+

--- a/.trinity/experience.md
+++ b/.trinity/experience.md
@@ -1,5 +1,33 @@
 # t27 / Trinity Agent Experience Log
 
+## 2026-07-06 — Wave Loop 396 (FPGA SPI boot debug — bit-config, round-trip verify, cold-POR diagnostics)
+
+### What worked
+- Implemented three CLI diagnostics in `cli/tri/src/fpga.rs` without touching the compiler: `--pre-jtag-reset` for `tri fpga stat`, `tri fpga bit-config <bit>`, and `tri fpga round-trip-verify <bit>`.
+- Wrote `scripts/dump_bit_config.py` using the **prjxray Series-7 Type-1 packet layout** (register address in bits [26:13], word count in bits [10:0]) to decode COR0/COR1/IDCODE/CTL0/CTL1/BSPI and confirm the bitstream is SPI x1 with the correct IDCODE `0x03636093`.
+- Used `openFPGALoader` with the Digilent FTDI cable (`digilent_hs2`) for program, dump, and STAT readback after discovering the Xilinx DLC10 cable (0x03FD) is not connected.
+- Implemented `round-trip-verify` by aligning both the original .bit payload and the dumped flash payload at the sync word `0xAA995566`, accounting for the 7-series SPI preamble that openFPGALoader prepends.
+- Cross-checked with the XC7A100T `blink_j26.bit` and observed `ID_ERROR=1` (STAT `0x5000890c`), confirming the FPGA does check IDCODE during flash boot and that the XC7A200T GF16 bitstream has the right IDCODE.
+
+### What changed behavior
+- `tri fpga stat` can now skip the openFPGALoader JTAG reset with `--pre-jtag-reset`, allowing a post-cold-POR STAT read before the FPGA is reset.
+- `tri fpga bit-config` exposes 7-series configuration register values from any .bit file.
+- `tri fpga round-trip-verify` gives a deterministic pass/fail for flash write-path integrity.
+- `fpga/HARDWARE_SSOT.md` now states that FBG676 and FGG676 have identical pinout and documents the revised flash-boot diagnostic checklist.
+- W396 closed as honest diagnostic gathering: H2 (bitstream config), H3 (round-trip corruption), and H4 (package chipdb) were ruled out; H1 (cold-POR mode sampling) remains unverified and requires a user-assisted physical power-cycle.
+
+### Patterns to reuse
+- When a 7-series .bit parser is needed, use the prjxray bit layout, not the higher-level UG470 register-field layout; the latter misplaces address/count bits and produces "no packets found".
+- Align flash round-trip comparisons at the Xilinx sync word `0xAA995566`; openFPGALoader strips the ASCII header and inserts SPI preamble bytes.
+- When the actual cable is an FTDI probe, treat openFPGALoader as the canonical tool and document that the DLC10 driver is not required.
+- Record every physical measurement with a timestamp and power state, even if the result is "still no boot".
+
+### Anti-patterns to avoid
+- Do not compare flash dump bytes from offset 0 directly to .bit payload bytes from offset 0; the formats differ by header and preamble.
+- Do not use `--enable-quad` / `--disable-quad` with the N25Q128 flash; it has no separate QE bit and openFPGALoader aborts.
+- Do not write `Closes #NNNN` in a PR without first running `gh issue view NNNN`.
+- Do not modify prjxray-db as a first diagnostic step when package pinout identity can be verified from primary Xilinx sources.
+
 ## 2026-07-05 — Wave Loop 394 (FPGA flash-boot diagnostics)
 
 ### What worked

--- a/cli/tri/src/fpga.rs
+++ b/cli/tri/src/fpga.rs
@@ -73,6 +73,11 @@ pub enum FpgaCmd {
         /// openFPGALoader cable profile (default: digilent_hs2).
         #[arg(long, default_value = "digilent_hs2")]
         cable: String,
+        /// Skip the JTAG reset/PROGRAM_B pulse before reading STAT.
+        /// Use this to capture cold-POR mode sampling before the FPGA
+        /// is re-initialized by the cable.
+        #[arg(long)]
+        pre_jtag_reset: bool,
     },
     /// Synthesize the GF16 4x4 matrix design through the openXC7 toolchain.
     /// Output is written to `<build_dir>/gf16_matmul4x4_top.bit`.
@@ -145,6 +150,32 @@ pub enum FpgaCmd {
         /// Size in bytes to dump (default: 16 MiB, the whole N25Q128).
         #[arg(long, default_value_t = 16777216)]
         size: usize,
+    },
+    /// Parse the .bit header and print the configuration registers that
+    /// affect Master SPI boot (COR0, COR1, WBSTAR, TIMER, CTL0, CTL1,
+    /// IDCODE, BSPI).
+    BitConfig {
+        /// Path to the Xilinx .bit file.
+        bit: PathBuf,
+    },
+    /// Program the given .bit to SPI flash, dump the same region back, and
+    /// compare the dumped bytes against the bitstream payload. This verifies
+    /// the openFPGALoader write path is bit-perfect for the raw bitstream.
+    RoundTripVerify {
+        /// Bitstream to program and read back.
+        bit: PathBuf,
+        /// openFPGALoader cable profile (default: digilent_hs2).
+        #[arg(long, default_value = "digilent_hs2")]
+        cable: String,
+        /// FPGA part/package for bridge selection (default: xc7a200tfgg676).
+        #[arg(long, default_value = "xc7a200tfgg676")]
+        part: String,
+        /// Optional explicit path to a JTAG-to-SPI bridge bitstream.
+        #[arg(long)]
+        bridge: Option<PathBuf>,
+        /// JTAG frequency in Hz (default: 6 MHz).
+        #[arg(long, default_value = "6000000")]
+        freq: u32,
     },
     /// Read the SPI flash status register via openFPGALoader's JTAG-to-SPI bridge.
     /// Decodes WIP, WEL, and QE bits to help diagnose boot-from-flash failures.
@@ -322,7 +353,11 @@ pub fn run(cmd: &FpgaCmd) -> Result<()> {
             reset,
             verbose,
         } => load_sram(bit, cable, part, *reset, *verbose),
-        FpgaCmd::Stat { cable } => stat(cable),
+        FpgaCmd::Stat { cable, pre_jtag_reset } => stat(cable, *pre_jtag_reset),
+        FpgaCmd::BitConfig { bit } => bit_config(bit),
+        FpgaCmd::RoundTripVerify { bit, cable, part, bridge, freq } => {
+            round_trip_verify(bit, cable, part, bridge.as_ref(), *freq)
+        }
         FpgaCmd::SynthGf16 {
             build_dir,
             chipdb,
@@ -1279,8 +1314,16 @@ fn load_sram(bit: &PathBuf, cable: &str, part: &str, reset: bool, verbose: bool)
     Ok(())
 }
 
-fn stat(cable: &str) -> Result<()> {
-    let (_status, output) = run_openfpgaloader(cable, &["--read-register", "STAT"], true)?;
+fn stat(cable: &str, pre_jtag_reset: bool) -> Result<()> {
+    let mut extra = vec!["--read-register", "STAT"];
+    if pre_jtag_reset {
+        // --skip-reset is documented for write-flash mode, but pass it
+        // anyway; if ignored the tool still reads STAT without a reset in
+        // --read-register path on tested openFPGALoader versions.
+        extra.push("--skip-reset");
+        eprintln!("[stat] reading STAT without JTAG reset/PROGRAM_B pulse");
+    }
+    let (_status, output) = run_openfpgaloader(cable, &extra, true)?;
     let text = output.unwrap_or_default();
     let raw = parse_stat_raw(&text)?;
     let bits = StatBits::from_raw(raw);
@@ -1316,6 +1359,108 @@ fn parse_stat_raw(text: &str) -> Result<u32> {
         }
     }
     bail!("openFPGALoader output did not contain 'Register raw value:'")
+}
+
+fn bit_config(bit: &PathBuf) -> Result<()> {
+    if !bit.is_file() {
+        bail!("bitstream not found: {}", bit.display());
+    }
+    let root = repo_root()?;
+    let script = root.join("scripts").join("dump_bit_config.py");
+    if !script.is_file() {
+        bail!("bitstream config parser not found: {}", script.display());
+    }
+    let bit_str = bit.to_str().ok_or_else(|| anyhow!("bitstream path is not UTF-8"))?;
+    let mut cmd = std::process::Command::new("python3");
+    cmd.arg(&script).arg(bit_str);
+    eprintln!("[bit-config] $ python3 {} {}", script.display(), bit_str);
+    let status = cmd.status().with_context(|| "spawn dump_bit_config.py")?;
+    if !status.success() {
+        bail!("dump_bit_config.py exited with {:?}", status);
+    }
+    Ok(())
+}
+
+fn round_trip_verify(
+    bit: &PathBuf,
+    cable: &str,
+    part: &str,
+    bridge: Option<&PathBuf>,
+    freq: u32,
+) -> Result<()> {
+    if !bit.is_file() {
+        bail!("bitstream not found: {}", bit.display());
+    }
+
+    // 1. Determine the raw bitstream payload length after the .bit ASCII header.
+    let bit_bytes = std::fs::read(bit)
+        .with_context(|| format!("read {}", bit.display()))?;
+    let sync_idx = find_sync_word(&bit_bytes)
+        .ok_or_else(|| anyhow!("sync word 0xAA995566 not found in {}", bit.display()))?;
+    let payload = &bit_bytes[sync_idx + 4..];
+    let payload_len = payload.len();
+    eprintln!(
+        "[round-trip] .bit header ends at byte {}; raw payload length = {} bytes",
+        sync_idx,
+        payload_len
+    );
+
+    // 2. Program flash (openFPGALoader strips the .bit header automatically).
+    program_flash(bit, cable, part, bridge, freq, None, false, true, false, false, false, Some("1"))?;
+
+    // 3. Dump the same number of bytes back from flash address 0.
+    let root = repo_root()?;
+    let dump_path = root.join("build").join("fpga").join("gf16").join("round_trip_dump.bin");
+    std::fs::create_dir_all(dump_path.parent().unwrap())
+        .with_context(|| format!("create {}", dump_path.parent().unwrap().display()))?;
+    let size_str = payload_len.to_string();
+    let dump_args: Vec<&str> = vec![
+        "--dump-flash",
+        "--fpga-part",
+        part,
+        "--file-size",
+        &size_str,
+        dump_path.to_str().ok_or_else(|| anyhow!("dump path is not UTF-8"))?,
+    ];
+    let (_status, _output) = run_openfpgaloader(cable, &dump_args, true)?;
+
+    // 4. Align both streams at the sync word and compare the raw configuration
+    // payload. openFPGALoader strips the .bit ASCII header and may add the
+    // 7-series bus-width auto-detection preamble (0xFF padding + 0x000000BB
+    // 0x11220044) in front of the sync word, so a byte-0 comparison is wrong.
+    let dump_bytes = std::fs::read(&dump_path)
+        .with_context(|| format!("read dumped flash {}", dump_path.display()))?;
+    let dump_sync = find_sync_word(&dump_bytes)
+        .ok_or_else(|| anyhow!("sync word not found in flash dump {} — dump is all 0xFF?", dump_path.display()))?;
+    let dump_tail = &dump_bytes[dump_sync + 4..];
+    let bit_tail = payload; // payload already starts right after the .bit sync word
+    let cmp_len = dump_tail.len().min(bit_tail.len());
+    if cmp_len == 0 {
+        bail!("no data after sync word to compare");
+    }
+    if dump_tail[..cmp_len] == bit_tail[..cmp_len] {
+        println!(
+            "[round-trip] OK  flash dump aligns at sync word 0x{:08X} and matches .bit payload ({} comparable bytes)",
+            dump_sync,
+            cmp_len
+        );
+        Ok(())
+    } else {
+        let first_diff = dump_tail[..cmp_len].iter().zip(bit_tail[..cmp_len].iter()).position(|(a, b)| a != b);
+        let diff_offset = first_diff.unwrap_or(0);
+        eprintln!(
+            "[round-trip] MISMATCH at byte offset {} after flash sync word (dump 0x{:02X} != bit 0x{:02X})",
+            diff_offset,
+            dump_tail[diff_offset],
+            bit_tail[diff_offset]
+        );
+        bail!("round-trip verify failed: flash contents differ from bitstream payload")
+    }
+}
+
+fn find_sync_word(data: &[u8]) -> Option<usize> {
+    const SYNC: &[u8] = b"\xaa\x99\x55\x66";
+    data.windows(SYNC.len()).position(|w| w == SYNC)
 }
 
 fn program_flash(

--- a/docs/reports/FPGA_LOOP_COOPERATION_2026-07-06.md
+++ b/docs/reports/FPGA_LOOP_COOPERATION_2026-07-06.md
@@ -1,0 +1,66 @@
+# FPGA Loop Cooperation Variants — 2026-07-06 (for W397)
+
+**Basis:** W396 closed as honest diagnostic gathering. H2 (bitstream config), H3 (round-trip mismatch), and H4 (package chipdb) are ruled out. H1 (cold-POR mode-pin sampling) is the only remaining high-priority hypothesis. W397 must either confirm H1 or expand the diagnostic set.
+
+---
+
+## Variant A — Confirm and fix cold-POR mode sampling (default)
+
+Execute the user-assisted cold-POR experiment that W396 could not complete autonomously:
+
+1. Power off the QMTech Wukong V1 board completely (all rails) for ≥10 s.
+2. Power on.
+3. Within seconds, run `tri fpga stat --pre-jtag-reset` and capture `MODE`, `BUS Width`, `INIT_B`, `DONE`.
+4. Then run `tri fpga stat` (JTAG reset path) and capture again.
+
+If cold-POR `MODE` differs from post-reset `MODE=0x1`, H1 is confirmed. Root-cause fixes depend on the observed value:
+
+- If cold-POR samples `MODE=0x0` (JTAG) or another value, inspect the board's M0/M1/M2 pull resistor network and `CFGBVS`/`PUDC_B` strapping. A stronger pull-up/down or a dedicated strapping resistor may be needed.
+- If cold-POR samples the same `MODE=0x1` but boot still fails, the issue is not mode sampling; move to Variant B or C.
+
+**Deliverables:** evidence log, board schematic note, `fpga/HARDWARE_SSOT.md` update, and (if a fix is found) a working flash-boot end-to-end.
+
+**IGLA impact:** +0 generic ∀ in W397 unless a quick fix leaves cycles; keep the 125-wave no-regression streak.
+
+---
+
+## Variant B — Bitstream-generation / SPI-startup fix
+
+If Variant A shows the same correct `MODE=0x1` at cold-POR and boot still fails, the problem lies deeper than mode sampling. Candidate causes:
+
+- `COR0` CCLK frequency field is `0` (default decode). Some Artix-7 speed grades interpret this as a frequency the N25Q128 cannot satisfy in the specific board environment, or the openXC7 `fasm2frames`/`xc7frames2bit` path omits a required SPI-startup timing detail.
+- The openXC7-generated bitstream works in JTAG/SRAM loading but is missing a frame or command needed for autonomous SPI boot. Compare a Vivado-generated `.bin` of the same design byte-by-byte with the OpenXC7 output.
+- The `bscan_spi` bridge loaded during openFPGALoader flash access leaves the FPGA in a state that interferes with the next boot sequence.
+
+**Actions:**
+- Regenerate a minimal GF16 bitstream with explicit `BITSTREAM.CONFIG.CONFIGRATE` and `SPI_BUSWIDTH` constraints and test flash boot.
+- Use `bitread`/FASM diff to compare OpenXC7 vs Vivado bitstreams for the same design.
+- Try a different, simpler design (e.g., `fpga/openxc7-synth/blink_j26.bit` rebuilt for XC7A200T) to see if the failure is design-specific.
+
+**Deliverables:** root cause in the generation flow, a patched wrapper or `.fasm` pre-processing step, and a booting bitstream.
+
+---
+
+## Variant C — Vivado-in-Docker fallback
+
+If both Variant A and Variant B fail to yield a bootable OpenXC7 bitstream, accept that the open-source 7-series toolchain may have a fundamental gap for XC7A200T FGG676 autonomous SPI boot. Switch to the Vivado-in-Docker path.
+
+**Prerequisites (require user action outside the agent):**
+- Restore/install Vivado 2025.2 or later Linux installer.
+- Provide a valid `wi_authentication_key` or offline entitlement.
+- Build the `t27/vivado:webpack` Docker image or supply a multi-arch image.
+
+**Actions:**
+- Build `gf16_matmul4x4_top.bit` through Vivado for `xc7a200tfgg676-1`.
+- Program flash with `tri fpga program-flash` and test cold boot.
+- If Vivado-generated bitstream boots from flash, bisect the OpenXC7 differences and file actionable upstream issues or patches.
+
+**Deliverables:** boot-from-flash working via Vivado, documented OpenXC7 gap, and a decision on whether to maintain dual-toolchain support.
+
+---
+
+## Recommendation
+
+Start with **Variant A**. It is the only hypothesis that survived W396 and requires only a user-assisted power-cycle plus CLI capture. If H1 is disproven, proceed to **Variant B** before escalating to **Variant C**, because Vivado-in-Docker has unresolved entitlement/container blockers.
+
+*phi^2 + phi^-2 = 3 | TRINITY*

--- a/docs/reports/FPGA_LOOP_EVIDENCE_2026-07-05.md
+++ b/docs/reports/FPGA_LOOP_EVIDENCE_2026-07-05.md
@@ -1,55 +1,150 @@
-# FPGA Loop Evidence — 2026-07-05 (W394)
+# FPGA Loop Evidence — 2026-07-05 (W396)
 
 **Board:** QMTech Wukong V1 / XC7A200T-FGG676-1
 **Cable:** Digilent FTDI (`0x0403:0x6014`, `digilent_hs2` profile)
 **Host:** macOS arm64
 **Date:** 2026-07-05
+**Issue:** #1292
 
 ---
 
 ## Summary
 
-W394 did not change the physical board state; it changed the **diagnostic surface** for the boot-from-flash failure discovered in W393. The `tri` CLI now exposes all openFPGALoader options relevant to SPI flash mode, and the documentation explicitly tracks both leading hypotheses (mode-pin strapping and quad-mode / `SPI_BUSWIDTH` mismatch).
+W396 revised the boot-from-flash diagnostic priority based on a primary-source check of Xilinx package pinouts: **FBG676 and FGG676 share the same die and BGA-676 pinout**, so the `xc7a200tfbg676-1` prjxray-db entry is pinout-correct and cannot be the SPI-boot failure cause. The wave therefore focused on the three remaining hypotheses:
 
-## CLI changes
+1. H1 — cold-POR mode-pin sampling differs from JTAG-reset sampling.
+2. H2 — bitstream config registers (`SPI_BUSWIDTH`, `STARTUPCLK`, `CFGRATE`) are wrong for Master SPI x1.
+3. H3 — round-trip mismatch between `.bit` file and flash dump.
 
-### `tri fpga program-flash`
+CLI hardening landed (`tri fpga stat --pre-jtag-reset`, `tri fpga bit-config`, `tri fpga round-trip-verify`). Physical experiments ruled out **H2 and H3**. **H1 remains unverified** because a true cold power-cycle cannot be performed by software; a user-assisted cold-POR measurement is the only remaining step before declaring root cause or moving to W397.
 
-New options added in `cli/tri/src/fpga.rs`:
+A secondary finding: **`--enable-quad` and `--disable-quad` are incompatible with the Micron N25Q128_3V** on this board because the N25Q family has no separate QE status bit. openFPGALoader v1.1.0 aborts with "SPI Flash has no Quad bit".
 
-| Option | Purpose |
-|---|---|
-| `--enable-quad` | Sets the SPI flash quad-enable (QE) bit before writing. |
-| `--disable-quad` | Clears the SPI flash QE bit. |
-| `--spi-buswidth <1\|2\|4>` | Records the bitstream's expected SPI width for diagnosis. |
+---
 
-Recommended experiment command:
+## Revised hypothesis priority
 
-```bash
-tri fpga program-flash build/fpga/gf16/gf16_matmul4x4_top.bit \
-    --bulk-erase --verify --enable-quad --spi-buswidth 4
+| Priority | Hypothesis | Status after W396 |
+|---|---|---|
+| H1 (high) | Cold-POR `M[2:0]` sampling ≠ JTAG-reset sampling | **Unverified** — needs cold power-cycle |
+| H2 (high) | Bitstream config regs incompatible with Master SPI x1 | **Ruled out** — `COR1=0x0` (x1), `STARTUPCLK=CCLK`, `IDCODE=0x03636093` |
+| H3 (medium) | Round-trip mismatch between `.bit` and flash dump | **Ruled out** — `round-trip-verify` OK, 9 730 548 bytes match after sync alignment |
+| H4 (low) | Package chipdb mismatch FBG676 vs FGG676 | **Ruled out** — same die/pinout per Xilinx |
+
+---
+
+## CLI hardening
+
+### `tri fpga stat --pre-jtag-reset`
+
+Reads STAT while passing `--skip-reset` to openFPGALoader, intended to capture the mode bits before any JTAG/PROGRAM_B pulse. On this board the current openFPGALoader `--read-register STAT` path does not reset the FPGA even without `--skip-reset`, but the flag documents the intent and future-proofs the command.
+
+Example output with the board already configured (from SRAM load):
+
+```text
+Register raw value: 0x401079fc
+MODE            0x1
+BUS Width       x1
+Done            0x1
 ```
 
-### `tri fpga flash-status`
+### `tri fpga bit-config <bit>`
 
-New diagnostic subcommand. openFPGALoader does not expose a raw RDSR (0x05) read, so the command runs `openFPGALoader -f --detect` to identify the flash chip and prints guidance for reading the status register through other means (e.g. `flashrom` or a future 200T `bscan_spi` proxy).
+Wraps `scripts/dump_bit_config.py` and parses the 7-series `.bit` header. Output for `build/fpga/gf16/gf16_matmul4x4_top.bit`:
 
-## Documentation updates
+```text
+== COR0 register (addr 0x09) ==
+  raw                 : 0x02003FE5
+  startup_clk       [16:15] : 0 (CCLK)
+  cclk_freq_mhz     [22:17] : 0
+  done_pipeline     [25]    : 1
 
-- `fpga/HARDWARE_SSOT.md` now lists both required checks for flash boot:
-  1. `M[2:0] = 001` (Master SPI) mode-pin strapping.
-  2. SPI flash QE bit and matching `SPI_BUSWIDTH`.
-- `docs/reports/FPGA_LOOP_EVIDENCE_2026-07-04.md` updated with the W394 diagnostic protocol.
-- `docs/reports/FPGA_LOOP_COOPERATION_2026-07-05.md` defines W395 variants.
+== COR1 register (addr 0x0e) ==
+  raw                 : 0x00000000
+  spi_buswidth      [8:7]   : 0 (x1)
 
-## Open question
+== IDCODE register (addr 0x0c) ==
+  raw                 : 0x03636093
+```
 
-The physical quad-mode experiment has not yet been run. The next step is to execute the recommended command above, power-cycle the board, and run `tri fpga stat`.
+All values are consistent with Master SPI x1 boot for an XC7A200T.
+
+### `tri fpga round-trip-verify <bit>`
+
+Programs the flash, dumps the same byte count back, and aligns both streams at the `0xAA995566` sync word before comparing. Result for the GF16 bitstream:
+
+```text
+[round-trip] OK  flash dump aligns at sync word 0x00000030 and matches .bit payload (9730548 comparable bytes)
+```
+
+The flash dump has the expected 7-series SPI preamble: `0xFF` padding, bus-width auto-detection pattern `00 00 00 BB 11 22 00 44`, more `0xFF`, then sync word.
+
+---
+
+## Physical experiments
+
+### E1 — cold-POR mode sampling (H1)
+
+**Not completed autonomously.** A software-only agent cannot disconnect board power. The requested measurement is:
+
+1. Remove **all** power from the board (USB + any barrel jack) for ≥10 s.
+2. Re-apply power.
+3. **Before any other JTAG interaction**, run `tri fpga stat --pre-jtag-reset` and record `MODE`, `BUS Width`, `INIT_B`, and `DONE`.
+4. Then run `tri fpga stat` (without `--pre-jtag-reset`) and record again.
+
+If cold-POR `MODE` differs from the post-JTAG-reset `MODE=0x1`, H1 is confirmed.
+
+### E2 — bitstream config audit (H2)
+
+See `tri fpga bit-config` output above. Conclusion: **H2 is not the root cause**. The bitstream is correctly configured for Master SPI x1.
+
+### E3 — round-trip verify (H3)
+
+See `tri fpga round-trip-verify` output above. Conclusion: **H3 is not the root cause**. The openFPGALoader write path produces a bit-perfect copy of the raw bitstream in flash.
+
+### E4 — quad-mode experiment
+
+The Micron N25Q128_3V (JEDEC `0x20ba18`) does **not** expose a quad-enable status bit. Both `--enable-quad` and `--disable-quad` fail in openFPGALoader v1.1.0:
+
+```text
+spiFlash Error: SPI Flash has no Quad bit (or spiFlashdb must be updated)
+Fail
+Error: Failed to enable/disable Quad mode
+```
+
+Programming **without** quad flags succeeds and verifies. After a subsequent JTAG reset (`openFPGALoader -r --read-register STAT`) the FPGA attempts Master SPI x1 boot but stalls with:
+
+```text
+Register raw value: 0x5000190c
+DONE            0x0
+EOS             0x0
+MODE            0x1
+BUS Width       x1
+CRC Error       No CRC error
+ID Error        No ID error
+```
+
+Flash boot still fails even though the bitstream is correct and the flash content is bit-perfect. This strongly points to a board-level or environmental factor (H1: mode-pin sampling, or an as-yet-unmeasured signal-integrity issue).
+
+A cross-check with a smaller `blink_j26.bit` (built for XC7A100T) produced `ID Error` (`0x5000890c`), as expected for a part-mismatched bitstream, confirming that the FPGA **does** check IDCODE during flash boot.
+
+---
+
+## Acceptance status
+
+| Criterion | Reached? | Notes |
+|---|---|---|
+| AC-1 (cold-POR mode difference) | No | Requires user-assisted cold power-cycle |
+| AC-2 (bitstream config wrong) | No | Config is correct |
+| AC-3 (round-trip mismatch) | No | Flash write path is bit-perfect |
+| AC-4 (quad-mode boot works) | No | N25Q128 has no QE bit; quad flags abort |
+
+**W396 closes as honest diagnostic gathering:** H2/H3/H4 are ruled out, H1 is the only remaining high-priority hypothesis. W397 will either confirm H1 with a cold-POR measurement or expand to signal-integrity / oscilloscope checks.
+
+---
 
 ## Conformance
 
 `t27c suite --repo-root .` remained at **575/575 PASS** with zero seal mismatches.
-
----
 
 *phi^2 + phi^-2 = 3 | TRINITY*

--- a/docs/reports/WAVE_LOOP_396_REPORT.md
+++ b/docs/reports/WAVE_LOOP_396_REPORT.md
@@ -1,0 +1,77 @@
+# Wave Loop 396 Report — SPI boot debug on QMTech Wukong V1 / XC7A200T
+
+**Issue:** #1292  
+**Branch:** `wave-loop-396` → `trinity-rust-rings`  
+**Base:** `6382e54b8`  
+**Date:** 2026-07-05  
+**Status:** diagnostic gathering; no root cause yet
+
+---
+
+## What was ordered
+
+Continue diagnosing why the board does not boot from Micron N25Q128 SPI flash after successful write+verify. Re-prioritize hypotheses based on the verified fact that `xc7a200tfbg676-1` and `xc7a200tfgg676-1` share the same die and BGA-676 pinout, so package mismatch is not the cause.
+
+1. H1 — cold-POR mode-pin sampling.
+2. H2 — bitstream config registers.
+3. H3 — round-trip mismatch.
+4. H4 — chipdb package hygiene (ruled out).
+
+Add CLI hardening: `tri fpga stat --pre-jtag-reset`, `tri fpga bit-config`, `tri fpga round-trip-verify`.
+
+## What was done
+
+- Opened GitHub issue **#1292** and branched `wave-loop-396` from `trinity-rust-rings` @ `6382e54b8`.
+- Wrote `scripts/dump_bit_config.py`, a lightweight 7-series `.bit` header/config-register parser.
+- Added CLI commands:
+  - `tri fpga stat --pre-jtag-reset`
+  - `tri fpga bit-config <bit>`
+  - `tri fpga round-trip-verify <bit>`
+- Ran physical experiments on the connected board:
+  - **E1 (H1):** cold-POR measurement could not be completed autonomously; documented the required user-assisted protocol.
+  - **E2 (H2):** parsed `gf16_matmul4x4_top.bit`. `COR1=0x0` → SPI x1, `COR0[16:15]=0` → CCLK startup, `IDCODE=0x03636093`. H2 ruled out.
+  - **E3 (H3):** round-trip verify passed; 9 730 548 bytes match after sync-word alignment. H3 ruled out.
+  - **E4:** `--enable-quad` / `--disable-quad` abort on N25Q128; x1 program+verify succeeds, but post-reset STAT remains `0x5000190c` (DONE=0, EOS=0, MODE=x1, no CRC/ID error).
+- Updated `fpga/HARDWARE_SSOT.md` with:
+  - FBG676=FGG676 pinout identity.
+  - N25Q128 quad-bit incompatibility.
+  - Revised flash-boot diagnostic checklist.
+- Wrote `docs/reports/FPGA_LOOP_EVIDENCE_2026-07-05.md` and `docs/reports/FPGA_LOOP_COOPERATION_2026-07-06.md`.
+- Ran `./scripts/tri test`: **575/575 PASS**.
+
+## Findings
+
+- H2, H3, and H4 are not the root cause.
+- The bitstream is correct for Master SPI x1 boot.
+- The flash write path is bit-perfect.
+- The most likely remaining cause is **H1** (cold-POR mode-pin sampling) or an unmeasured signal-integrity/timing issue.
+- A true cold power-cycle is required to confirm or rule out H1.
+
+## Files changed
+
+- `cli/tri/src/fpga.rs`
+- `cli/tri/src/main.rs` (no change needed; clap wiring is in `fpga.rs`)
+- `scripts/dump_bit_config.py` (new)
+- `fpga/HARDWARE_SSOT.md`
+- `docs/reports/FPGA_LOOP_EVIDENCE_2026-07-05.md`
+- `docs/reports/FPGA_LOOP_COOPERATION_2026-07-06.md`
+- `docs/reports/WAVE_LOOP_396_REPORT.md` (this file)
+- `.trinity/current-issue.md`
+- `.trinity/experience.md` (updated)
+
+## Conformance
+
+- 575/575 PASS
+- 0 seal mismatches
+- No IGLA/Lean growth (hardware-debug cycle)
+
+## Next steps
+
+See `docs/reports/FPGA_LOOP_COOPERATION_2026-07-06.md` for W397 variants:
+- **A (default):** user-assisted cold-POR measurement to confirm H1.
+- **B:** bitstream-generation / SPI-startup deep dive if H1 is ruled out.
+- **C:** Vivado-in-Docker fallback if openXC7 cannot produce a bootable bitstream.
+
+---
+
+*phi^2 + phi^-2 = 3 | TRINITY*

--- a/fpga/HARDWARE_SSOT.md
+++ b/fpga/HARDWARE_SSOT.md
@@ -21,15 +21,20 @@
 
 > **2026-07-03 update:** the physical chip on the connected QMTech Wukong V1 board is an **XC7A200T**, not the earlier assumed XC7A100T. `openFPGALoader` reads IDCODE `0x03636093` and identifies the family as Artix-7 200T. Bitstreams must target `xc7a200tfgg676-1`. The legacy `ternary_mac_demo_top.bit` (3.6 MB) was built for `xc7a100tfgg676-1`; a 200T-compatible bitstream is kept as `ternary_mac_demo_top_200t.bit`.
 
+> **2026-07-05 update:** `xc7a200tfbg676-1` and `xc7a200tfgg676-1` use the **same
+> die and the same BGA-676 pinout**. Xilinx only publishes one pinout file
+> (`xc7a200tfbg676pkg.txt`); the `fgg` variant is the lidded/commercial grade of
+> the same substrate. All configuration pins (`M0/M1/M2`, `CCLK`, `DONE`,
+> `INIT_B`) are on identical BGA positions. Therefore using the prjxray-db
+> `xc7a200tfbg676-1` entry for the FGG676 board is **pinout-correct**; package
+> mismatch is **not** the SPI-boot failure cause.
+
 `Arty A7-100` (`xc7a100t-csg324`, `specs/boards/arty_a7.t27`) is a **different**
 board — not the flash target. Do not mix its `csg324` package into build/flash
 flows for the Wukong.
 
 All Vivado TCL (`fpga/vivado/build*.tcl`) and SPI-flash helpers
 (`fpga/tools/*_xc7a100t*fgg676*.bit`) already target `fgg676`. Keep it that way.
-
-> Note: an earlier memory/deck claim of "XC7A200T" was wrong — the real board is
-> A100T.
 
 ---
 
@@ -95,22 +100,37 @@ The connected Digilent FTDI cable (`0x0403:0x6014`) drives SPI flash through
 **openFPGALoader** and its JTAG-to-SPI bridge (`spiOverJtag`). The in-tree
 `dlc10` driver does not support this cable.
 
-Canonical command:
+Canonical command for x1 SPI boot:
 ```bash
 tri fpga program-flash build/fpga/gf16/gf16_matmul4x4_top.bit \
-    --bulk-erase --verify --enable-quad
+    --spi-buswidth 1 --verify
 ```
 
-If the board does not boot from flash after a power-cycle, check two things:
+**Do not use `--enable-quad` or `--disable-quad` with the Micron N25Q128_3V**
+(JEDEC `0x20ba18`) on this board. openFPGALoader v1.1.0 fails with
+"SPI Flash has no Quad bit (or spiFlashdb must be updated)" because the N25Q
+family supports quad mode natively without a separate QE status bit; the quad
+flags only attempt to toggle that non-existent bit and abort the command.
 
-1. **Mode-pin strapping.** The FPGA must sample `M[2:0] = 001` (Master SPI)
-   at power-on. Verify the QMTech Wukong V1 resistor straps for M0/M1/M2.
-2. **Quad-mode mismatch.** Some virgin boards/flash chips will not boot until the
-   SPI flash **quad-enable (QE)** bit is set. Use `--enable-quad` with
-   `tri fpga program-flash`; see openFPGALoader issue #464 for the same symptom on
-   a TE0712 + XC7A200. The bitstream itself must also be configured for the same
-   SPI width (`BITSTREAM.CONFIG.SPI_BUSWIDTH`: 1, 2, or 4). For x1 SPI boot,
-   `--enable-quad` is not required.
+If the board does not boot from flash after a power-cycle, diagnose in this
+order:
+
+1. **Cold-POR mode-pin sampling (most likely).** `M[2:0]` must be sampled as
+   `001` (Master SPI) at power-on. The value read by `tri fpga stat` after a
+   JTAG reset may differ from the value sampled at a true cold power-cycle.
+   Use `tri fpga stat --pre-jtag-reset` immediately after applying board power
+   (before any other JTAG operation) and compare the `MODE` and `BUS Width`
+   fields.
+2. **Bitstream config audit.** Run `tri fpga bit-config <bit>` and confirm
+   `COR1[8:7]` (`SPI_BUSWIDTH`) is `00` for x1, `COR0[16:15]` (`STARTUPCLK`) is
+   `00` (CCLK), and `IDCODE` matches the target FPGA (`0x03636093` for
+   XC7A200T).
+3. **Flash write-path integrity.** Run `tri fpga round-trip-verify <bit>`. It
+   programs the flash, dumps the same bytes back, and verifies that the dumped
+   bitstream payload matches the original `.bit` file after sync-word alignment.
+4. **Quad-mode / BPI-mode mismatch.** Only relevant if the board straps and
+   bitstream are intentionally configured for x4 SPI or BPI; the current
+   Wukong V1 + GF16 flow uses x1.
 
 Use `tri fpga flash-status` to probe the detected flash chip, and
 `tri fpga dump-flash` to read back the flash contents for verification.
@@ -136,8 +156,10 @@ clear by design class:**
   using dedicated config pins (FCS_B=C8/MOSI=B19/MISO=A18) + STARTUPE2 — i.e. the
   SPI-flash *proxy* `bscan_spi_qmtech` (nextpnr `pack_clocking_xc7.cc` aborts with
   `std::out_of_range`). Our matrix does **not** use those, so OpenXC7 works.
-  **VERIFIED 2026-05-31: the recipe in §8 built `gf16_matmul4x4_top.bit` and it
-  reaches `DONE=HIGH` on the board.**
+  **VERIFIED 2026-07-04: the `tri fpga synth-gf16` flow targets
+  `xc7a200tfbg676-1` (same die/pinout as `fgg676-1`) and reaches `DONE=HIGH`
+  when loaded into SRAM. Flash boot from the same bitstream remains under
+  diagnosis (see `docs/reports/FPGA_LOOP_EVIDENCE_2026-07-05.md`).**
 - **(A) Vivado in Linux Docker** — only needed for the **SPI-flash proxy**
   bitstream (Vivado-only in the OSS ecosystem). Setup exists
   (`docker/Dockerfile.vivado` 2025.2, `tri fpga build-proxy-docker`) but is

--- a/scripts/dump_bit_config.py
+++ b/scripts/dump_bit_config.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Parse a Xilinx 7-series .bit file and dump configuration registers.
+
+Reads the ASCII header, locates the 0xAA995566 sync word, then walks the
+configuration packets looking for Type-1 writes to the registers that govern
+Master SPI boot:
+
+  COR0  (0x09)  CCLK frequency, startup clock source, DONE/GTS/GWE release
+  COR1  (0x0e)  SPI_BUSWIDTH
+  WBSTAR(0x10)  warm-boot start address
+  TIMER (0x11)  watchdog / configuration timer
+  CTL0  (0x05)  control register 0
+  CTL1  (0x18)  control register 1
+  IDCODE(0x0c)  device IDCODE
+  BSPI  (0x1f)  SPI configuration register
+
+Field decoding follows UG470 "7 Series FPGAs Configuration" and the prjxray
+Series7ConfigurationRegister enum.
+"""
+
+import sys
+import struct
+
+SYNC = b'\xaa\x99\x55\x66'
+
+REG_NAMES = {
+    0x00: "CRC",
+    0x01: "FAR",
+    0x02: "FDRI",
+    0x03: "FDRO",
+    0x04: "CMD",
+    0x05: "CTL0",
+    0x06: "MASK",
+    0x07: "STAT",
+    0x08: "LOUT",
+    0x09: "COR0",
+    0x0a: "MFWR",
+    0x0b: "CBC",
+    0x0c: "IDCODE",
+    0x0d: "AXSS",
+    0x0e: "COR1",
+    0x10: "WBSTAR",
+    0x11: "TIMER",
+    0x13: "UNKNOWN",
+    0x16: "BOOTSTS",
+    0x18: "CTL1",
+    0x1f: "BSPI",
+}
+
+
+def extract_bitstream_words(data: bytes):
+    """Return the 32-bit big-endian words after the sync word."""
+    sync_idx = data.find(SYNC)
+    if sync_idx < 0:
+        raise ValueError("sync word 0xAA995566 not found")
+    tail = data[sync_idx + len(SYNC):]
+    # Trim to a multiple of 4 bytes.
+    if len(tail) % 4:
+        tail = tail[:-(len(tail) % 4)]
+    return list(struct.unpack(">%dI" % (len(tail) // 4), tail))
+
+
+def parse_packets(words):
+    """Yield Type-1 register writes from the word stream.
+
+    prjxray (and therefore the openXC7 flow) packs Series-7 Type-1 headers as:
+        bits [31:29] = header type (001 for Type-1)
+        bits [28:27] = opcode
+        bits [26:13] = register address (enum value)
+        bits [10:0]  = word count
+    Type-2 header:
+        bits [31:29] = 010
+        bits [28:27] = opcode
+        bits [26:0]  = word count
+    Type-2 is only used for FDRI data writes and is ignored here.
+    """
+    i = 0
+    while i < len(words):
+        w = words[i]
+        pkt_type = (w >> 29) & 0x7
+        opcode = (w >> 27) & 0x3
+        if pkt_type == 1:
+            reg = (w >> 13) & 0x3fff
+            count = w & 0x07ff
+            i += 1
+            payload = words[i:i + count]
+            i += count
+            yield (pkt_type, opcode, reg, payload)
+        elif pkt_type == 2:
+            # type-2 data packet; skip its declared word count
+            count = w & 0x07ffffff
+            i += 1
+            i += count
+            yield (pkt_type, opcode, None, words[i - count:i])
+        else:
+            # NOP / reserved header
+            i += 1
+            yield (pkt_type, opcode, None, [])
+
+
+def field(value, hi, lo):
+    return (value >> lo) & ((1 << (hi - lo + 1)) - 1)
+
+
+def decode_cor0(v):
+    lines = []
+    lines.append(f"  raw                 : 0x{v:08X}")
+    # prjxray/xc7series/configuration_options_0_value.h field layout
+    lines.append(f"  release_gwe_cycle [2:0]   : {field(v, 2, 0)} ({field(v, 2, 0) + 1})")
+    lines.append(f"  release_gts_cycle [5:3]   : {field(v, 5, 3)} ({field(v, 5, 3) + 1})")
+    lines.append(f"  stall_mmcm        [8:6]   : {field(v, 8, 6)} {'NoWait' if field(v, 8, 6) == 7 else 'wait'}")
+    lines.append(f"  stall_dci         [11:9]  : {field(v, 11, 9)} {'NoWait' if field(v, 11, 9) == 7 else 'wait'}")
+    lines.append(f"  release_done_cycle[14:12] : {field(v, 14, 12)} ({field(v, 14, 12) + 1})")
+    startup = field(v, 16, 15)
+    startup_names = {0: "CCLK", 1: "UserClk", 2: "JTAGClk"}
+    lines.append(f"  startup_clk       [16:15] : {startup} ({startup_names.get(startup, 'reserved')})")
+    cclk_mhz = field(v, 22, 17)
+    lines.append(f"  cclk_freq_mhz     [22:17] : {cclk_mhz}")
+    lines.append(f"  readback_single   [23]    : {field(v, 23, 23)}")
+    lines.append(f"  drive_done_high   [24]    : {field(v, 24, 24)}")
+    lines.append(f"  done_pipeline     [25]    : {field(v, 25, 25)}")
+    return "\n".join(lines)
+
+
+def decode_cor1(v):
+    lines = []
+    lines.append(f"  raw                 : 0x{v:08X}")
+    spi_width = field(v, 8, 7)
+    width_names = {0: "x1", 1: "x2", 2: "x4", 3: "reserved"}
+    lines.append(f"  spi_buswidth      [8:7]   : {spi_width} ({width_names.get(spi_width, 'reserved')})")
+    lines.append(f"  bpi_page_size     [3:0]   : {field(v, 3, 0)}")
+    return "\n".join(lines)
+
+
+def decode_idcode(v):
+    return f"  raw                 : 0x{v:08X}"
+
+
+def decode_wbstar(v):
+    return f"  raw                 : 0x{v:08X}  start_address={v & 0x7fffff}"
+
+
+def decode_timer(v):
+    return f"  raw                 : 0x{v:08X}"
+
+
+def decode_ctl0(v):
+    return f"  raw                 : 0x{v:08X}"
+
+
+def decode_ctl1(v):
+    return f"  raw                 : 0x{v:08X}"
+
+
+def decode_bspi(v):
+    lines = []
+    lines.append(f"  raw                 : 0x{v:08X}")
+    lines.append(f"  read_cmd          [7:0]   : 0x{field(v, 7, 0):02X}")
+    lines.append(f"  dummy_clk_cycles  [11:8]   : {field(v, 11, 8)}")
+    return "\n".join(lines)
+
+
+DECODERS = {
+    0x09: ("COR0", decode_cor0),
+    0x0e: ("COR1", decode_cor1),
+    0x0c: ("IDCODE", decode_idcode),
+    0x10: ("WBSTAR", decode_wbstar),
+    0x11: ("TIMER", decode_timer),
+    0x05: ("CTL0", decode_ctl0),
+    0x18: ("CTL1", decode_ctl1),
+    0x1f: ("BSPI", decode_bspi),
+}
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} <bitstream.bit>", file=sys.stderr)
+        sys.exit(1)
+
+    path = sys.argv[1]
+    with open(path, "rb") as f:
+        data = f.read()
+
+    print(f"File: {path} ({len(data)} bytes)")
+    sync_idx = data.find(SYNC)
+    print(f"Sync word 0xAA995566 at byte offset: {sync_idx} (0x{sync_idx:x})")
+
+    words = extract_bitstream_words(data)
+    print(f"Configuration words after sync: {len(words)}")
+    print()
+
+    # Collect the final write to each interesting register.
+    last_writes = {}
+    for pkt_type, opcode, reg, payload in parse_packets(words):
+        if pkt_type == 1 and opcode == 2 and reg is not None and reg in DECODERS and payload:
+            last_writes[reg] = payload[-1]
+
+    if not last_writes:
+        print("No configuration-register writes found.")
+        sys.exit(1)
+
+    for reg in sorted(last_writes):
+        name, decoder = DECODERS[reg]
+        print(f"== {name} register (addr 0x{reg:02X}) ==")
+        print(decoder(last_writes[reg]))
+        print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Wave Loop 396 — SPI boot debug CLI hardening and diagnostic evidence.

- `tri fpga stat --pre-jtag-reset` for cold-POR STAT capture.
- `tri fpga bit-config <bit>` to audit 7-series config registers.
- `tri fpga round-trip-verify <bit>` to confirm flash write integrity.
- `scripts/dump_bit_config.py` prjxray-style .bit parser.
- Updated `fpga/HARDWARE_SSOT.md` with FBG676=FGG676 pinout identity and revised flash checklist.
- Evidence report, cooperation variants, and wave report under `docs/reports/`.
- Conformance suite: **575/575 PASS**.

Closes #1292
