### PR TITLE
fix(paper-gf16): честность — FPGA-synth вместо 'verified on silicon', shuttle TTSKY26b

### DIFF
--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,3 +1,25 @@
+# NOW — GF16-paper honesty fix (Closes #1341)
+
+## Honesty — GF16-статья: FPGA-synth вместо 'verified on silicon', shuttle TTSKY26b (Closes #1341)
+
+- Branch: `fix/gf16-paper-honesty-silicon-shuttle`
+- Issue: #1341
+- Файлы: `docs/arxiv-submission/trinity-gf16.tex`, `docs/arxiv-trinity-gf16-draft.md`
+
+### What landed
+- Абстракт: «4x4 matmul verified on silicon, 35/35 RTL tests» → «verified in FPGA synthesis and RTL simulation, 35/35 tests» (encoding ≠ compute ≠ FPGA; sim/synth ≠ HW-кремний).
+- Shuttle `TTSKY26a (May 2026)` → `TTSKY26b TT4913 Gamma` по SSOT `conformance/FORMAT-SPEC-001.json` (`frozen_silicon_anchor.tapeout`); добавлено «silicon not yet returned (expected late 2026), no on-chip measurement claimed» (TinyTapeout: чипы TTSKY26a/b — late 2026).
+- «actual hardware runs» → «actual FPGA hardware runs (Artix-7 XC7A100T), not ASIC silicon».
+- Заголовок + `\label` §5 ASIC Path: TTSKY26a → TTSKY26b TT4913 Gamma.
+
+### Не тронуто
+- Цифры 323 MHz / 40350 LUT / 64 DSP48E1 / 35/35 / 12.8–41.2 GOPS (FPGA-прогоны), спека 1/6/9 bias=31, φ-anchor.
+
+### Контекст
+- Связано с erratum-треком каталожной статьи arXiv:2606.09686 (84→83, канон `ERRATA_2026-06-14.md`).
+
+---
+
 # NOW — Wave Loop 412 close-out / Wave Loop 413 setup
 
 ## Wave Loop 412 — measured-to-lean standalone + raw-ns + PVT context (Closes #1332)

--- a/docs/arxiv-submission/trinity-gf16.tex
+++ b/docs/arxiv-submission/trinity-gf16.tex
@@ -111,10 +111,12 @@ a phi-anchored exponent bias of 31. GF16 uses a 1/6/9 bit layout
 (sign/exponent/mantissa) and achieves 323 MHz combinational throughput
 on a Xilinx Artix-7 XC7A100T FPGA using the open-source openXC7
 toolchain (Yosys + nextpnr). We present a complete dot-product (N=4) and
-4x4 matrix multiplication accelerator verified on silicon, with 35/35
-RTL tests passing and 0 timing violations at 100 MHz. The design has
-been submitted for ASIC fabrication on Sky130 via the TinyTapeout
-TTSKY26a shuttle (May 2026).
+4x4 matrix multiplication accelerator verified in FPGA synthesis and
+RTL simulation, with 35/35 tests passing and 0 timing violations at
+100 MHz. The design has been submitted for ASIC fabrication on Sky130
+via the TinyTapeout TTSKY26b TT4913 Gamma shuttle (submission closed
+May 2026); silicon has not yet been returned (expected late 2026), so
+no on-chip measurement is claimed.
 
 \subsection{1. Introduction}\label{introduction}
 
@@ -360,7 +362,7 @@ GF16 ops/sec @ 100 MHz & 12.8 GOPS \\
 }
 
 \subsection{5. ASIC Path (TinyTapeout
-TTSKY26a)}\label{asic-path-tinytapeout-ttsky26a}
+TTSKY26b TT4913 Gamma)}\label{asic-path-tinytapeout-ttsky26b}
 
 \subsubsection{5.1 Submission}\label{submission}
 
@@ -432,8 +434,8 @@ exponent/mantissa split offers 65x wider dynamic range than float16 with
 better precision than bfloat16.
 
 All verified numbers (323 MHz, 40,350 LUTs, 64 DSP48E1, 35/35 tests, 0
-latches, 0 timing violations) are from actual hardware runs, not
-simulation estimates.
+latches, 0 timing violations) are from actual FPGA hardware runs
+(Artix-7 XC7A100T), not ASIC silicon nor simulation estimates.
 
 \subsection{References}\label{references}
 

--- a/docs/arxiv-trinity-gf16-draft.md
+++ b/docs/arxiv-trinity-gf16-draft.md
@@ -2,7 +2,7 @@
 
 ## Abstract
 
-We introduce Golden Float 16 (GF16), a 16-bit floating-point format with a phi-anchored exponent bias of 31. GF16 uses a 1/6/9 bit layout (sign/exponent/mantissa) and achieves 323 MHz combinational throughput on a Xilinx Artix-7 XC7A100T FPGA using the open-source openXC7 toolchain (Yosys + nextpnr). We present a complete dot-product (N=4) and 4x4 matrix multiplication accelerator verified on silicon, with 35/35 RTL tests passing and 0 timing violations at 100 MHz. The design has been submitted for ASIC fabrication on Sky130 via the TinyTapeout TTSKY26a shuttle (May 2026).
+We introduce Golden Float 16 (GF16), a 16-bit floating-point format with a phi-anchored exponent bias of 31. GF16 uses a 1/6/9 bit layout (sign/exponent/mantissa) and achieves 323 MHz combinational throughput on a Xilinx Artix-7 XC7A100T FPGA using the open-source openXC7 toolchain (Yosys + nextpnr). We present a complete dot-product (N=4) and 4x4 matrix multiplication accelerator verified in FPGA synthesis and RTL simulation, with 35/35 tests passing and 0 timing violations at 100 MHz. The design has been submitted for ASIC fabrication on Sky130 via the TinyTapeout TTSKY26b TT4913 Gamma shuttle (submission closed May 2026); silicon has not yet been returned (expected late 2026), so no on-chip measurement is claimed.
 
 ## 1. Introduction
 
@@ -156,7 +156,7 @@ All designs verified on FPGA via XVC programming:
 | GF16 ops/sec (matmul) | 41.2 GOPS @ 323 MHz |
 | GF16 ops/sec @ 100 MHz | 12.8 GOPS |
 
-## 5. ASIC Path (TinyTapeout TTSKY26a)
+## 5. ASIC Path (TinyTapeout TTSKY26b TT4913 Gamma)
 
 ### 5.1 Submission
 
@@ -194,7 +194,7 @@ A complete Python reference (encode/decode/mul/add/dot4) is provided in `conform
 
 We have demonstrated a complete implementation of the Trinity GF16 floating-point format, from specification through FPGA verification to ASIC submission. The phi-anchored bias=31 provides a natural centering for ML and scientific computation values, while the 6/9 exponent/mantissa split offers 65x wider dynamic range than float16 with better precision than bfloat16.
 
-All verified numbers (323 MHz, 40,350 LUTs, 64 DSP48E1, 35/35 tests, 0 latches, 0 timing violations) are from actual hardware runs, not simulation estimates.
+All verified numbers (323 MHz, 40,350 LUTs, 64 DSP48E1, 35/35 tests, 0 latches, 0 timing violations) are from actual FPGA hardware runs (Artix-7 XC7A100T), not ASIC silicon nor simulation estimates.
 
 ## References
 


### PR DESCRIPTION
## Суть

Honesty-правка формулировок статьи GF16 (arXiv:2606.05017): текст заявлял «4x4 matmul **verified on silicon**» при доказательстве через RTL/FPGA-synth (Artix-7 XC7A100T). Это противоречит правилу разграничения **encoding ≠ compute ≠ FPGA** и **sim/synth ≠ HW-кремний**: «отправлен на изготовление» ≠ «измерено на кристалле».

## Что изменено (оба файла согласованно)

`docs/arxiv-submission/trinity-gf16.tex` + `docs/arxiv-trinity-gf16-draft.md`:

- **«verified on silicon, with 35/35 RTL tests»** → **«verified in FPGA synthesis and RTL simulation, with 35/35 tests»**.
- **shuttle «TTSKY26a (May 2026)»** → **«TTSKY26b TT4913 Gamma (submission closed May 2026)»** — по каноническому SSOT `conformance/FORMAT-SPEC-001.json` (`frozen_silicon_anchor.tapeout = "TTSKY26b TT4913 Gamma"`, RTL `tt-trinity-gamma/src/gf16_v2_mul.v`). Добавлено: «silicon has not yet been returned (expected late 2026), so no on-chip measurement is claimed» — по данным TinyTapeout чипы TTSKY26a/b ожидаются ноя–дек 2026.
- **«actual hardware runs»** → **«actual FPGA hardware runs (Artix-7 XC7A100T), not ASIC silicon nor simulation estimates»**.
- Заголовок и `\label` §5 ASIC Path: `TTSKY26a` → `TTSKY26b TT4913 Gamma`.

## Что НЕ тронуто

Цифры производительности (323 MHz, 40 350 LUT, 64 DSP48E1, 35/35 tests, 12.8–41.2 GOPS — все с FPGA-прогонов), спека 1/6/9 bias=31, φ-anchor. Diff: 12 insertions / 10 deletions в 2 файлах.

## Верификация фактов

- SSOT `frozen_silicon_anchor` (FORMAT-SPEC-001.json): tapeout = TTSKY26b TT4913 Gamma.
- TinyTapeout submission-stats API: TTSKY26a закрыт 2026-05-11, TTSKY26b — 2026-05-18; чипы обоих ожидаются late 2026 → на 04.07.2026 физического кремния нет.

Связано с erratum-треком каталожной статьи (arXiv:2606.09686, 84→83).


Closes #1341
