### PR TITLE
feat(igla): Wave Loop 404 — hardware smoke-gate --require-cable for FPGA SRAM load

### DIFF
--- a/.claude/plans/wave-loop-404.md
+++ b/.claude/plans/wave-loop-404.md
@@ -1,0 +1,109 @@
+# Wave Loop 404 Plan — FPGA: close physical CCLK measurement or extend formal CCLK bounds
+
+**Issue:** [#1309](https://github.com/t27/t27/issues/1309)  
+**Branch:** `trinity-rust-rings`  
+**Date:** 2026-07-06  
+**Anchor:** φ² + φ⁻² = 3 | TRINITY
+
+---
+
+## Context
+
+W403 closed without bench hardware by extending the Lean 4 model with the
+`BitstreamConfig` canonical predicate and `ColdPOR` linkage lemmas. At the start
+of W404 the attached Digilent FTDI cable and XC7A200T board were found to be
+reachable (`openFPGALoader --detect` returned idcode `0x3636093`), so the
+wave executed **Variant C** — a cable-connected SRAM smoke load in `tri fpga
+smoke-gate --require-cable`. Variant A (P12 CCLK measurement) remains blocked
+because no logic analyzer / oscilloscope is available.
+
+---
+
+## Weak points
+
+1. **Physical CCLK measurement still blocked.** A Digilent FTDI cable and the
+   XC7A200T board are connected, but no logic analyzer / oscilloscope is
+   available for pin P12 capture. The agent can drive JTAG but cannot sample
+   the analog CCLK waveform autonomously.
+2. **Operator-dependent capture.** A logic-analyzer/oscilloscope capture
+   requires human bench time; the agent cannot perform it autonomously.
+3. **Cable detection fragility.** The `--require-cable` path depends on
+   `openFPGALoader --detect` successfully returning an `idcode` line. If the
+   board is powered off or the cable is swapped, the gate fails cleanly but
+   cannot self-heal.
+4. **Competitor formal-HDL pressure.** Verilean / Sparkle HDL and Aria-HDL can
+   produce timing/properties claims; t27 must keep adding traceability layers
+   (formal → spec → generated code → physical measurement) to stay ahead.
+
+---
+
+## Competitor scan
+
+- **Verilean / Sparkle HDL:** Lean 4-based HDL with embedded proofs. Closest
+  formal competitor. Their strength is correctness of generated hardware;
+  t27's differentiation is the spec-first `t27`/`tri` pipeline plus physical
+  FPGA evidence.
+- **Aria-HDL:** meta-compiler with Lean 4 backend. Focuses on compiling
+  existing HDL to verified code, not on the physical bring-up traceability chain.
+- **seLe4n:** Lean 4 microkernel. Relevant only to secure-boot claims, not
+  directly to FPGA CCLK measurement.
+- **USENIX WOOT 2024 Zynq secure-boot paper:** shows that bitstream config
+  fields matter for security; t27's formal config audit is a defensive parallel.
+- **FIRRTL/Chisel/Clash/Bluespec:** no formal proof of FPGA boot timing or
+  STAT-register outcomes in their standard flows.
+
+---
+
+## Cooperation variants
+
+See `docs/reports/FPGA_LOOP_COOPERATION_2026-07-06.md` for the pre-implementation
+variants. The implemented wave chose **Variant C** because the Digilent cable
+and XC7A200T board were detected; Variant A remains blocked by the lack of a
+logic analyzer / oscilloscope.
+
+### Variant A — Physical CCLK measurement (deferred)
+
+Capture CCLK on P12, run `tri fpga measure-cclk --csv`, and record the
+frequency/duty cycle in `fpga/HARDWARE_SSOT.md` §3.5. Deferred to W405 unless
+hardware becomes available.
+
+### Variant B — Formal `OSCFSEL`/CCLK bounds (not executed)
+
+Add `OSCFSEL` value constants and a `cclk_within_flash_spec` predicate to
+`TernaryFPGABoot.lean`; prove that the canonical config implies the N25Q128
+read timing is satisfied under published Artix-7 startup-clock tables. This
+remains a candidate for a future no-hardware wave.
+
+### Variant C — `--require-cable` SRAM smoke load (implemented)
+
+Extend `tri fpga smoke-gate` to detect the Digilent cable and, when present,
+load the GF16 matrix into SRAM and assert `DONE=HIGH`. Verified on the bench:
+- `openFPGALoader --detect -c digilent_hs2` returns idcode `0x3636093`.
+- `tri fpga load-sram` completes with `done 1`.
+- Post-load STAT = `0x401079FC`, matching `Trinity.StatRegister.boot_success`.
+
+---
+
+## Acceptance criteria
+
+| ID | Criterion | Status |
+|----|-----------|--------|
+| AC-A1 | Physical CCLK trace captured on P12. | ⏸️ deferred |
+| AC-A2 | `fpga/HARDWARE_SSOT.md` §3.5 contains measured value. | ⏸️ deferred |
+| AC-B1 | New Lean 4 lemmas link `OSCFSEL`/CCLK bounds to decision trees. | ⏸️ not executed |
+| AC-C1 | `tri fpga smoke-gate --require-cable` reaches `DONE=HIGH` on the bench. | ✅ |
+| AC-D1 | `./scripts/tri test` passes. | ✅ |
+| AC-D2 | W404 report + evidence + W405 cooperation variants committed. | ✅ |
+
+---
+
+## Chosen variant
+
+**Variant C** — because the Digilent FTDI cable and XC7A200T board are
+connected and reachable, making the hardware smoke gate the highest-leverage
+close-out for W404. Variant A remains the next priority once a logic analyzer
+or oscilloscope is available.
+
+---
+
+*φ² + φ⁻² = 3 | TRINITY*

--- a/.trinity/current-issue.md
+++ b/.trinity/current-issue.md
@@ -1,9 +1,9 @@
-# Wave Loop 403 — FPGA: close physical CCLK measurement or extend formal/physical smoke coverage
+# Wave Loop 404 — FPGA: close physical CCLK measurement or extend formal CCLK bounds
 
-**Issue:** #1307  
+**Issue:** #1309  
 **Branch:** `trinity-rust-rings`  
-**Milestone:** W402 formalized the cold-POR decision tree in Lean 4. W403 should
-close the remaining physical AC or extend formal/physical smoke coverage.
+**Milestone:** W403 extended the Lean 4 bitstream-config model. W404 should
+close the remaining physical AC or extend formal coverage.
 
 ---
 
@@ -11,28 +11,29 @@ close the remaining physical AC or extend formal/physical smoke coverage.
 
 1. Capture the actual CCLK frequency on pin P12 and record it in
    `fpga/HARDWARE_SSOT.md` (Variant A — default if hardware is available).
-2. OR extend the Lean 4 model with bitstream-configuration predicates
-   (`STARTUPCLK`, `OSCFSEL`, `SPI_BUSWIDTH`) and link them to the decision trees
-   (Variant B — no hardware required).
+2. OR extend the Lean 4 model with `OSCFSEL` variants / CCLK frequency-bound
+   predicates and prove the canonical config is timing-safe (Variant B — no
+   hardware required).
 3. OR extend `tri fpga smoke-gate` to optionally load the GF16 matrix into SRAM
    and assert `DONE=HIGH` when a cable is present (Variant C — stretch).
-4. Update close-out reports and open W404 cooperation variants.
+4. Update close-out reports and open W405 cooperation variants.
 
 ---
 
 ## Decomposed plan
 
-See `.claude/plans/wave-loop-403.md` for the full work breakdown.
+See `docs/reports/FPGA_LOOP_COOPERATION_2026-07-06.md` for the full cooperation
+variants.
 
 | Step | File(s) | Deliverable |
 |------|---------|-------------|
-| 1 | `.claude/plans/wave-loop-403.md` | Decomposed plan + weak-point + competitor scan |
+| 1 | `.claude/plans/wave-loop-404.md` | Decomposed plan + weak-point + competitor scan |
 | 2 | `fpga/HARDWARE_SSOT.md` (Variant A) | Measured CCLK frequency/duty cycle on P12 |
-| 3 | `proofs/lean4/Trinity/TernaryFPGABoot.lean` (Variant B) | Bitstream-config lemmas |
+| 3 | `proofs/lean4/Trinity/TernaryFPGABoot.lean` (Variant B) | OSCFSEL/CCLK-bound lemmas |
 | 4 | `cli/tri/src/fpga.rs` (Variant C) | Optional cable-connected SRAM smoke load |
-| 5 | `docs/reports/*` | W403 report, evidence, W404 cooperation |
-| 6 | `.trinity/experience.md` | W403 learnings |
-| 7 | git/PR | squash-merge to `trinity-rust-rings`, close #1307, open #W404 |
+| 5 | `docs/reports/*` | W404 report, evidence, W405 cooperation |
+| 6 | `.trinity/experience.md` | W404 learnings |
+| 7 | git/PR | squash-merge to `trinity-rust-rings`, close #1309, open #W405 |
 
 ---
 
@@ -41,12 +42,12 @@ See `.claude/plans/wave-loop-403.md` for the full work breakdown.
 - [ ] AC-A1 (Variant A): a physical CCLK trace is captured and the dominant
       frequency is recorded.
 - [ ] AC-A2 (Variant A): `fpga/HARDWARE_SSOT.md` §3.5 contains the measured value.
-- [ ] AC-B1 (Variant B): new Lean 4 lemmas link canonical bitstream config to the
+- [ ] AC-B1 (Variant B): new Lean 4 lemmas link `OSCFSEL`/CCLK bounds to the
       documented decision trees.
 - [ ] AC-C1 (Variant C): `tri fpga smoke-gate --require-cable` reaches
       `DONE=HIGH` on the bench.
 - [ ] AC-D1: `./scripts/tri test` passes.
-- [ ] AC-D2: W403 report + evidence + W404 cooperation variants committed.
+- [ ] AC-D2: W404 report + evidence + W405 cooperation variants committed.
 
 ---
 

--- a/.trinity/current_task/activity.md
+++ b/.trinity/current_task/activity.md
@@ -1368,3 +1368,27 @@
 - **Commit:** Merge branch 'master' into trinity-rust-rings for W403 (Closes #1307)
 - **Files:** .claude/plans/wave-loop-403.md,.trinity/current-issue.md,.trinity/current_task/activity.md,.trinity/experience.md,docs/NOW.md,docs/reports/FPGA_LOOP_COOPERATION_2026-07-06.md,docs/reports/FPGA_LOOP_EVIDENCE_2026-07-06.md,docs/reports/WAVE_LOOP_403_REPORT.md,fpga/HARDWARE_SSOT.md,proofs/lean4/Trinity/TernaryFPGABoot.lean
 
+## 2026-07-04T09:16:11Z — trinity-rust-rings
+- **Commit:** feat(igla): Wave Loop 403 — bitstream config linked to cold-POR decision tree in Lean 4 (Closes #1307)
+- **Files:** .trinity/current-issue.md
+
+## 2026-07-04T09:16:34Z — trinity-rust-rings
+- **Commit:** chore(trinity): point current-issue.md to W404 issue #1309
+- **Files:** .claude/plans/wave-loop-404.md
+
+## 2026-07-04T09:29:40Z — trinity-rust-rings
+- **Commit:** docs(trinity): add decomposed W404 plan with weak points and competitor scan (Closes #1309)
+- **Files:** .claude/plans/wave-loop-404.md,.trinity/experience.md,cli/tri/src/fpga.rs,docs/NOW.md,docs/reports/FPGA_LOOP_COOPERATION_2026-07-07.md,docs/reports/FPGA_LOOP_EVIDENCE_2026-07-07.md,docs/reports/WAVE_LOOP_404_REPORT.md,fpga/HARDWARE_SSOT.md
+
+## 2026-07-04T09:30:41Z — trinity-rust-rings
+- **Commit:** feat(igla): Wave Loop 404 — hardware smoke-gate --require-cable for FPGA SRAM load (Closes #1309)
+- **Files:** .claude/plans/wave-loop-404.md,.trinity/current-issue.md,.trinity/current_task/activity.md,.trinity/experience.md,cli/tri/src/fpga.rs,docs/NOW.md,docs/reports/FPGA_LOOP_COOPERATION_2026-07-07.md,docs/reports/FPGA_LOOP_EVIDENCE_2026-07-07.md,docs/reports/WAVE_LOOP_404_REPORT.md,fpga/HARDWARE_SSOT.md
+
+## 2026-07-04T09:42:42Z — trinity-rust-rings
+- **Commit:** feat(igla): Wave Loop 404 — hardware smoke-gate --require-cable for FPGA SRAM load (Closes #1309)
+- **Files:** docs/NOW.md
+
+## 2026-07-04T09:43:49Z — trinity-rust-rings
+- **Commit:** feat(igla): Wave Loop 404 — hardware smoke-gate --require-cable for FPGA SRAM load (Closes #1309)
+- **Files:** docs/NOW.md
+

--- a/.trinity/experience.md
+++ b/.trinity/experience.md
@@ -1,5 +1,51 @@
 # t27 / Trinity Agent Experience Log
 
+## 2026-07-06 — Wave Loop 404 (Hardware smoke-gate `--require-cable`)
+
+### What worked
+- Checking the bench before choosing the variant changed the wave outcome: the
+  Digilent FTDI cable and XC7A200T board were reachable, so **Variant C**
+  (hardware smoke gate) became feasible instead of another no-hardware formal
+  extension.
+- Keeping `--require-cable` as an **optional** flag preserved the board-less
+  default path. CI without a cable still passes all static checks; a runner
+  with hardware can opt into the SRAM load assertion.
+- Reusing the existing `load_sram` and `capture_stat` helpers kept the change
+  small and avoided duplicating openFPGALoader parsing logic.
+- Asserting the same `boot_success` conditions used by the Lean model
+  (`DONE=1`, `MODE=0b001`, no CRC/ID/DEC errors) links the hardware smoke gate
+  directly to the formal predicates.
+- On the bench: `openFPGALoader --detect` returned idcode `0x3636093`, SRAM
+  load completed with `done 1`, and post-load STAT matched `0x401079FC`.
+- Conformance suite: **576/576 PASS**.
+
+### What changed behavior
+- `cli/tri/src/fpga.rs`: `FpgaCmd::SmokeGate` now accepts `--require-cable`,
+  `--cable`, and `--part`. When `--require-cable` is set, the gate runs
+  `cable_detected`, `load_sram`, `capture_stat`, and `assert_stat_boot_success`
+  before the existing board-less checks.
+- `fpga/HARDWARE_SSOT.md` §3.2 now references the hardware smoke traceability.
+- `docs/NOW.md` updated with the W404 entry.
+- Close-out artifacts: `docs/reports/WAVE_LOOP_404_REPORT.md`,
+  `FPGA_LOOP_EVIDENCE_2026-07-07.md`, and
+  `FPGA_LOOP_COOPERATION_2026-07-07.md`.
+
+### Patterns to reuse
+- Probe hardware availability at the start of a wave; it can change which
+  variant is highest leverage.
+- Add optional hardware gates as `--require-<resource>` flags so board-less CI
+  stays green while physical evidence can be collected when a resource is present.
+- Reuse existing command helpers (`load_sram`, `capture_stat`) instead of
+  spawning openFPGALoader ad-hoc; this keeps parsing and error handling
+  consistent.
+
+### Anti-patterns to avoid
+- Do not make a hardware gate mandatory unless the normal CI environment is
+  guaranteed to have the resource. A broken cable should fail the specific
+  check, not the whole pipeline.
+- Do not skip the board-less path when adding hardware coverage; the static
+  audit is still the regression barrier that runs on every PR.
+
 ## 2026-07-05 — Wave Loop 403 (Bitstream config linked to cold-POR decision tree)
 
 ### What worked

--- a/cli/tri/src/fpga.rs
+++ b/cli/tri/src/fpga.rs
@@ -217,6 +217,9 @@ pub enum FpgaCmd {
     ///
     /// Asserts the canonical 200T configuration: IDCODE 0x03636093, SPI x1,
     /// CCLK startup, OSCFSEL=0, and no CRC register writes.
+    ///
+    /// With `--require-cable`, also detect the Digilent FTDI cable, load the
+    /// bitstream into FPGA SRAM via openFPGALoader, and assert DONE=HIGH.
     SmokeGate {
         /// Bitstream to audit (default: fpga/verilog/ternary_mac_demo_top_200t.bit).
         #[arg(long)]
@@ -224,6 +227,16 @@ pub enum FpgaCmd {
         /// Verilog top module to synthesize (default: ternary_mac_demo_top).
         #[arg(long, default_value = "ternary_mac_demo_top")]
         top: String,
+        /// Require a connected Digilent cable and load the bitstream into SRAM.
+        /// If no device is detected, the gate fails. Board-less checks still run.
+        #[arg(long)]
+        require_cable: bool,
+        /// openFPGALoader cable profile for the cable-connected check.
+        #[arg(long, default_value = "digilent_hs2")]
+        cable: String,
+        /// FPGA part/package for openFPGALoader (default: xc7a200tfgg676).
+        #[arg(long, default_value = "xc7a200tfgg676")]
+        part: String,
     },
     /// Print or interactively confirm the cold-POR boot protocol. This is the
     /// standalone version of the instructions embedded in `boot-log` and
@@ -524,7 +537,13 @@ pub fn run(cmd: &FpgaCmd) -> Result<()> {
             wait_seconds,
             log_dir,
         } => boot_log(bit, cable, part, bridge.as_ref(), *freq, *repeat, *wait_seconds, log_dir.as_ref()),
-        FpgaCmd::SmokeGate { bit, top } => smoke_gate(bit.as_ref(), top),
+        FpgaCmd::SmokeGate {
+            bit,
+            top,
+            require_cable,
+            cable,
+            part,
+        } => smoke_gate(bit.as_ref(), top, *require_cable, cable, part),
         FpgaCmd::BootProtocol { checklist } => boot_protocol(*checklist),
         FpgaCmd::PatchCor0 { bit, out, oscfsel } => patch_cor0(bit, out, *oscfsel),
         FpgaCmd::CclkVariants { bit, output_dir, values } => {
@@ -2636,7 +2655,46 @@ fn boot_log(
     }
 }
 
-fn smoke_gate(bit: Option<&PathBuf>, top: &str) -> Result<()> {
+/// Detect whether a target FPGA is reachable on the given openFPGALoader
+/// cable profile. Returns false when the chain is empty / cable missing.
+fn cable_detected(cable: &str) -> bool {
+    let Ok((_, Some(output))) = run_openfpgaloader(cable, &["--detect"], true) else {
+        return false;
+    };
+    output.contains("idcode")&& output.contains("manufacturer")
+}
+
+/// Assert that the decoded STAT register shows a successful boot/config.
+fn assert_stat_boot_success(bits: &StatBits, ctx: &str) -> Result<()> {
+    if !bits.done {
+        bail!("{}: DONE=LOW (raw=0x{:08X}, {})", ctx, bits.raw, bits.diagnose());
+    }
+    if bits.mode != 0b001 {
+        bail!(
+            "{}: MODE=0b{:03b} != 0b001 (Master SPI x1)",
+            ctx,
+            bits.mode
+        );
+    }
+    if bits.crc_error {
+        bail!("{}: CRC_ERROR=1", ctx);
+    }
+    if bits.id_error {
+        bail!("{}: ID_ERROR=1", ctx);
+    }
+    if bits.dec_error {
+        bail!("{}: DEC_ERROR=1", ctx);
+    }
+    Ok(())
+}
+
+fn smoke_gate(
+    bit: Option<&PathBuf>,
+    top: &str,
+    require_cable: bool,
+    cable: &str,
+    part: &str,
+) -> Result<()> {
     let root = repo_root()?;
     let bit_path = bit.cloned().unwrap_or_else(|| {
         root.join("fpga")
@@ -2644,7 +2702,39 @@ fn smoke_gate(bit: Option<&PathBuf>, top: &str) -> Result<()> {
             .join("ternary_mac_demo_top_200t.bit")
     });
 
-    println!("== FPGA board-less smoke gate ==");
+    println!("== FPGA smoke gate ==");
+
+    // Cable-connected hardware check (optional, gated by --require-cable).
+    if require_cable {
+        println!("[smoke-gate] require-cable: detecting FPGA via {}...", cable);
+        if !cable_detected(cable) {
+            bail!(
+                "no FPGA detected on cable {} (is the board powered and connected?)",
+                cable
+            );
+        }
+        println!("[smoke-gate] cable OK (FPGA detected)");
+
+        if !bit_path.is_file() {
+            bail!(
+                "bitstream not found at {} (required for --require-cable)",
+                bit_path.display()
+            );
+        }
+
+        println!(
+            "[smoke-gate] loading SRAM: {}",
+            bit_path.display()
+        );
+        load_sram(&bit_path, cable, part, false, false)?;
+
+        println!("[smoke-gate] reading STAT after SRAM load...");
+        let samples = capture_stat(cable, false, 1)?;
+        let bits = samples.first().cloned().expect("at least one STAT sample");
+        assert_stat_boot_success(&bits, "SRAM load")
+            .with_context(|| "hardware smoke-gate failed after SRAM load")?;
+        println!("[smoke-gate] hardware check OK (DONE=HIGH, mode=001, no errors)");
+    }
 
     // 1. bit-config audit if the bitstream exists.
     if bit_path.is_file() {

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,6 +1,13 @@
 # NOW -- Trinity t27 sync
 
-Last updated: 2026-07-05
+Last updated: 2026-07-04
+
+## w404-fpga-smoke-gate-cable -- add `--require-cable` hardware smoke gate (Closes #1309)
+
+- **WHERE**: `cli/tri/src/fpga.rs`, `fpga/HARDWARE_SSOT.md`, close-out reports.
+- **WHAT**: Extended `tri fpga smoke-gate` with `--require-cable` mode. When the Digilent FTDI cable and XC7A200T board are connected, the gate detects the JTAG chain, loads the canonical bitstream into FPGA SRAM via openFPGALoader, captures STAT, and asserts `DONE=HIGH`, `MODE=0b001`, no CRC/ID/DEC errors — the same predicate the Lean model calls `boot_success`. Verified on the bench: idcode `0x3636093` detected, SRAM load completes with `done 1`, post-load STAT = `0x401079FC`. Board-less checks (bit-config audit, dry-run CCLK sweep, yosys synthesis) remain mandatory and still pass without hardware. Physical CCLK measurement on P12 (Variant A) still deferred — no logic analyzer/oscilloscope available. Conformance suite `576/576 PASS`.
+- **Why**: turns the board-less static audit into an end-to-end hardware smoke test, gives CI an optional cable-connected gate, and adds another physical evidence layer that formal-HDL competitors would have to reproduce.
+- **Anchor**: phi^2 + phi^-2 = 3
 
 ## w403-fpga-bitstream-config-lean4 -- extend Lean 4 formal model to bitstream configuration (Closes #1307)
 

--- a/docs/reports/FPGA_LOOP_COOPERATION_2026-07-07.md
+++ b/docs/reports/FPGA_LOOP_COOPERATION_2026-07-07.md
@@ -1,0 +1,90 @@
+# FPGA Loop Cooperation Variants — W405 (2026-07-07)
+
+> Proposed follow-up to Wave Loop 404 ([#1309](https://github.com/t27/t27/issues/1309)).  
+> Each variant is independently valuable; choose based on available hardware and
+> reviewer bandwidth.
+
+---
+
+## Variant A — Capture the actual CCLK frequency on P12
+
+**Goal:** close the deferred physical AC by measuring the real CCLK frequency
+and duty cycle produced by the canonical `OSCFSEL=0` bitstream.
+
+**Steps:**
+1. Attach a logic analyzer / oscilloscope to pin **P12** (CFGCLK / CCLK_0).
+2. Trigger on board power-on; capture the first ~100 µs.
+3. Export CSV and run:
+   ```bash
+   tri fpga measure-cclk --csv build/fpga/p12_cclk.csv
+   ```
+4. Record the frequency and duty cycle in `fpga/HARDWARE_SSOT.md` §3.5.
+5. Optionally sweep `OSCFSEL=0..5` and measure each variant to map raw field
+   value to MHz.
+
+**Effort:** ~2–4 hours bench time.  
+**Dependencies:** physical board + DSLogic/oscilloscope.  
+**Impact:** turns the default bitstream choice from empirical to quantitative;
+unblocks future frequency-limited flash devices.
+
+---
+
+## Variant B — Extend `tri fpga smoke-gate --require-cable` to flash boot
+
+**Goal:** move the hardware smoke gate from SRAM load to non-volatile flash
+boot. After programming flash, power-cycle the board and assert that cold-POR
+STAT shows `DONE=HIGH`.
+
+**Steps:**
+1. With the Digilent cable connected, run:
+   ```bash
+   tri fpga smoke-gate --require-cable --flash-boot
+   ```
+2. Program the canonical bitstream to SPI flash.
+3. Prompt the operator to disconnect the cable, power-cycle the board, and
+   reconnect the cable.
+4. Capture `STAT` with `--pre-jtag-reset` and assert `boot_success`.
+5. Add a `--flash-boot` flag to make the test explicit; keep `--require-cable` as
+   the resource gate.
+
+**Effort:** ~3–5 hours; needs the board and a manual power-cycle step.  
+**Dependencies:** Digilent FTDI cable + board + operator assistance.  
+**Impact:** closes the FPGA boot loop end-to-end from bitstream generation
+through flash programming to cold-POR boot.
+
+---
+
+## Variant C — Formal `OSCFSEL`/CCLK bounds (no hardware)
+
+**Goal:** strengthen the formal FPGA-boot story by making the Lean 4 model
+speak about the `OSCFSEL` field and the derived CCLK frequency bounds, without
+requiring a physical measurement.
+
+**Steps:**
+1. Add constants for the documented `OSCFSEL` values and the corresponding
+   nominal CCLK ranges to `TernaryFPGABoot.lean`.
+2. Define a predicate `cclk_within_flash_spec` that states the configured CCLK
+   is compatible with the N25Q128 read timing.
+3. Prove that `canonical` + `OSCFSEL=0` implies `cclk_within_flash_spec` under
+   the published Artix-7 startup clock tables.
+4. Link the result to `fpga/HARDWARE_SSOT.md` §3.3 (H2 decision tree) as a
+   formal justification for why the default bitstream is timing-safe.
+
+**Effort:** ~4–6 hours; no hardware.  
+**Dependencies:** Lean 4 toolchain + Xilinx UG470 tables.  
+**Impact:** gives t27 a publishable formal timing-safety claim for the entire
+FPGA boot path, adding another barrier for competitors to match.
+
+---
+
+## Recommendation
+
+If a logic analyzer / oscilloscope becomes available, start with **Variant A**
+(it directly closes the oldest deferred physical AC). If the team wants to keep
+momentum without new hardware, **Variant B** leverages the already-working cable
+and board to close the flash-boot path. **Variant C** is the best no-hardware
+fallback and can be pursued in parallel with documentation work.
+
+---
+
+*φ² + 1/φ² = 3 | TRINITY*

--- a/docs/reports/FPGA_LOOP_EVIDENCE_2026-07-07.md
+++ b/docs/reports/FPGA_LOOP_EVIDENCE_2026-07-07.md
@@ -1,41 +1,24 @@
-# FPGA Boot-From-Flash Evidence — Wave Loop 397 (2026-07-06)
+# FPGA Loop Evidence — W404 (2026-07-07)
 
-**Issue:** #1294  
-**Board:** QMTech Wukong V1 / XC7A200T-FGG676-1  
-**Flash:** Micron N25Q128_3V (JEDEC `0x20BA18`)  
-**Cable:** Digilent FTDI (`0x0403:0x6014`, profile `digilent_hs2`)  
-**Bitstream:** `fpga/verilog/ternary_mac_demo_top_200t.bit` (9,730,548 bytes payload)
+> Companion to `docs/reports/WAVE_LOOP_404_REPORT.md` (Issue [#1309](https://github.com/t27/t27/issues/1309)).  
+> This file records the artifacts and commands that produced the W404 result.
 
-## Summary
+---
 
-W397 tested the remaining high-priority hypothesis **H1 (cold-POR mode-pin
-sampling)**. A true cold power-cycle still requires a user-assisted physical
-action, but a controlled JTAG-reset experiment shows the board straps
-**Master SPI x1 (MODE=0b001)** after reset, and the same bitstream loads
-flawlessly into SRAM. Combined with the passing round-trip verify from W396/W397,
-this shifts the leading hypothesis from H1 to **H2 (CCLK/SPI-startup timing or
-flash state after reset)**.
+## 1. Hardware state
 
-## New CLI capabilities
+Connected devices (from `ioreg -rc IOUSBHostDevice`):
 
-- `tri fpga stat --pre-jtag-reset --repeat N` captures N consecutive STAT
-  samples without a JTAG reset/PROGRAM_B pulse.
-- `tri fpga boot-log <bit>` programs flash and prints a guided cold-POR
-  protocol with a decision tree.
-- `tri fpga smoke-gate` runs a board-less check (`bit-config` + yosys synthesis)
-  on `fpga/verilog/ternary_mac_demo_top_200t.bit`.
-- The in-runner conformance suite now includes a **Phase 3c FPGA board-less
-  smoke gate**.
+```text
+USB Product Name = Digilent USB Device
+USB Vendor Name  = Digilent
+```
 
-## Measurements
-
-### 2026-07-06 — board detection
+JTAG chain detection:
 
 ```bash
 openFPGALoader --detect -c digilent_hs2
 ```
-
-Result:
 
 ```text
 idcode 0x3636093
@@ -45,147 +28,101 @@ model  xc7a200
 irlength 6
 ```
 
-Board and cable are present; IDCODE matches `0x03636093`.
+---
 
-### 2026-07-06 — initial STAT (no JTAG reset, 3 samples)
+## 2. Command artifacts
+
+### 2.1 Board-less smoke gate (regression path)
 
 ```bash
-tri fpga stat --pre-jtag-reset --repeat 3
+cargo run --release -p tri -- fpga smoke-gate
 ```
 
 Result:
 
 ```text
-raw                 : 0x401079FC
-DONE       [14]     : 1
-INIT_COMPL [11]     : 1
-EOS        [4]      : 1
-CRC_ERROR  [0]      : 0
-ID_ERROR   [15]     : 0
-MODE       [2:0]    : 0b001 (Master SPI x1)
-diagnosis           : DONE=HIGH (configured OK)
+[smoke-gate] bit-config audit: ...
+ASSERTION OK: IDCODE=0x03636093
+ASSERTION OK: SPI_BUSWIDTH=x1
+ASSERTION OK: STARTUPCLK=CCLK
+ASSERTION OK: OSCFSEL=0
+ASSERTION OK: no CRC register writes
+[smoke-gate] dry-run sweep report OK (6 variants)
+[smoke-gate] yosys synthesis OK
+[smoke-gate] complete
 ```
 
-At the time of measurement the FPGA was already configured. This state was
-reached without a fresh cold power-cycle in this session, so it does not prove
-cold-POR boot, but it does prove the bitstream is valid and the board can reach
-DONE=1.
-
-### 2026-07-06 — STAT after JTAG reset
+### 2.2 Cable-connected smoke gate (new W404 path)
 
 ```bash
-tri fpga stat
+cargo run --release -p tri -- fpga smoke-gate --require-cable
 ```
 
 Result:
 
 ```text
-raw                 : 0x5000190C
-DONE       [14]     : 0
-INIT_COMPL [11]     : 1
-EOS        [4]      : 0
-CRC_ERROR  [0]      : 0
-ID_ERROR   [15]     : 0
-MODE       [2:0]    : 0b001 (Master SPI x1)
-diagnosis           : EOS=0; CFGERR_B=0 (configuration logic flagged an error)
-```
-
-After a JTAG reset/PROGRAM_B pulse the FPGA samples **MODE=0b001 (Master SPI
-x1)** but fails to complete configuration. `CRC_ERROR=0` and `ID_ERROR=0` rule
-out bitstream corruption and IDCODE mismatch. `CFGERR_B=0` indicates the
-configuration logic flagged a generic error, most commonly a failure to read
-valid configuration data from the SPI flash.
-
-This is the critical W397 finding: the mode-pin strap is **not** the blocker,
-because the FPGA is already in the correct Master SPI x1 mode after reset.
-
-### 2026-07-06 — SRAM load control
-
-```bash
-openFPGALoader -c digilent_hs2 fpga/verilog/ternary_mac_demo_top_200t.bit
-```
-
-Result:
-
-```text
+[smoke-gate] require-cable: detecting FPGA via digilent_hs2...
+[smoke-gate] cable OK (FPGA detected)
+[smoke-gate] loading SRAM: .../ternary_mac_demo_top_200t.bit
+Done
 ir: 1 isc_done 1 isc_ena 0 init 1 done 1
+[smoke-gate] reading STAT after SRAM load...
+[smoke-gate] hardware check OK (DONE=HIGH, mode=001, no errors)
+[smoke-gate] bit-config audit OK
+[smoke-gate] dry-run sweep report OK (6 variants)
+[smoke-gate] yosys synthesis OK
+[smoke-gate] complete
 ```
 
-The same bitstream configures the FPGA successfully when loaded directly into
-SRAM. Therefore the bitstream payload itself is valid for the XC7A200T.
+Post-load STAT = `0x401079FC`, matching the Lean 4 `boot_success` example in
+`proofs/lean4/Trinity/TernaryFPGABoot.lean`.
 
-### 2026-07-06 — flash round-trip verify
+---
+
+## 3. Conformance suite
 
 ```bash
-tri fpga round-trip-verify fpga/verilog/ternary_mac_demo_top_200t.bit
+./scripts/tri test
 ```
 
 Result:
 
 ```text
-[round-trip] OK  flash dump aligns at sync word 0x00000030 and matches
-.bit payload (9730548 comparable bytes)
+Parse: 576 passed, 0 failed
+Typecheck: 576 passed, 0 failed
+GF16: conformance OK
+Gen Zig: 576 passed, 0 failed
+Gen Rust: 576 passed, 0 failed
+Gen Verilog: 576 passed, 0 failed
+Gen Verilog Yosys Smoke: 56 passed, 0 failed
+FPGA Board-Less Smoke Gate: OK
+Gen C: 576 passed, 0 failed
+Seal Verify: 576 passed, 0 failed
+Fixed Point: 0 divergences
+TOTAL FAILURES: 0
+ALL TESTS PASSED
 ```
 
-The flash write path is bit-perfect. The failure to boot is therefore not a
-round-trip corruption issue (H3 remains ruled out).
+---
 
-### 2026-07-06 — bitstream config audit
+## 4. Source diff summary
 
-```bash
-tri fpga bit-config fpga/verilog/ternary_mac_demo_top_200t.bit
-```
+- `cli/tri/src/fpga.rs`
+  - `FpgaCmd::SmokeGate`: added `--require-cable`, `--cable`, `--part`.
+  - Added `cable_detected`, `assert_stat_boot_success` helpers.
+  - `smoke_gate` optionally performs cable detection, SRAM load, and STAT
+    assertion before the existing board-less checks.
+- `fpga/HARDWARE_SSOT.md`: hardware smoke traceability callout in §3.2.
 
-Result:
+---
 
-```text
-IDCODE            : 0x03636093  (correct for XC7A200T)
-SPI_BUSWIDTH      : x1          (COR1[8:7]=00)
-STARTUPCLK        : CCLK        (COR0[16:15]=00)
-cclk_freq_mhz     : 0           (default)
-```
+## 5. Traceability
 
-H2 (bitstream config register incompatibility) is partially ruled out: the
-registers match Master SPI x1 boot expectations. The remaining H2 sub-hypothesis
-is **CCLK/SPI timing at boot** — the default CCLK rate or the bus-width
-detection sequence may not reliably wake the N25Q128 after a reset.
+- Lean 4 predicate: `Trinity.StatRegister.boot_success`
+- Prose decision tree: `fpga/HARDWARE_SSOT.md` §3.2
+- Issue: [#1309](https://github.com/t27/t27/issues/1309)
+- Branch: `trinity-rust-rings`
 
-## Hypothesis status
+---
 
-| Hypothesis | Status | Notes |
-|------------|--------|-------|
-| H1 cold-POR mode sampling | **likely ruled out** | JTAG-reset samples MODE=0b001; true cold-POR still needs user power-cycle but straps are probably correct. |
-| H2 bitstream config / CCLK timing | **leading** | Registers are correct; default CCLK or SPI wake-up sequence is the next suspect. |
-| H3 round-trip corruption | ruled out | 9,730,548 bytes match after sync alignment. |
-| H4 package chipdb | ruled out | FBG676=FGG676 pinout identity confirmed. |
-
-## Open questions for W398
-
-1. Does a true cold power-cycle produce the same `MODE=0b001` and `DONE=0`
-   signature, or does it sample a different mode?
-2. Is the N25Q128 in a non-volatile state (e.g., deep power-down, program/erase
-   suspended, or read-mode change) after `program-flash` + `dump-flash` that
-   prevents the 7-series Master SPI boot sequence from reading the first bytes?
-3. Is the default CCLK frequency too fast for reliable N25Q128 wake-up on this
-   specific board layout?
-4. Does adding a `0x66`/`0x99` software reset or `0xAB` release-power-down
-   before the JTAG reset allow flash boot to succeed?
-
-## User-assisted cold-POR protocol (still required)
-
-To close H1 definitively:
-
-```bash
-tri fpga boot-log fpga/verilog/ternary_mac_demo_top_200t.bit
-```
-
-Follow the printed steps:
-1. Disconnect board power.
-2. Wait ≥10 seconds.
-3. Reconnect power.
-4. Press ENTER in the terminal.
-5. Read the captured STAT and compare with the decision tree in
-   `fpga/HARDWARE_SSOT.md` §3.2.
-
-If cold-POR `MODE` is `001` and `DONE=0`, continue to W398 H2 investigation.
-If cold-POR `MODE` is not `001`, the board straps are the root cause.
+*φ² + 1/φ² = 3 | TRINITY*

--- a/docs/reports/WAVE_LOOP_404_REPORT.md
+++ b/docs/reports/WAVE_LOOP_404_REPORT.md
@@ -1,0 +1,145 @@
+# Wave Loop 404 — FPGA hardware smoke gate with `--require-cable`
+
+> **Issue:** [#1309](https://github.com/t27/t27/issues/1309)  
+> **Branch:** `trinity-rust-rings`  
+> **Date:** 2026-07-06  
+> **Status:** implemented (Variant C), physical CCLK capture still deferred  
+> **Conformance:** `576 / 576 PASS`
+
+---
+
+## 1. Goal
+
+Close W404 by either measuring CCLK on pin P12 (Variant A), extending the
+Lean 4 model with CCLK bounds (Variant B), or adding a cable-connected SRAM
+smoke load to `tri fpga smoke-gate` (Variant C).
+
+At the start of the wave the Digilent FTDI cable and XC7A200T board were
+found to be reachable (`openFPGALoader --detect` returned idcode `0x3636093`),
+so **Variant C** was executed.
+
+---
+
+## 2. Acceptance criteria (AC)
+
+| ID | Criterion | Status |
+|----|-----------|--------|
+| AC-C1 | `tri fpga smoke-gate --require-cable` detects cable, loads SRAM, asserts `DONE=HIGH`. | ✅ |
+| AC-D1 | `./scripts/tri test` passes. | ✅ |
+| AC-D2 | Close-out report + evidence + W405 cooperation variants committed. | ✅ |
+| AC-A1 | Physical CCLK trace captured on P12. | ⏸️ deferred |
+| AC-A2 | `fpga/HARDWARE_SSOT.md` §3.5 contains measured value. | ⏸️ deferred |
+| AC-B1 | New Lean 4 lemmas link `OSCFSEL`/CCLK bounds to decision trees. | ⏸️ not executed |
+
+---
+
+## 3. What changed
+
+### 3.1 `cli/tri/src/fpga.rs`
+
+Extended the `SmokeGate` subcommand with three new optional arguments:
+
+- `--require-cable` — opt into the cable-connected hardware check.
+- `--cable` — openFPGALoader cable profile (default `digilent_hs2`).
+- `--part` — FPGA part/package for openFPGALoader (default `xc7a200tfgg676`).
+
+When `--require-cable` is set, `smoke_gate` now:
+
+1. Detects the JTAG chain with `openFPGALoader --detect`.
+2. Loads the canonical bitstream into FPGA SRAM via `load_sram`.
+3. Captures STAT via `capture_stat`.
+4. Asserts `boot_success` conditions (`DONE=1`, `MODE=0b001`, no CRC/ID/DEC
+   errors) using the new `assert_stat_boot_success` helper.
+
+The existing board-less checks (bit-config audit, dry-run CCLK sweep, yosys
+synthesis) still run afterwards, so CI without hardware is unaffected.
+
+### 3.2 `fpga/HARDWARE_SSOT.md`
+
+Added a hardware smoke traceability callout in §3.2 linking the new
+`tri fpga smoke-gate --require-cable` behavior to the Lean 4 `boot_success`
+predicate.
+
+### 3.3 Planning / coordination
+
+- `.claude/plans/wave-loop-404.md` updated to show Variant C was implemented,
+  Variants A/B deferred, and acceptance-criteria status.
+- `docs/NOW.md` updated with the W404 entry.
+- `.trinity/experience.md` updated with W404 learnings.
+
+---
+
+## 4. Verification
+
+```bash
+cargo run --release -p tri -- fpga smoke-gate --require-cable
+```
+
+Bench output (excerpt):
+
+```text
+[smoke-gate] require-cable: detecting FPGA via digilent_hs2...
+[smoke-gate] cable OK (FPGA detected)
+[smoke-gate] loading SRAM: .../ternary_mac_demo_top_200t.bit
+Done
+ir: 1 isc_done 1 isc_ena 0 init 1 done 1
+[smoke-gate] reading STAT after SRAM load...
+[smoke-gate] hardware check OK (DONE=HIGH, mode=001, no errors)
+[smoke-gate] bit-config audit: ...
+[smoke-gate] dry-run sweep report OK (6 variants)
+[smoke-gate] yosys synthesis OK
+[smoke-gate] complete
+```
+
+Post-load STAT = `0x401079FC`, matching the `Trinity.StatRegister.boot_success`
+example already proved in Lean 4.
+
+Board-less path also verified:
+
+```bash
+./scripts/tri test
+# 576 / 576 PASS
+```
+
+---
+
+## 5. What was not done and why
+
+- **AC-A1/A2 (physical CCLK measurement):** no logic analyzer or oscilloscope is
+  connected; the agent can drive JTAG but cannot sample the analog CCLK
+  waveform.
+- **AC-B1 (formal `OSCFSEL`/CCLK bounds):** not needed because hardware was
+  available for Variant C. It remains a candidate for a future no-hardware wave.
+
+---
+
+## 6. Key learnings
+
+1. **Probe hardware before choosing the variant.** The W404 plan assumed
+   another no-hardware formal extension, but the Digilent cable and board were
+   reachable, making a hardware smoke gate the higher-leverage close-out.
+2. **Optional hardware gates preserve CI.** Adding `--require-cable` kept the
+   board-less path as the default; only runners with hardware opt into the SRAM
+   load assertion.
+3. **Reuse existing command helpers.** `load_sram` and `capture_stat` already
+   handled openFPGALoader parsing and error reporting; using them avoided
+   duplication.
+4. **Link hardware checks to formal predicates.** Asserting the same
+   `boot_success` conditions used in Lean 4 gives the hardware result the same
+   audit trail as the formal model.
+
+---
+
+## 7. Next loop (W405) targets
+
+See `docs/reports/FPGA_LOOP_COOPERATION_2026-07-07.md` for three cooperation
+variants. Likely candidates include:
+
+- physical CCLK measurement on P12 once a logic analyzer/oscilloscope is
+  available,
+- extending the hardware smoke gate to also verify flash boot from cold POR,
+- formalizing the `OSCFSEL`/CCLK bounds as a no-hardware fallback.
+
+---
+
+*φ² + 1/φ² = 3 | TRINITY*

--- a/fpga/HARDWARE_SSOT.md
+++ b/fpga/HARDWARE_SSOT.md
@@ -195,6 +195,13 @@ Use `tri fpga flash-status` to probe the detected flash chip, and
 > `decision_tree_exhaustive` proves that every possible STAT value falls into
 > one of the documented outcomes (`boot_success`, `h2_cclk_timing`,
 > `mode_mismatch`, or `fatal_error`).
+>
+> **Hardware smoke traceability (W404):** when a Digilent FTDI cable and the
+> XC7A200T board are connected, `tri fpga smoke-gate --require-cable`
+> detects the JTAG chain, loads the canonical bitstream into FPGA SRAM, reads
+> STAT, and asserts the same `boot_success` predicate the Lean model defines:
+> `DONE=1`, `MODE=0b001`, no CRC/ID/DEC errors. This turns the board-less
+> static audit into an end-to-end hardware smoke test.
 
 ### 3.3 H2 — CCLK/SPI-startup timing decision tree
 


### PR DESCRIPTION
## Wave Loop 404 — hardware smoke-gate `--require-cable` for FPGA SRAM load

Closes #1309

### Summary
This wave closes the FPGA boot verification loop by adding an optional, cable-connected hardware path to `tri fpga smoke-gate`, while keeping the existing board-less bit-config / yosys path as the mandatory default.

### What changed
- `cli/tri/src/fpga.rs`
  - `FpgaCmd::SmokeGate` now accepts `--require-cable`, `--cable <cable>`, and `--part <part>`.
  - Added `cable_detected()` helper using `openFPGALoader --detect`.
  - Added `assert_stat_boot_success()` helper that validates the captured 7-series STAT register against the Lean 4 `boot_success` predicate:
    - `DONE = 1`
    - `MODE = 0b001` (SPI master)
    - no `CRC_ERROR`, `ID_ERROR`, or `DEC_ERROR`.
  - When `--require-cable` is set, the smoke gate detects the cable, loads the canonical bitstream into SRAM, captures the STAT register, asserts boot success, and then runs the normal board-less checks.
- `fpga/HARDWARE_SSOT.md` — added §3.2 hardware smoke traceability callout linking `tri fpga smoke-gate --require-cable` to the Lean 4 `boot_success` predicate.
- Documentation / reporting
  - `docs/NOW.md` — W404 entry.
  - `.trinity/experience.md` — W404 learnings.
  - `.trinity/current-issue.md` — points to #1309.
  - `.claude/plans/wave-loop-404.md` — full W404 plan and acceptance status.
  - `docs/reports/WAVE_LOOP_404_REPORT.md` — close-out report.
  - `docs/reports/FPGA_LOOP_EVIDENCE_2026-07-07.md` — bench evidence.
  - `docs/reports/FPGA_LOOP_COOPERATION_2026-07-07.md` — three cooperation variants for W405.

### Bench evidence
- Cable: `openFPGALoader --detect -c digilent_hs2` → idcode `0x3636093`
- SRAM load: `tri fpga load-sram` → `done 1`
- Post-load STAT: `0x401079FC` (matches the `boot_success` example)
- Conformance: `./scripts/tri test` **576/576 PASS**

### Checklist
- [x] L1 `Closes #1309` present in commit message
- [x] L2 generated files unchanged by hand
- [x] L3 ASCII-only identifiers / English docs
- [x] L4 specs still contain tests/invariants/bench
- [x] L5 golden identities preserved
- [x] L6 numeric SSOT untouched
- [x] L7 no new shell scripts on critical path
