### PR TITLE
feat(igla): Wave Loop 418 — PVT regression, VCD/CSV hardening, standalone Lean integration

### DIFF
--- a/.claude/plans/wave-loop-418.md
+++ b/.claude/plans/wave-loop-418.md
@@ -1,0 +1,152 @@
+# Wave Loop 418 Plan
+
+**Issue:** #1353  
+**Branch:** `wave-loop-418`
+
+---
+
+## Decision gate
+
+| Bench available? | Pick |
+|--------------------|------|
+| P12 + analyzer + DLC10/Digilent cable | Variant A |
+| Relay / power switch + cable | Variant B |
+| Nothing | Variant C |
+
+Current state (2026-07-04): **nothing** — P12 unwired, DLC10 cable missing, no
+USB relay detected. The W417 hygiene wave did not change the bench. Default to
+**Variant C** for W418.
+
+---
+
+## Goals
+
+1. If the bench becomes available, capture real CCLK for `OSCFSEL=6/7` and
+   commit instrument-to-Lean theorems (Variant A).
+2. If relay hardware becomes available, automate cold-POR power-cycling and
+   capture real STAT (Variant B).
+3. Otherwise, keep hardening the formal model and the instrument-import path:
+   add a PVT-envelope lower-bound regression test, extend VCD parser coverage for
+   `$date`/`$version`/`$comment` headers and analog CSV voltage columns, build a
+   standalone Lean integration test from a synthetic CSV, and document the
+   first-real-capture checklist (Variant C).
+
+---
+
+## Work breakdown
+
+### Variant A — Physical CCLK capture
+
+Files: `fpga/HARDWARE_SSOT.md`, `proofs/lean4/Trinity/TernaryFPGABoot.lean`, `docs/reports/*`
+
+- Wire P12 to the logic analyzer.
+- Generate `OSCFSEL=6` and `OSCFSEL=7` variants with `tri fpga cclk-variants`.
+- Program each variant to flash, cold-POR boot, and capture CCLK.
+- Import captures with `tri fpga measured-to-lean --csv/--vcd --raw-ns --standalone --validate --pvt-context`.
+- Commit generated theorems and update `fpga/HARDWARE_SSOT.md`.
+
+### Variant B — Real relay-controlled cold-POR
+
+Files: `cli/tri/src/fpga.rs`, `fpga/HARDWARE_SSOT.md`
+
+- Select a relay interface (USB-serial relay module, smart power strip, or MCU GPIO bridge).
+- Implement a `RelayControl` trait with `power_cycle(delay_ms: u64)`.
+- Extend `FpgaCmd::ColdPor` to accept real `--relay-port` values.
+- Capture STAT after relay power-cycle and write a non-mock log.
+- Document wiring and safety rules.
+
+### Variant C — Further formal tooling (default fallback)
+
+Files: `cli/tri/src/fpga.rs`, `proofs/lean4/Trinity/TernaryFPGABoot.lean`, `fpga/HARDWARE_SSOT.md`, `docs/reports/*`
+
+1. **PVT-envelope regression test**
+   - Add a Rust unit test that exhaustively samples the operating rectangle
+     (temp, vccint, corner) and asserts
+     `n25q128_min_sck_half_ns_pvt ≥ NOMINAL_HALF_NS`.
+   - Add a Lean 4 lemma `n25q128_min_sck_half_ns_pvt_nonneg` proving the same
+     bound symbolically.
+   - Document in `fpga/HARDWARE_SSOT.md` how to replace the linear coefficients
+     once real N25Q128_3V PVT curves are available.
+
+2. **Instrument import coverage**
+   - VCD parser: skip `$date`, `$version`, `$comment` multi-line header sections
+     without confusing them with `$var` declarations.
+   - CSV parser: support analog CSV exports that contain a voltage column
+     directly, so `--vcd-threshold-v` is not the only analog path.
+   - Add unit tests for both.
+
+3. **Standalone Lean integration test**
+   - Extend `measured-to-lean --standalone` output so the generated file is a
+     complete, lake-buildable package snippet (imports + theorem + main proof).
+   - Add a Rust integration test that writes a synthetic CSV, runs
+     `tri fpga measured-to-lean --csv --raw-ns --standalone --pvt-context`, and
+     type-checks the result in a temporary `lake` package.
+
+4. **First-real-capture checklist**
+   - Update `fpga/HARDWARE_SSOT.md` with a step-by-step checklist for the first
+     real CCLK capture (wiring, samplerate, PVT context, validation,
+     theorem generation).
+
+---
+
+## Weak points
+
+1. **Physical evidence gap remains** under Variant C. The formal pipeline keeps
+   improving, but no silicon evidence is produced until P12 is wired and the
+   cable/relay hardware is available.
+2. **PVT envelope coefficients are still informed estimates**, not Micron
+   datasheet curves. The regression test only guards the lower bound; real
+   characterization may require larger margins.
+3. **VCD header sections** vary across tools (some emit `$date` on one line,
+   others across multiple lines). Header handling will be best-effort for the
+   most common variants.
+4. **Analog CSV voltage columns** have no standard format; the parser will
+   support the Saleae/DSView single-channel layout and document the expected
+   column names.
+5. **Standalone Lean integration test** depends on `lake` being available in
+   the test environment. CI must have Lean 4 installed.
+
+---
+
+## Competitor scan
+
+- **Sparkle HDL / Verilean:** formal Verilog-to-Lean/Coq verification; no public
+  instrument-to-Lean bridge or PVT-aware timing envelope for flash boot.
+- **SymbiYosys / Yosys formal:** bounded property checking on RTL; no link to
+  logic-analyzer measurements.
+- **Koika / Kami:** processor-model verification in Coq; unrelated to 7-series
+  boot timing.
+- **OpenFPGALoader / prjxray:** bitstream/JTAG tooling; no formal proof pipeline.
+- **TinyTapeout / Efabless:** silicon-shuttle flow; relies on PDK
+  characterization, not user-captured proofs.
+- **OpenSTA / vyges-sta-si:** gate-level STA with PVT/OCV derating, but no
+  instrument capture and no theorem-prover output.
+- **t27 differentiation:** still the only open pipeline converting instrument
+  exports (CSV/VCD) into Lean 4 proofs of flash timing compliance, now with an
+  explicit, falsifiable PVT uncertainty envelope, envelope monotonicity proofs,
+  per-OSCFSEL transaction theorems, and an integration-test path.
+
+---
+
+## Verification checklist
+
+- [ ] `cargo test -p tri fpga::tests` passes (new + existing tests).
+- [ ] `lake build Trinity.TernaryFPGABoot` passes from `proofs/lean4/`.
+- [ ] `./scripts/tri test` passes parse/typecheck/gen/seal-verify.
+- [ ] For Variant A: at least one generated `.lean` file builds standalone.
+- [ ] For Variant B: real relay port produces a non-mock boot log.
+- [x] For Variant C: PVT-envelope regression test, VCD header/analog CSV tests,
+      and standalone Lean integration test land.
+
+---
+
+## Acceptance criteria
+
+- The chosen variant is fully implemented and verified.
+- All invariant checks pass.
+- Report + evidence + W419 cooperation variants are produced.
+- PR closes #1353.
+
+---
+
+*φ² + φ⁻² = 3 | TRINITY*

--- a/.trinity/current-issue.md
+++ b/.trinity/current-issue.md
@@ -1,42 +1,85 @@
-# Wave Loop 417 — hygiene, reland W415/W416, and next-variant gate
+# Wave Loop 418 — FPGA physical capture, real relay gate, or further formal tooling
 
-**Issue:** #1350  
-**Branch:** `wave-loop-417`  
-**Milestone:** Close out the W415/W416 reland mess and set up the next FPGA boot-evidence wave.
+**Issue:** #1353  
+**Branch:** `wave-loop-418`  
+**Milestone:** Continue the FPGA boot-evidence line from W417.
 
 ---
 
 ## Goal
 
-Wave 415 and Wave 416 were stuck on a dirty PR (#1346) and a branch that had
-fallen behind `master`. Wave 417 lands the hygiene work: close/replace stale
-PRs, fix the branch target to `master` (Strategy P), repair the CI blocker
-introduced by the Russian cross-walk file, and produce the W417 report plus
-W418 cooperation variants.
+Wave 417 closed the W415/W416 hygiene loop. Wave 418 re-evaluates the bench
+state and executes the first available variant.
+
+1. **Variant A (preferred when bench becomes available):**
+   - Wire P12 to a logic-analyzer channel and capture real CCLK for
+     `OSCFSEL=6` and `OSCFSEL=7`.
+   - Import the captures with `tri fpga measured-to-lean --csv/--vcd --raw-ns
+     --standalone --validate --pvt-context <ctx.json>` and commit the generated
+     Lean theorems.
+   - Document the measured frequencies/duty cycles and PVT context in
+     `fpga/HARDWARE_SSOT.md`.
+
+2. **Variant B (if relay hardware is available):**
+   - Implement a real `--relay-port` backend for `tri fpga cold-por`
+     (e.g. serial or TCP relay controlling board power).
+   - Perform an automated cold-POR power-cycle and capture STAT without
+     operator intervention.
+   - Document relay wiring in `fpga/HARDWARE_SSOT.md`.
+
+3. **Variant C (fallback if bench still blocked):**
+   - Add a regression test that the PVT envelope stays ≥ the nominal bound
+     across the full operating rectangle.
+   - Extend instrument import for VCD `$date`/`$version`/`$comment` headers and
+     analog CSV voltage columns.
+   - Build a standalone Lean proof integration test from a synthetic CSV.
+   - Document the first-real-capture checklist in `fpga/HARDWARE_SSOT.md`.
 
 ---
 
 ## Decomposed plan
 
+See `docs/reports/FPGA_LOOP_COOPERATION_W418_2026-07-04.md`.
+
 | Step | File(s) | Deliverable |
 |------|---------|-------------|
-| 1 | GitHub PRs/issues | Close superseded #1351; confirm stale wave-loop PRs/issues are closed |
-| 2 | `docs/BRANCHING_MODEL.md` | Document Strategy P: wave-loop PR target is `master` |
-| 3 | `docs/.legacy-non-english-docs` | Allowlist `conformance/vectors/CROSSWALK_sw_hw.md` until translated |
-| 4 | `docs/NOW.md` | Update W417 section to in-progress / close-out state |
-| 5 | `docs/reports/*` | `WAVE_LOOP_417_REPORT.md`, `FPGA_LOOP_EVIDENCE_W417_2026-07-04.md`, `FPGA_LOOP_COOPERATION_W418_2026-07-04.md` |
-| 6 | `.trinity/experience.md` | Capture W417 learnings |
-| 7 | git/PR | Open PR from `wave-loop-417` to `master`, close #1350, create #1353 for W418 |
+| 1 | `cli/tri/src/fpga.rs` | Variant A import, B relay backend, or C regression/integration tests |
+| 2 | `proofs/lean4/Trinity/TernaryFPGABoot.lean` | PVT envelope regression lemma or new measured theorems |
+| 3 | `fpga/HARDWARE_SSOT.md` | Updated capture / relay / integration protocol |
+| 4 | `docs/reports/*` | W418 report, evidence, W419 cooperation |
+| 5 | `.trinity/experience.md` | W418 learnings |
+| 6 | git/PR | squash-merge to `master`, close #1353, open #? for W419 |
 
 ---
 
 ## Acceptance criteria
 
-- [ ] AC-1: `docs/BRANCHING_MODEL.md` clearly states wave-loop PRs target `master`.
-- [ ] AC-2: `cargo build --release` in `bootstrap/` no longer panics on the Russian cross-walk file.
-- [ ] AC-3: `./scripts/tri test` parse/typecheck/gen/seal phases pass.
-- [ ] AC-4: W417 report and W418 cooperation files exist and are linked from `docs/NOW.md`.
-- [ ] AC-5: PR from `wave-loop-417` to `master` is opened with `Closes #1350`.
+### Bundle A
+- [ ] AC-A1: P12 is wired to a logic-analyzer channel and real CCLK capture files exist for `OSCFSEL=6` and `OSCFSEL=7`.
+- [ ] AC-A2: `tri fpga measured-to-lean --csv/--vcd --raw-ns --standalone` generated Lean files build with `lake build`.
+- [ ] AC-A3: Measured CCLK is within the N25Q128_3V spec, or any exceedance is explicitly explained.
+
+### Bundle B
+- [ ] AC-B1: `tri fpga cold-por <bit> --relay-port <real>` performs an automated power-cycle and captures STAT.
+- [ ] AC-B2: The resulting log has `relay_mock: false` and a real STAT raw value.
+- [ ] AC-B3: `fpga/HARDWARE_SSOT.md` documents relay wiring and port mapping.
+
+### Bundle C
+- [ ] AC-C1: A regression test verifies the PVT envelope lower bound across the operating rectangle.
+- [ ] AC-C2: Instrument import handles VCD `$date`/`$version`/`$comment` headers or analog CSV voltage columns.
+- [ ] AC-C3: A standalone `.lean` file generated from the CLI type-checks in a temporary `lake` package.
+
+### Invariant checks
+- [ ] `./scripts/tri test` parse/typecheck/gen/seal-verify phases pass.
+- [ ] `lake build Trinity.TernaryFPGABoot` passes.
+- [ ] `cargo test -p tri fpga::tests` passes.
+
+---
+
+## Default variant
+
+Execute **Variant A** if the analyzer is wired. Otherwise try **Variant B** if a
+relay is available. Otherwise fall back to **Variant C**.
 
 ---
 

--- a/.trinity/current_task/activity.md
+++ b/.trinity/current_task/activity.md
@@ -1456,3 +1456,7 @@
 - **Commit:** docs(NOW): W418 setup, mark W417 PR #1354 merged
 - **Files:** .trinity/current_task/activity.md,docs/NOW.md
 
+## 2026-07-04T16:57:24Z — wave-loop-418
+- **Commit:** docs(NOW): W418 setup, mark W417 PR #1354 merged
+- **Files:** .claude/plans/wave-loop-418.md,.trinity/experience.md,cli/tri/src/fpga.rs,docs/NOW.md,docs/reports/FPGA_LOOP_COOPERATION_W419_2026-07-04.md,docs/reports/FPGA_LOOP_EVIDENCE_W418_2026-07-04.md,docs/reports/WAVE_LOOP_418_REPORT.md,fpga/HARDWARE_SSOT.md,proofs/lean4/Trinity/TernaryFPGABoot.lean
+

--- a/.trinity/current_task/activity.md
+++ b/.trinity/current_task/activity.md
@@ -1444,3 +1444,15 @@
 - **Commit:** docs(NOW): W418 header, fix W417 issue reference to #1350, add Last updated line
 - **Files:** .trinity/current-issue.md,.trinity/experience.md,docs/.legacy-non-english-docs,docs/BRANCHING_MODEL.md,docs/NOW.md,docs/reports/FPGA_LOOP_COOPERATION_W418_2026-07-04.md,docs/reports/FPGA_LOOP_EVIDENCE_W417_2026-07-04.md,docs/reports/WAVE_LOOP_417_REPORT.md
 
+## 2026-07-04T16:40:02Z — wave-loop-418
+- **Commit:** docs(w417): hygiene, Strategy P, legacy allowlist, W417 close-out artifacts
+- **Files:** .trinity/current-issue.md
+
+## 2026-07-04T16:40:27Z — wave-loop-418
+- **Commit:** docs(w418): set up current issue for Wave Loop 418
+- **Files:** docs/NOW.md
+
+## 2026-07-04T16:40:35Z — wave-loop-418
+- **Commit:** docs(NOW): W418 setup, mark W417 PR #1354 merged
+- **Files:** .trinity/current_task/activity.md,docs/NOW.md
+

--- a/.trinity/experience.md
+++ b/.trinity/experience.md
@@ -1,5 +1,63 @@
 # t27 / Trinity Agent Experience Log
 
+## 2026-07-04 — Wave Loop 418 (Variant C fallback: PVT regression, instrument import, standalone Lean integration)
+
+### What worked
+- Adding a PVT-envelope **lower-bound regression test** in Rust and a matching
+  Lean 4 lemma kept the placeholder envelope honest: every sampled operating
+  context must produce `n25q128_min_sck_half_ns_pvt >= 6 ns`. The Rust test
+  catches accidental coefficient changes; the Lean lemma proves the bound
+  symbolically.
+- Skipping multi-line VCD `$date`/`$version`/`$comment` header sections with a
+  small state machine was a contained parser change that prevents common
+  vendor headers from being mistaken for `$var` declarations.
+- Detecting the analog CSV voltage column by header name (`voltage`, `v`,
+  `analog`) fixes multi-channel imports where the first numeric column after
+  time is the wrong signal. Adding a `header_named_columns` guard prevents the
+  first-data-row numeric fallback from overriding an explicitly named column.
+- The **standalone Lean integration test** proves that `measured-to-lean
+  --standalone --raw-ns` emits a file that builds inside a fresh temporary lake
+  package requiring only the local Trinity library. This closes the gap between
+  CLI output and external consumption.
+- Documenting the first-real-capture checklist and the PVT coefficient replacement
+  recipe in `fpga/HARDWARE_SSOT.md` turns the current physical-evidence gap into
+  an actionable protocol once the bench is wired.
+
+### What changed behavior
+- `cli/tri/src/fpga.rs`: added PVT lower-bound regression test; added VCD
+  multi-line header skip; added analog CSV voltage-column auto-detection; added
+  standalone lake-package integration test.
+- `proofs/lean4/Trinity/TernaryFPGABoot.lean`: added
+  `n25q128_min_sck_half_ns_pvt` and `pvt_half_ns_at_least_nominal`.
+- `fpga/HARDWARE_SSOT.md`: added §3.6.14 first-real-capture checklist and
+  §3.6.15 PVT coefficient replacement recipe.
+- `docs/NOW.md`: updated W418 close-out and W419 setup.
+- Close-out artifacts: `docs/reports/WAVE_LOOP_418_REPORT.md`,
+  `docs/reports/FPGA_LOOP_EVIDENCE_W418_2026-07-04.md`, and
+  `docs/reports/FPGA_LOOP_COOPERATION_W419_2026-07-04.md`.
+
+### Patterns to reuse
+- When a formal model uses placeholder coefficients, add both a symbolic
+  lower-bound lemma and an exhaustive numeric regression test. The lemma
+  documents the invariant; the test guards against accidental regressions.
+- For instrument parsers, add a regression test that exercises the exact quirk
+  (multi-line VCD header, named CSV column) so future refactors do not drop the
+  special case.
+- To prove a generated proof artifact is externally consumable, build it inside
+  a temporary package that depends on the real library via a local path. This
+  reuses existing `.lake` caches and avoids network downloads in CI.
+- When hardware is unavailable, convert the blocked physical step into a
+  checklist and a falsifiable model update so the next wave can execute it
+  immediately once the bench is ready.
+
+### Anti-patterns to avoid
+- Do not let a parser fallback override an explicit user/header signal; track
+  whether the header named the columns and skip the fallback when it did.
+- Do not add PVT coefficients in only one of the Rust or Lean files; keep the
+  two models synchronized so the CLI and the proof assistant agree.
+- Do not claim an integration test passes just because the unit test of the
+  generator passes; actually invoke `lake build` on the generated file.
+
 ## 2026-07-04 — Wave Loop 417 (hygiene, reland W415/W416, Strategy P)
 
 ### What worked

--- a/cli/tri/src/fpga.rs
+++ b/cli/tri/src/fpga.rs
@@ -2340,7 +2340,7 @@ struct MeasuredCclkRawNs {
 
 /// Process corner used for PVT-aware flash timing derating.
 /// Mirrors `ProcessCorner` in `proofs/lean4/Trinity/TernaryFPGABoot.lean`.
-#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 enum ProcessCorner {
     Tt,
@@ -3440,6 +3440,7 @@ fn parse_cclk_csv_reader<R: std::io::BufRead>(reader: R) -> Result<(f64, f64)> {
     let mut times: Vec<f64> = Vec::new();
     let mut values: Vec<f64> = Vec::new();
     let mut header_seen = false;
+    let mut header_named_columns = false;
     let mut time_idx = 0usize;
     let mut value_idx = 1usize;
 
@@ -3462,12 +3463,29 @@ fn parse_cclk_csv_reader<R: std::io::BufRead>(reader: R) -> Result<(f64, f64)> {
                 || lower.contains("samplerate")
                 || lower.contains("sample")
                 || lower.contains("voltage")
+                || lower.contains("analog")
         });
         if has_header_token && !header_seen {
             header_seen = true;
-            // Find the first numeric-looking column index in the next data row
-            // lazily by recording candidates; we default to (0, 1) and refine
-            // on the first fully-numeric row.
+            let header_names: Vec<String> = parts.iter().map(|s| s.to_lowercase()).collect();
+            // Prefer the voltage/analog column as the signal value if the header
+            // names it explicitly. This fixes multi-channel CSVs where the first
+            // numeric column after time is the wrong channel.
+            for (i, name) in header_names.iter().enumerate() {
+                if name.contains("voltage") || name == "v" || name.contains("analog") {
+                    value_idx = i;
+                    header_named_columns = true;
+                    break;
+                }
+            }
+            // Time column is usually named time/s/time_s/timestamp; default to 0.
+            for (i, name) in header_names.iter().enumerate() {
+                if name.contains("time") || name == "t" || name.contains("timestamp") {
+                    time_idx = i;
+                    header_named_columns = true;
+                    break;
+                }
+            }
             continue;
         }
 
@@ -3478,8 +3496,8 @@ fn parse_cclk_csv_reader<R: std::io::BufRead>(reader: R) -> Result<(f64, f64)> {
             .collect();
 
         // If this is the first data row and we have at least two numeric columns,
-        // lock the time/value indices.
-        if !header_seen || (times.is_empty() && parsed.iter().filter(|x| x.is_some()).count() >= 2) {
+        // lock the time/value indices only when the header did not name them.
+        if !header_seen || (!header_named_columns && times.is_empty() && parsed.iter().filter(|x| x.is_some()).count() >= 2) {
             let numeric_positions: Vec<usize> = parsed
                 .iter()
                 .enumerate()
@@ -3614,6 +3632,9 @@ fn parse_vcd_to_raw_ns(
     let mut var_tokens: Vec<String> = Vec::new();
     let mut in_timescale = false;
     let mut ts_tokens: Vec<String> = Vec::new();
+    let mut in_date = false;
+    let mut in_version = false;
+    let mut in_comment = false;
     let mut past_dumpvars = false;
     let mut dumpoff = false;
     let mut current_time_s: f64 = 0.0;
@@ -3628,6 +3649,48 @@ fn parse_vcd_to_raw_ns(
             continue;
         }
         let tokens: Vec<&str> = trimmed.split_whitespace().collect();
+
+        // Header sections that must be skipped entirely so their contents are
+        // never mistaken for `$var` declarations or value changes.
+        if trimmed.to_lowercase().starts_with("$date") {
+            in_date = true;
+            if trimmed.to_lowercase().ends_with("$end") || trimmed.to_lowercase().contains(" $end") {
+                in_date = false;
+            }
+            continue;
+        }
+        if in_date {
+            if trimmed.to_lowercase().ends_with("$end") || trimmed.eq_ignore_ascii_case("$end") {
+                in_date = false;
+            }
+            continue;
+        }
+        if trimmed.to_lowercase().starts_with("$version") {
+            in_version = true;
+            if trimmed.to_lowercase().ends_with("$end") || trimmed.to_lowercase().contains(" $end") {
+                in_version = false;
+            }
+            continue;
+        }
+        if in_version {
+            if trimmed.to_lowercase().ends_with("$end") || trimmed.eq_ignore_ascii_case("$end") {
+                in_version = false;
+            }
+            continue;
+        }
+        if trimmed.to_lowercase().starts_with("$comment") {
+            in_comment = true;
+            if trimmed.to_lowercase().ends_with("$end") || trimmed.to_lowercase().contains(" $end") {
+                in_comment = false;
+            }
+            continue;
+        }
+        if in_comment {
+            if trimmed.to_lowercase().ends_with("$end") || trimmed.eq_ignore_ascii_case("$end") {
+                in_comment = false;
+            }
+            continue;
+        }
 
         // Timescale parsing: `$timescale 1 ns $end` (possibly across lines).
         if trimmed.to_lowercase().starts_with("$timescale") {
@@ -4860,6 +4923,24 @@ mod tests {
         assert!((duty - 60.0).abs() < 5.0, "duty {} should be ~60%", duty);
     }
 
+    /// Voltage column is explicitly named and is not the second column. The
+    /// parser must use the named voltage column rather than the first numeric
+    /// column after time.
+    #[test]
+    fn test_parse_cclk_csv_named_voltage_column() {
+        let mut csv = String::from("time_s,counter,voltage\n");
+        let dt = (1.0 / 8.0e6) / 20.0;
+        for i in 0..200 {
+            let t = i as f64 * dt;
+            let counter = i as f64; // steadily increasing, not the signal
+            let v = if i % 20 < 10 { 0.0 } else { 3.3 }; // 50% duty 8 MHz
+            csv.push_str(&format!("{:.12},{},{}\n", t, counter, v));
+        }
+        let (freq, duty) = parse_cclk_csv_reader(std::io::Cursor::new(csv)).unwrap();
+        assert!((freq - 8.0e6).abs() < 150_000.0, "freq {} should be ~8 MHz", freq);
+        assert!((duty - 50.0).abs() < 5.0, "duty {} should be ~50%", duty);
+    }
+
     #[test]
     fn test_parse_cclk_csv_too_few_samples() {
         let csv = "Time,Voltage\n0.0,0.0\n1.0,3.3\n";
@@ -5233,6 +5314,49 @@ mod tests {
         std::fs::remove_file(&vcd_tmp).unwrap();
     }
 
+    /// Multi-line $date / $version / $comment header sections must be skipped so
+    /// their free-form contents are not mistaken for $var declarations. This
+    /// is a regression test for vendor VCDs that split the header across lines.
+    #[test]
+    fn test_parse_vcd_multiline_header_sections_skipped() {
+        let timescale_ps = 100;
+        let mut vcd = String::new();
+        vcd.push_str("$date\n");
+        vcd.push_str("  Thu Jan 01 00:00:00 2026\n");
+        vcd.push_str("$end\n");
+        vcd.push_str("$version\n");
+        vcd.push_str("  SomeVendor Simulator 1.2.3\n");
+        vcd.push_str("$end\n");
+        vcd.push_str("$comment\n");
+        vcd.push_str("  This is a multi-line comment that could contain words like wire or reg.\n");
+        vcd.push_str("$end\n");
+        vcd.push_str(&format!("$timescale {} ps $end\n", timescale_ps));
+        vcd.push_str("$scope module top $end\n");
+        vcd.push_str("$var wire 1 ! cclk $end\n");
+        vcd.push_str("$upscope $end\n");
+        vcd.push_str("$enddefinitions $end\n");
+        vcd.push_str("$dumpvars\n");
+        vcd.push_str("0!\n");
+        vcd.push_str("$end\n");
+        let period_s = 1.0 / 25_000_000.0;
+        let half_s = period_s / 2.0;
+        let mut t = 0.0;
+        for i in 0..40 {
+            t += half_s;
+            let ts = (t / (timescale_ps as f64 * 1.0e-12)).round() as u64;
+            let val = if i % 2 == 0 { '1' } else { '0' };
+            vcd.push_str(&format!("#{}\n{}!\n", ts, val));
+        }
+        let vcd_tmp = std::env::temp_dir().join(format!("tri_test_vcd_multiline_header_{}.vcd", std::process::id()));
+        std::fs::write(&vcd_tmp, vcd).unwrap();
+        let (period_ns, low_ns, high_ns) = parse_vcd_to_raw_ns(
+            &vcd_tmp, Some("cclk"), 0, None).unwrap();
+        assert_eq!(period_ns, 40, "period {} should be 40 ns", period_ns);
+        assert_eq!(low_ns, 20, "low {} should be 20 ns", low_ns);
+        assert_eq!(high_ns, 20, "high {} should be 20 ns", high_ns);
+        std::fs::remove_file(&vcd_tmp).unwrap();
+    }
+
     /// VCD with an escaped identifier that contains a space in the name.
     /// The parser must join name tokens and strip the leading backslash.
     #[test]
@@ -5502,6 +5626,35 @@ mod tests {
         assert!(out.is_ok());
     }
 
+    /// Regression: the PVT-aware minimum SCK half-period bound must be at least
+    /// the nominal 6 ns across the entire operating rectangle. This mirrors the
+    /// Lean 4 `pvt_half_ns_at_least_nominal` lemma and catches accidental
+    /// coefficient changes that would shrink the envelope below the datasheet.
+    #[test]
+    fn test_pvt_half_ns_lower_bound_across_operating_rectangle() {
+        let temps = [PVT_TEMP_MIN_C, -20_i64, 0_i64, 25_i64, PVT_TEMP_MAX_C];
+        let vccints = [PVT_VCCINT_MIN_MV, 950_u64, 1000_u64, 1050_u64, PVT_VCCINT_MAX_MV];
+        let corners = [ProcessCorner::Ff, ProcessCorner::Tt, ProcessCorner::Ss];
+        for temp in temps {
+            for vccint in vccints {
+                for corner in &corners {
+                    let ctx = PvtContext {
+                        temp_c: temp,
+                        vccint_mv: vccint,
+                        vccaux_mv: 2700,
+                        process_corner: corner.clone(),
+                    };
+                    let half_ns = n25q128_min_sck_half_ns_pvt(&ctx);
+                    assert!(
+                        half_ns >= 6,
+                        "PVT half-period bound {} ns below nominal 6 ns at temp={} °C, vccint={} mV, corner={:?}",
+                        half_ns, temp, vccint, corner
+                    );
+                }
+            }
+        }
+    }
+
     #[test]
     fn test_parse_pvt_context_roundtrip() {
         let pvt = write_pvt_context_json(
@@ -5554,5 +5707,81 @@ mod tests {
             assert!(out.is_err());
         }
         let _ = std::fs::remove_dir_all(&log_dir);
+    }
+
+    /// Standalone Lean integration test: a synthetic raw-ns capture is exported
+    /// with `--standalone`, then copied into a minimal temporary `lake` package
+    /// that depends on the local Trinity library. The package must typecheck
+    /// with `lake build`, proving the generated theorem is consumable outside
+    /// the monorepo.
+    #[test]
+    fn test_measured_to_lean_standalone_lake_package_builds() {
+        let root = repo_root().unwrap();
+        let trinity_pkg = root.join("proofs").join("lean4");
+        if !trinity_pkg.join("lakefile.lean").is_file() {
+            // Skip if the Trinity package is not present in this checkout.
+            return;
+        }
+
+        // Generate a synthetic raw-ns capture.
+        let m = MeasuredCclkRawNs {
+            period_ns: 40,
+            sck_low_ns: 20,
+            sck_high_ns: 20,
+            source: "synthetic".to_string(),
+        };
+        let json = serde_json::to_string(&m).unwrap();
+        let tmp = std::env::temp_dir().join(format!(
+            "tri_standalone_lake_in_{}.json",
+            std::process::id()
+        ));
+        std::fs::write(&tmp, json).unwrap();
+
+        let generated = std::env::temp_dir().join(format!(
+            "tri_standalone_lake_generated_{}.lean",
+            std::process::id()
+        ));
+        let out = measured_to_lean(
+            Some(&tmp), None, None, None, 0, None, Some(&generated),
+            "measured_cclk", false, None, true, true, false,
+        );
+        assert!(out.is_ok(), "measured-to-lean standalone should succeed: {:?}", out);
+        assert!(generated.is_file(), "generated Lean file should exist");
+
+        // Create a minimal temporary lake package that consumes the theorem.
+        let pkg_dir = std::env::temp_dir().join(format!(
+            "tri_standalone_lake_pkg_{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&pkg_dir);
+        std::fs::create_dir_all(pkg_dir.join(".lake")).unwrap();
+
+        let trinity_path = trinity_pkg.canonicalize().unwrap_or_else(|_| trinity_pkg.clone());
+        let lakefile = format!(
+            "import Lake\nopen Lake DSL\n\npackage StandaloneTest where\n\nrequire Trinity from \"{}\"\n\n@[default_target]\nlean_lib StandaloneTest where\n",
+            trinity_path.display().to_string().replace('\\', "/")
+        );
+        std::fs::write(pkg_dir.join("lakefile.lean"), lakefile).unwrap();
+        std::fs::copy(&generated, pkg_dir.join("StandaloneTest.lean")).unwrap();
+
+        // Build the temporary package. This reuses the local Trinity/.lake cache
+        // because the dependency is a local path.
+        let lake_status = std::process::Command::new("lake")
+            .arg("build")
+            .current_dir(&pkg_dir)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .status();
+
+        // Clean up inputs before assertions so failures still remove temp files.
+        let _ = std::fs::remove_file(&tmp);
+        let _ = std::fs::remove_file(&generated);
+        let _ = std::fs::remove_dir_all(&pkg_dir);
+
+        let status = lake_status.expect("lake command should be available");
+        assert!(
+            status.success(),
+            "temporary lake package consuming standalone measured-to-lean output should build"
+        );
     }
 }

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,11 +2,27 @@
 
 Last updated: 2026-07-04
 
+## Wave Loop 418 — FPGA physical capture, real relay gate, or further formal tooling (Issue #1353)
+
+- Branch: `wave-loop-418`
+- Issue: #1353
+- PR: to open after work
+- Report: `docs/reports/WAVE_LOOP_418_REPORT.md` (to create)
+- Evidence: `docs/reports/FPGA_LOOP_EVIDENCE_W418_2026-07-04.md` (to create)
+- Cooperation W419: `docs/reports/FPGA_LOOP_COOPERATION_W419_2026-07-04.md` (to create)
+
+### Candidate variants
+- Variant A: capture real CCLK for `OSCFSEL=6/7` once P12 is wired and the analyzer / DLC10 cable is available.
+- Variant B: implement a real `--relay-port` backend once a relay board or USB power switch is available.
+- Variant C: PVT envelope regression test, VCD `$date`/`$version`/`$comment` headers, analog CSV voltage columns, standalone Lean integration test.
+
+---
+
 ## Wave Loop 417 — hygiene, reland W415/W416, and next-variant gate (Closes #1350)
 
 - Branch: `wave-loop-417`
 - Issue: #1350
-- PR: #1351/#1352 (W415 and W416 relanded; see report)
+- PR: #1354
 - Report: `docs/reports/WAVE_LOOP_417_REPORT.md`
 - Evidence: `docs/reports/FPGA_LOOP_EVIDENCE_W417_2026-07-04.md`
 - Cooperation W418: `docs/reports/FPGA_LOOP_COOPERATION_W418_2026-07-04.md`
@@ -16,9 +32,10 @@ Last updated: 2026-07-04
 - Rebased `wave-loop-416` onto current master; opened and merged PR #1352 with corrected `Closes #1349` link.
 - Closed superseded PR #1351 after its commits reached `master` via PR #1352.
 - Closed stale wave-loop PRs #1315, #1317, #1322, #1324, #1330 and issues #1313, #1316, #1318, #1323, #1325.
-- Created real tracking issues #1349 (W416) and #1350 (W417).
+- Created real tracking issues #1349 (W416), #1350 (W417), and #1353 (W418).
 - Updated `docs/BRANCHING_MODEL.md` to master-first Strategy P.
 - Allowlisted `conformance/vectors/CROSSWALK_sw_hw.md` in `docs/.legacy-non-english-docs` to unblock the `fpga-smoke` / `t27c` language-policy check while the file awaits translation.
+- Merged PR #1354 (wave-loop-417 → master).
 
 ### Not done (blocked on hardware)
 - Real P12 CCLK capture for `OSCFSEL=6/7` — P12 unwired, DLC10 cable missing.

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,20 +1,62 @@
-# NOW — Wave Loop 417 close-out / Wave Loop 418 setup (2026-07-04)
+# NOW — Wave Loop 418 close-out / Wave Loop 419 setup (2026-07-04)
 
 Last updated: 2026-07-04
 
-## Wave Loop 418 — FPGA physical capture, real relay gate, or further formal tooling (Issue #1353)
+## Wave Loop 419 — physical CCLK capture, real relay gate, or further formal tooling (Issue #1354)
 
-- Branch: `wave-loop-418`
-- Issue: #1353
+- Branch: `wave-loop-419`
+- Issue: #1354 (to create)
 - PR: to open after work
-- Report: `docs/reports/WAVE_LOOP_418_REPORT.md` (to create)
-- Evidence: `docs/reports/FPGA_LOOP_EVIDENCE_W418_2026-07-04.md` (to create)
-- Cooperation W419: `docs/reports/FPGA_LOOP_COOPERATION_W419_2026-07-04.md` (to create)
+- Report: `docs/reports/WAVE_LOOP_419_REPORT.md` (to create)
+- Evidence: `docs/reports/FPGA_LOOP_EVIDENCE_W419_2026-07-04.md` (to create)
+- Cooperation W420: `docs/reports/FPGA_LOOP_COOPERATION_W420_2026-07-04.md` (to create)
 
 ### Candidate variants
 - Variant A: capture real CCLK for `OSCFSEL=6/7` once P12 is wired and the analyzer / DLC10 cable is available.
 - Variant B: implement a real `--relay-port` backend once a relay board or USB power switch is available.
-- Variant C: PVT envelope regression test, VCD `$date`/`$version`/`$comment` headers, analog CSV voltage columns, standalone Lean integration test.
+- Variant C: further instrument-import parity, PVT envelope monotonicity tests, and standalone lake-package documentation.
+
+---
+
+## Wave Loop 418 — Variant C fallback: PVT regression, instrument import, and standalone Lean integration (Closes #1353)
+
+- Branch: `wave-loop-418`
+- Issue: #1353
+- PR: to open
+- Report: `docs/reports/WAVE_LOOP_418_REPORT.md`
+- Evidence: `docs/reports/FPGA_LOOP_EVIDENCE_W418_2026-07-04.md`
+- Cooperation W419: `docs/reports/FPGA_LOOP_COOPERATION_W419_2026-07-04.md`
+
+### What landed (Variant C — bench still blocked)
+- `cli/tri/src/fpga.rs`
+  - Added PVT-envelope lower-bound regression test across the operating rectangle
+    (`test_pvt_half_ns_lower_bound_across_operating_rectangle`).
+  - Hardened VCD parser to skip multi-line `$date`/`$version`/`$comment` header
+    sections (`test_parse_vcd_multiline_header_sections_skipped`).
+  - Improved analog CSV voltage-column auto-detection by header name
+    (`voltage`, `v`, `analog`) for multi-channel exports
+    (`test_parse_cclk_csv_named_voltage_column`).
+  - Added standalone Lean integration test that builds the generated theorem in
+    a temporary `lake` package
+    (`test_measured_to_lean_standalone_lake_package_builds`).
+- `proofs/lean4/Trinity/TernaryFPGABoot.lean`
+  - Added `n25q128_min_sck_half_ns_pvt` and the matching lower-bound lemma
+    `pvt_half_ns_at_least_nominal`.
+- `fpga/HARDWARE_SSOT.md`
+  - Added §3.6.14 "First real CCLK capture checklist".
+  - Added §3.6.15 "Replacing the placeholder PVT envelope coefficients" with
+    current coefficients and a replacement recipe.
+
+### Not done (blocked on hardware)
+- Real P12 CCLK capture for `OSCFSEL=6/7` — P12 unwired, DLC10 cable missing.
+- Real relay cold-POR gate — no relay board / USB power switch available.
+
+### Verification
+- `cargo test -p tri pvt`: **PASS** (3 tests).
+- `cargo test -p tri vcd`: **PASS** (11 tests).
+- `cargo test -p tri csv`: **PASS** (10 tests).
+- `cargo test -p tri test_measured_to_lean_standalone_lake_package_builds`: **PASS**.
+- `lake build Trinity.TernaryFPGABoot`: **PASS** (2967 jobs).
 
 ---
 

--- a/docs/reports/FPGA_LOOP_COOPERATION_W419_2026-07-04.md
+++ b/docs/reports/FPGA_LOOP_COOPERATION_W419_2026-07-04.md
@@ -1,0 +1,101 @@
+# FPGA Loop Cooperation Variants — Wave 419 (2026-07-04)
+
+**Next issue:** #1354  
+**Next branch:** `wave-loop-419`  
+**Anchor:** φ² + φ⁻² = 3 | TRINITY
+
+Wave 418 closed the Variant C fallback (formal tooling and instrument import).
+For Wave 419 the bench status may change, so three cooperation variants are
+defined.
+
+---
+
+## Variant A — Physical CCLK capture (preferred if bench becomes available)
+
+**Trigger:** P12 is wired to a logic-analyzer channel, the DSLogic / sigrok setup
+works, and the DLC10 cable is available for programming.
+
+**Deliverables:**
+
+1. Generate `OSCFSEL=6` and `OSCFSEL=7` bitstream variants with
+   `tri fpga cclk-variants`.
+2. Program each variant to SPI flash and perform a true cold-POR boot.
+3. Capture the CCLK trace during configuration for each variant using
+   `tri fpga measure-cclk --live` or a DSView / sigrok export.
+4. Import the captures with `tri fpga measured-to-lean --csv/--vcd --raw-ns
+   --standalone --validate --pvt-context <ctx.json>` and commit the generated
+   `.lean` files (or paste them into `proofs/lean4/Trinity/TernaryFPGABoot.lean`).
+5. Document the measured frequencies, duty cycles, and PVT context in
+   `fpga/HARDWARE_SSOT.md`.
+
+**Acceptance criteria:**
+- Real CCLK CSV/VCD files exist for both oscillator settings.
+- Generated Lean theorems build with `lake build`.
+- Measured CCLK satisfies the PVT-aware flash spec or is explicitly explained.
+
+---
+
+## Variant B — Real relay-controlled cold-POR CI gate
+
+**Trigger:** The bench has a relay board (or a USB-controllable power switch) and
+the Digilent DLC10 cable is detected, but P12 is not wired for CCLK capture.
+
+**Deliverables:**
+
+1. Select a relay interface (USB-serial relay module, smart power strip with a
+   local API, or a microcontroller GPIO bridge).
+2. Implement a small `RelayControl` trait with `power_cycle(delay_ms: u64)`.
+3. Extend `FpgaCmd::ColdPor` so `--relay-port` accepts real port strings
+   (`/dev/cu.usbserial-*`, `tcp://...`) in addition to `MOCK`.
+4. After relay power-cycle, run `capture_stat` and write a real boot log with
+   `relay_mock: false`.
+5. Add Rust tests for the relay protocol framing (without touching hardware).
+6. Document relay wiring, port syntax, and safety rules in
+   `fpga/HARDWARE_SSOT.md`.
+
+**Acceptance criteria:**
+- `tri fpga cold-por <bit> --relay-port <real>` performs an automated
+  power-cycle and captures STAT.
+- The resulting log has `relay_mock: false` and a real STAT raw value.
+- `fpga/HARDWARE_SSOT.md` documents relay wiring and port mapping.
+
+---
+
+## Variant C — Instrument-import parity and PVT envelope polish (fallback)
+
+**Trigger:** P12 and the relay hardware are still unavailable.
+
+**Deliverables:**
+
+1. Extend VCD parser parity:
+   - Add support for additional real-valued net formats and vendor-specific
+     timescale syntaxes if samples are available.
+   - Harden `$comment` sections that contain nested `$end`-like tokens.
+2. Extend analog CSV parity:
+   - Add auto-detection for additional voltage column names observed in the wild
+     (`vccint`, `vccaux`, `cclk_v`, etc.).
+   - Support multi-channel CSVs where the user selects the active channel by name.
+3. PVT envelope polish:
+   - Add a Lean 4 monotonicity proof for the voltage derating.
+   - Add a Rust test that checks the envelope is monotone in temperature and
+     antitone in VCCINT.
+4. Documentation:
+   - Add a worked example of the full `measured-to-lean --standalone` lake
+     package workflow to `fpga/HARDWARE_SSOT.md`.
+
+**Acceptance criteria:**
+- At least one additional instrument-import unit test lands.
+- The PVT envelope has monotonicity/antitonicity tests in both Rust and Lean.
+- The standalone lake-package workflow is documented end-to-end.
+
+---
+
+## Default selection
+
+1. Try **Variant A** if the analyzer and DLC10 cable are available.
+2. Else try **Variant B** if a relay and DLC10 cable are available.
+3. Else fall back to **Variant C**.
+
+---
+
+*φ² + φ⁻² = 3 | TRINITY*

--- a/docs/reports/FPGA_LOOP_EVIDENCE_W418_2026-07-04.md
+++ b/docs/reports/FPGA_LOOP_EVIDENCE_W418_2026-07-04.md
@@ -1,0 +1,92 @@
+# FPGA Loop Evidence — Wave Loop 418 (2026-07-04)
+
+**Issue:** #1353  
+**Branch:** `wave-loop-418`  
+**Scope:** Variant C fallback — formal tooling, instrument import coverage,
+PVT regression test, and standalone Lean integration test.
+
+---
+
+## 1. PVT-envelope lower-bound regression
+
+Evidence: `cli/tri/src/fpga.rs`, `proofs/lean4/Trinity/TernaryFPGABoot.lean`
+
+- Rust test `test_pvt_half_ns_lower_bound_across_operating_rectangle` exhaustively
+  checks the operating rectangle and confirms
+  `n25q128_min_sck_half_ns_pvt(ctx) >= 6` for every sampled context.
+- Lean lemma `pvt_half_ns_at_least_nominal` proves the same bound symbolically for
+  any context inside the operating envelope.
+- Worst-case context (ss corner, 900 mV, +85 °C) produces a 13 ns bound.
+
+---
+
+## 2. VCD parser header hardening
+
+Evidence: `cli/tri/src/fpga.rs`
+
+- Added state machine for `$date`, `$version`, and `$comment` sections in
+  `parse_vcd_to_raw_ns`.
+- Multi-line header contents are skipped before `$var` / value-change parsing.
+- Regression test `test_parse_vcd_multiline_header_sections_skipped` verifies a
+  vendor-style multi-line header is parsed correctly.
+
+---
+
+## 3. Analog CSV voltage-column auto-detection
+
+Evidence: `cli/tri/src/fpga.rs`
+
+- Header names `voltage`, `v`, and `analog` are recognized as the signal column.
+- The named column is preferred over the first-numeric-column fallback.
+- Regression test `test_parse_cclk_csv_named_voltage_column` verifies a
+  three-column CSV where the signal is in the third column.
+
+---
+
+## 4. Standalone Lean integration test
+
+Evidence: `cli/tri/src/fpga.rs`
+
+- Rust test `test_measured_to_lean_standalone_lake_package_builds`:
+  1. writes a synthetic raw-ns capture (`period=40 ns`, `low=20 ns`, `high=20 ns`),
+  2. generates a self-contained `.lean` file via `--standalone --raw-ns`,
+  3. creates a temporary `lake` package requiring the local Trinity library,
+  4. builds the package with `lake build`,
+  5. asserts the build succeeds.
+
+This proves the `--standalone` output is a valid, buildable lake package snippet.
+
+---
+
+## 5. Local verification commands
+
+```bash
+# Rust checks
+cd /Users/playra/t27
+cargo check -p tri
+cargo test -p tri pvt
+cargo test -p tri vcd
+cargo test -p tri csv
+cargo test -p tri test_measured_to_lean_standalone_lake_package_builds
+
+# Lean check
+cd proofs/lean4
+lake build Trinity.TernaryFPGABoot
+```
+
+All commands above passed in the W418 development session.
+
+---
+
+## 6. Hardware status
+
+- P12 CCLK capture: **not wired**.
+- DLC10 cable: **missing** (VID 0x03FD not detected).
+- Relay board / USB power switch: **not available**.
+
+Therefore W418 executed Variant C and produced no new silicon evidence. W419 will
+again evaluate A/B/C variants.
+
+---
+
+*φ² + φ⁻² = 3 | TRINITY*

--- a/docs/reports/WAVE_LOOP_418_REPORT.md
+++ b/docs/reports/WAVE_LOOP_418_REPORT.md
@@ -1,0 +1,161 @@
+# Wave Loop 418 Report — Variant C fallback: PVT regression, instrument import, and standalone Lean integration
+
+**Issue:** #1353  
+**Branch:** `wave-loop-418`  
+**Variant:** C (bench still blocked: P12 unwired, DLC10 cable missing, no relay).  
+**Anchor:** φ² + φ⁻² = 3 | TRINITY
+
+---
+
+## Executive summary
+
+Wave Loop 418 kept the FPGA/formal pipeline moving while the physical bench
+remains unavailable. The wave delivered:
+
+- A **PVT-envelope lower-bound regression** in Rust and a matching Lean 4 lemma,
+  guarding the N25Q128_3V SCK half-period bound across the operating rectangle.
+- **VCD parser hardening** for multi-line `$date`/`$version`/`$comment` header
+  sections.
+- **Analog CSV voltage-column auto-detection** by header name, fixing multi-channel
+  imports where the signal is not the second column.
+- A **standalone Lean integration test** that writes a synthetic raw-ns capture,
+  generates a self-contained `.lean` file with `--standalone`, and type-checks it
+  inside a temporary `lake` package.
+- Updated `fpga/HARDWARE_SSOT.md` with a first-real-capture checklist and a recipe
+  for replacing the placeholder PVT coefficients once real N25Q128_3V PVT data
+  is available.
+
+No new silicon evidence was produced — the physical-evidence gap remains until
+P12 is wired and the cable/relay hardware is available.
+
+---
+
+## What changed
+
+### 1. PVT-envelope lower-bound regression
+
+`cli/tri/src/fpga.rs`:
+
+- Added `Clone` derive to `ProcessCorner` so contexts can be iterated in tests.
+- Added `test_pvt_half_ns_lower_bound_across_operating_rectangle`, which samples
+  temp ∈ {-40, -20, 0, 25, 85} °C, vccint ∈ {900, 950, 1000, 1050, 1100} mV,
+  and corners {ff, tt, ss}, then asserts
+  `n25q128_min_sck_half_ns_pvt(ctx) >= 6` for every point.
+
+`proofs/lean4/Trinity/TernaryFPGABoot.lean`:
+
+- Added `n25q128_min_sck_half_ns_pvt` as the symmetric half-period bound.
+- Added `pvt_half_ns_at_least_nominal`, a symbolic proof that the PVT-aware bound
+  is at least the nominal 6 ns across the operating envelope.
+
+### 2. VCD header-section skip
+
+`cli/tri/src/fpga.rs`:
+
+- Added per-line state variables `in_date`, `in_version`, `in_comment` in
+  `parse_vcd_to_raw_ns`.
+- Multi-line header sections are skipped entirely so their free-form contents
+  are never mistaken for `$var` declarations or value changes.
+- Added `test_parse_vcd_multiline_header_sections_skipped` to verify a vendor-style
+  multi-line header is parsed correctly.
+
+### 3. Analog CSV voltage-column detection
+
+`cli/tri/src/fpga.rs`:
+
+- Extended `parse_cclk_csv_reader` to recognize header tokens `voltage`, `v`,
+  and `analog` and use the named column as the signal value.
+- Added `header_named_columns` flag so the first-data-row numeric fallback does
+  not override an explicitly named voltage column.
+- Added `test_parse_cclk_csv_named_voltage_column` with a three-column CSV where
+  the voltage signal is the third column.
+
+### 4. Standalone Lean integration test
+
+`cli/tri/src/fpga.rs`:
+
+- Added `test_measured_to_lean_standalone_lake_package_builds`, which:
+  1. writes a synthetic `MeasuredCclkRawNs` JSON record,
+  2. calls `measured_to_lean` with `--standalone --raw-ns`,
+  3. creates a temporary `lake` package that requires the local Trinity library,
+  4. copies the generated `.lean` file as the package's main module,
+  5. runs `lake build` and asserts success.
+
+This proves the `--standalone` output is consumable outside the monorepo.
+
+### 5. HARDWARE_SSOT.md updates
+
+`fpga/HARDWARE_SSOT.md`:
+
+- Added §3.6.14 "First real CCLK capture checklist" covering wiring, capture,
+  PVT context recording, theorem generation, and typechecking.
+- Added §3.6.15 "Replacing the placeholder PVT envelope coefficients" with a
+  table of current coefficients and a step-by-step recipe for updating them once
+  real N25Q128_3V PVT curves are available.
+
+---
+
+## Verification results
+
+| Check | Result |
+|-------|--------|
+| `cargo check -p tri` | **PASS** |
+| `cargo test -p tri pvt` | **PASS** (3 PVT tests) |
+| `cargo test -p tri vcd` | **PASS** (11 VCD tests) |
+| `cargo test -p tri csv` | **PASS** (10 CSV tests) |
+| `cargo test -p tri test_measured_to_lean_standalone_lake_package_builds` | **PASS** |
+| `lake build Trinity.TernaryFPGABoot` | **PASS** |
+| Full `lake build` | blocked by pre-existing `Trinity.NeutrinoMasses` / `Trinity.H4Lagrangian` failures (unrelated to W418) |
+
+---
+
+## Weak points
+
+1. **Physical evidence gap remains.** P12 is still unwired and the DLC10 cable /
+   relay hardware is still missing, so no real CCLK capture or cold-POR log was
+   produced.
+2. **PVT coefficients are still placeholders.** The operating-rectangle regression
+   only guards the lower bound; real Micron curves may require different or larger
+   margins.
+3. **VCD header handling is best-effort.** It covers the most common single-line
+   and multi-line `$date`/`$version`/`$comment` variants, but exotic tool dialects
+   may need further hardening.
+4. **Analog CSV format diversity.** The parser supports the documented
+   Saleae/DSView/PulseView layouts; other instruments may need header-name
+   additions.
+
+---
+
+## Competitor scan
+
+No new competitor activity was observed. The t27 differentiation remains the
+only open pipeline converting instrument exports (CSV/VCD) into Lean 4 proofs
+of flash timing compliance, now strengthened by:
+
+- a falsifiable, monotonic PVT envelope with operating-rectangle regression,
+- multi-format VCD header support,
+- analog CSV voltage-column auto-detection,
+- a self-contained `--standalone` theorem that type-checks in a fresh lake package.
+
+---
+
+## Files touched
+
+- `cli/tri/src/fpga.rs`
+- `proofs/lean4/Trinity/TernaryFPGABoot.lean`
+- `fpga/HARDWARE_SSOT.md`
+- `docs/reports/WAVE_LOOP_418_REPORT.md`
+- `docs/reports/FPGA_LOOP_EVIDENCE_W418_2026-07-04.md`
+- `docs/reports/FPGA_LOOP_COOPERATION_W419_2026-07-04.md`
+
+---
+
+## Next steps
+
+1. Open PR from `wave-loop-418` to `master` with body `Closes #1353`.
+2. After merge, create the W419 issue and branch.
+3. Evaluate bench status for W419 and pick Variant A/B/C per the cooperation file.
+
+---
+
+*φ² + φ⁻² = 3 | TRINITY*

--- a/fpga/HARDWARE_SSOT.md
+++ b/fpga/HARDWARE_SSOT.md
@@ -744,6 +744,81 @@ hardened in W416 for three real-world quirks:
 logic-analyzer and simulator formats while still rejecting out-of-spec captures
 via `--validate`.
 
+#### 3.6.14 First real CCLK capture checklist
+
+When the bench is wired (P12 → logic-analyzer channel, ground connected, JTAG
+cable disconnected for cold-POR), follow this checklist for the first real
+CCLK capture and its formal proof:
+
+1. **Program the variant to flash** with the canonical x1 command:
+   ```bash
+   tri fpga program-flash build/fpga/cclk_variants/ternary_mac_demo_top_200t_oscfsel06.bit --spi-buswidth 1 --verify
+   ```
+2. **Disconnect the JTAG/programming cable** before power-cycle.
+3. **Power-cycle** the board (disconnect power, wait ≥10 s, reconnect).
+4. **Capture CCLK** immediately after POR. CCLK is active only during
+   configuration (first ~100 µs–1 ms). For a Digilent FTDI cable used as
+   `ftdi-la`:
+   ```bash
+   tri fpga measure-cclk --live --driver ftdi-la --channel ADBUS4 \
+       --samplerate 10000000 --samples 1000000 --validate
+   ```
+5. **Export the capture** to CSV or VCD:
+   ```bash
+   tri fpga measure-cclk --csv build/fpga/cclk_oscfsel06.csv --validate
+   ```
+6. **Record the operating context** (temperature, VCCINT, VCCAUX, process corner
+   if known). Typical conservative context:
+   ```bash
+   cat > build/fpga/wukong_ctx.json <<'EOF'
+   {"temp_c":25,"vccint_mv":1000,"vccaux_mv":2700,"process_corner":"tt"}
+   EOF
+   ```
+7. **Generate the raw-ns theorem** with PVT context:
+   ```bash
+   tri fpga measured-to-lean --csv build/fpga/cclk_oscfsel06.csv --raw-ns --validate \
+       --pvt-context build/fpga/wukong_ctx.json --standalone --out build/fpga/CclkOscfsel06.lean
+   ```
+8. **Typecheck the standalone theorem** by building it inside the local Trinity
+   tree or a temporary lake package:
+   ```bash
+   cp build/fpga/CclkOscfsel06.lean proofs/lean4/Trinity/
+   cd proofs/lean4 && lake build Trinity.CclkOscfsel06
+   ```
+9. **Commit the generated theorem** and update the OSCFSEL table in this file
+   with the measured frequency/duty and margin.
+
+#### 3.6.15 Replacing the placeholder PVT envelope coefficients
+
+The linear derating coefficients in `proofs/lean4/Trinity/TernaryFPGABoot.lean`
+and `cli/tri/src/fpga.rs` are conservative placeholders until Micron
+N25Q128_3V PVT characterization data is available:
+
+| Source | Coefficient | Current value | Meaning |
+|--------|-------------|---------------|---------|
+| Temperature | `n25q128_pvt_temp_derating_ns` | 0.02 ns/°C above -40 °C | At +85 °C adds 2.5 ns (integer 2 ns) |
+| Voltage | `n25q128_pvt_voltage_derating_ns` | 0.005 ns/mV below 1100 mV | At 900 mV adds 1 ns |
+| Process | `n25q128_pvt_process_derating_ns` | 0/2/4 ns for ff/tt/ss | ss adds 4 ns |
+
+To replace them with real curves:
+
+1. Obtain the N25Q128_3V datasheet `t_CL`/`t_CH` vs temperature and VCC plots
+   (or equivalent corners from the manufacturer).
+2. Fit a conservative **upper envelope** over the operating rectangle
+   (-40 °C..+85 °C, 900 mV..1100 mV) for each process corner.
+3. Update both files simultaneously:
+   - `proofs/lean4/Trinity/TernaryFPGABoot.lean`: `n25q128_pvt_temp_derating_ns`,
+     `n25q128_pvt_voltage_derating_ns`, `n25q128_pvt_process_derating_ns`.
+   - `cli/tri/src/fpga.rs`: `n25q128_pvt_temp_derating_ns`,
+     `n25q128_pvt_voltage_derating_ns`, `n25q128_pvt_process_derating_ns`.
+4. Re-run the regression tests:
+   - `cargo test -p tri test_pvt_half_ns_lower_bound_across_operating_rectangle`
+   - `lake build Trinity.TernaryFPGABoot`
+   The Lean `pvt_half_ns_at_least_nominal` lemma and the Rust operating-rectangle
+   sweep will fail if any new coefficient drops below the nominal 6 ns bound.
+5. Update this section with the new coefficients, the datasheet reference, and
+   the date of characterization.
+
 ---
 
 ## 4. Synthesis toolchain (how to get a `.bit`)

--- a/proofs/lean4/Trinity/TernaryFPGABoot.lean
+++ b/proofs/lean4/Trinity/TernaryFPGABoot.lean
@@ -623,6 +623,13 @@ def n25q128_min_sck_high_ns_pvt (ctx : PvtContext) : Nat :=
   + n25q128_pvt_voltage_derating_ns ctx.vccint_mv
   + n25q128_pvt_process_derating_ns ctx.process_corner
 
+/-- PVT-aware minimum SCK half-period time. The low and high bounds are symmetric
+    in the current envelope, so the half-period bound equals both; this function
+    is the single entry point used by the Rust `n25q128_min_sck_half_ns_pvt` and
+    by instrument-export validation. Units: nanoseconds. -/
+def n25q128_min_sck_half_ns_pvt (ctx : PvtContext) : Nat :=
+  n25q128_min_sck_low_ns_pvt ctx
+
 /-- PVT-aware measured-CCLK flash predicate. As long as the placeholder derating
     is at least the nominal 6 ns bound, it implies the nominal predicate. -/
 def measured_cclk_with_pvt_satisfies_flash_spec (freq_hz : Nat) (duty_pct : Nat) (ctx : PvtContext) : Bool :=
@@ -713,6 +720,16 @@ lemma pvt_high_ns_at_least_nominal (ctx : PvtContext) :
   have hp : n25q128_pvt_process_derating_ns ctx.process_corner ≥ 0 :=
     n25q128_pvt_process_derating_ns_nonneg ctx.process_corner
   omega
+
+/-- The PVT-aware SCK half-period bound is at least the nominal 6 ns bound across
+    the entire operating envelope. This is the regression fact checked by the
+    Rust `n25q128_min_sck_half_ns_pvt` operating-rectangle sweep. -/
+lemma pvt_half_ns_at_least_nominal (ctx : PvtContext) :
+  (PVT_TEMP_MIN_C ≤ ctx.temp_c) → (ctx.vccint_mv ≤ PVT_VCCINT_MAX_MV)
+  → n25q128_min_sck_half_ns_pvt ctx ≥ N25Q128_MIN_SCK_LOW_NS := by
+  intro h_temp h_volt
+  simp [n25q128_min_sck_half_ns_pvt]
+  exact pvt_low_ns_at_least_nominal ctx h_temp h_volt
 
 /-- If the PVT-aware predicate holds, the nominal predicate holds (for contexts
     inside the operating envelope). -/


### PR DESCRIPTION
Closes #1353

Wave Loop 418 (Variant C fallback) delivers:
- PVT-envelope lower-bound regression test in Rust + matching Lean 4 lemma.
- VCD parser hardening for multi-line $date/$version/$comment headers.
- Analog CSV voltage-column auto-detection by header name.
- Standalone Lean integration test that builds a generated theorem in a temporary lake package.
- Updated fpga/HARDWARE_SSOT.md with first-real-capture checklist and PVT coefficient replacement recipe.
- W418 report, evidence, and W419 cooperation variants.

Verification:
- cargo test -p tri pvt: PASS
- cargo test -p tri vcd: PASS
- cargo test -p tri csv: PASS
- cargo test -p tri test_measured_to_lean_standalone_lake_package_builds: PASS
- lake build Trinity.TernaryFPGABoot: PASS
- ./scripts/tri test: 576/576 core phases PASS; 16 pre-existing gen-verilog-yosys-smoke failures (weak point #1245, unrelated to W418).

🤖 Generated with [Claude Code](https://claude.com/claude-code)