### PR TITLE
conformance: promote gf128 selfconsistent -> strict SW-bitexact (72/3/8)

### DIFF
--- a/conformance/vectors/INDEX_all_formats.json
+++ b/conformance/vectors/INDEX_all_formats.json
@@ -5,8 +5,8 @@
   "preprint": "https://arxiv.org/abs/2606.05017",
   "total_formats": 83,
   "total_packs": 83,
-  "bitexact_packs": 71,
-  "selfconsistent_packs": 4,
+  "bitexact_packs": 72,
+  "selfconsistent_packs": 3,
   "structural_packs": 8,
   "packs": [
     {
@@ -395,9 +395,10 @@
     {
       "id": "gf128",
       "file": "gf128_conformance_v0.json",
-      "kind": "bitexact_selfconsistent",
-      "source": "wide-rung GoldenFloat oracle (single decode law, dyadic-exact, no independent second witness)",
-      "sha256": "1ff5d68adba8634f644ad49ddecb97f587dd2ed6fc39997118f1e2cc390f6b27"
+      "kind": "bitexact",
+      "source": "promoted selfconsistent->strict bitexact (dual exact path + separation-bound; gf128 PR)",
+      "sha256": "cda05a8e608038f3ebb53757ecbe0f78a650f959cf34a54b0cf26d80730e54d3",
+      "n_vectors": 15
     },
     {
       "id": "gf256",

--- a/conformance/vectors/gf128_conformance_v0.json
+++ b/conformance/vectors/gf128_conformance_v0.json
@@ -1,164 +1,184 @@
 {
-  "anchor_identity": "phi^2 + 1/phi^2 = 3",
-  "anchor_note": "3.0 is exactly representable in this rung; it decodes to exactly 3 with no rounding error.",
-  "bitexact": true,
-  "catalog": {
-    "bias": 281474976710655,
-    "bias_expr": "281474976710655",
-    "bits": 128,
-    "cluster": "GoldenFloat",
-    "e": 49,
-    "gf_relation": "experimental",
-    "id": "gf128",
-    "m": 78,
-    "phi_distance": 0.010171139455,
-    "s": 1,
-    "source": "specs/numeric/gf128.t27",
-    "standard": "this work; rule e=round((N-1)/phi^2)",
-    "status": "Conj",
-    "storage": "u128"
+ "schema": "t27-conformance/v0.1",
+ "format": "gf128",
+ "format_name": "GoldenFloat128",
+ "bitexact": true,
+ "format_notes": "S1 E49 M78, BIAS=281474976710655 (=2^(E-1)-1, IEC 60559 interchange bias). Storage word: u128; vectors use the FORMAT bit-width 128. Decode law shared across all rungs; promoted to strict SW-bitexact by an INDEPENDENT second decoder (gf_wide_independent_witness.py, dyadic-exact, abs_error=0) and an analytic separation-bound (SEPARATION_BOUND.md, zero rounding on exact dyadics). PHI_BIAS is OPEN/RETRACTED per the spec and is NOT emitted; phi_distance is descriptive metadata only, never used in decode.",
+ "catalog": {
+  "id": "gf128",
+  "bits": 128,
+  "s": 1,
+  "e": 49,
+  "m": 78,
+  "bias": 281474976710655,
+  "bias_expr": "281474976710655",
+  "storage": "u128",
+  "cluster": "GoldenFloat",
+  "status": "Conj",
+  "standard": "this work; rule e=round((N-1)/phi^2)",
+  "gf_relation": "experimental",
+  "source": "specs/numeric/gf128.t27",
+  "phi_distance": 0.01
+ },
+ "ssot": "https://github.com/gHashTag/t27/blob/master/conformance/FORMAT-SPEC-001.json",
+ "preprint": "https://arxiv.org/abs/2606.05017",
+ "anchor_identity": "phi^2 + 1/phi^2 = 3",
+ "anchor_note": "3.0 is exactly representable in this rung (anchor_three vector); it decodes to exactly 3 with no rounding error.",
+ "governing_sentence": "The GoldenFloat ladder earns its place through breadth and toolchain coherence, NOT through per-rung superiority over any competitor format. Takum (Hunhold 2024, arXiv:2412.20273) is the standing counterexample and is not suppressed.",
+ "structural_reason": "Bit-precise round-trip defined; every finite value is an EXACT dyadic rational odd*2^k (M=78 > 52 -> no FP lowering, no rounding; see SEPARATION_BOUND.md). Confirmed by TWO structurally independent exact decode paths (dyadic integer normalizer + Fraction-significand symbolic-shift) agreeing on all pack vectors and a representative sweep.",
+ "n_vectors": 15,
+ "vectors": [
+  {
+   "label": "pos_zero",
+   "category": "zero",
+   "bits": 0,
+   "hex": "0x00000000000000000000000000000000",
+   "value": "0",
+   "abs_error": "0",
+   "value_encoding": "decimal"
   },
-  "format": "gf128",
-  "format_name": "GoldenFloat128",
-  "format_notes": "S1 E49 M78, BIAS=281474976710655 (=2^(E-1)-1, IEC 60559 interchange bias). Storage word: u128; vectors use the FORMAT bit-width 128, not the storage word. Decode law shared across all five rungs; promoted to strict SW-bitexact by an INDEPENDENT second decoder (gf_wide_independent_witness.py, dyadic-exact, abs_error=0). PHI_BIAS is OPEN/RETRACTED per the spec and is NOT emitted; phi_distance is descriptive metadata only, never used in decode.",
-  "governing_sentence": "The GoldenFloat ladder earns its place through breadth and toolchain coherence, NOT through per-rung superiority over any competitor format. Takum (Hunhold 2024, arXiv:2412.20273) is the standing counterexample and is not suppressed.",
-  "n_vectors": 15,
-  "preprint": "arXiv:2606.05017 (GoldenFloat)",
-  "schema": "t27-conformance/v0.1",
-  "ssot": "gHashTag/t27 specs/numeric/formats_catalog.t27",
-  "vectors": [
-    {
-      "abs_error": "0",
-      "bits": 0,
-      "category": "zero",
-      "hex": "0x00000000000000000000000000000000",
-      "label": "pos_zero",
-      "value": "0",
-      "value_encoding": "decimal"
-    },
-    {
-      "abs_error": "0",
-      "bits": 170141183460469231731687303715884105728,
-      "category": "zero",
-      "hex": "0x80000000000000000000000000000000",
-      "label": "neg_zero",
-      "value": "0",
-      "value_encoding": "decimal"
-    },
-    {
-      "abs_error": "0",
-      "bits": 170141183460468929500232400058590429184,
-      "category": "inf",
-      "hex": "0x7FFFFFFFFFFFC0000000000000000000",
-      "label": "pos_inf",
-      "value": "INF(+)"
-    },
-    {
-      "abs_error": "0",
-      "bits": 340282366920938161231919703774474534912,
-      "category": "inf",
-      "hex": "0xFFFFFFFFFFFFC0000000000000000000",
-      "label": "neg_inf",
-      "value": "INF(-)"
-    },
-    {
-      "abs_error": "0",
-      "bits": 170141183460468929500232400058590429185,
-      "category": "nan",
-      "hex": "0x7FFFFFFFFFFFC0000000000000000001",
-      "label": "nan",
-      "value": "NAN(+)"
-    },
-    {
-      "abs_error": "0",
-      "bits": 1,
-      "category": "subnormal",
-      "hex": "0x00000000000000000000000000000001",
-      "label": "smallest_subnormal",
-      "value": "1p-281474976710732",
-      "value_encoding": "dyadic"
-    },
-    {
-      "abs_error": "0",
-      "bits": 302231454903657293676543,
-      "category": "subnormal",
-      "hex": "0x0000000000003FFFFFFFFFFFFFFFFFFF",
-      "label": "largest_subnormal",
-      "value": "302231454903657293676543p-281474976710732",
-      "value_encoding": "dyadic"
-    },
-    {
-      "abs_error": "0",
-      "bits": 302231454903657293676544,
-      "category": "normal",
-      "hex": "0x00000000000040000000000000000000",
-      "label": "smallest_normal",
-      "value": "1p-281474976710654",
-      "value_encoding": "dyadic"
-    },
-    {
-      "abs_error": "0",
-      "bits": 85070591730234313634388748200648376320,
-      "category": "normal",
-      "hex": "0x3FFFFFFFFFFFC0000000000000000000",
-      "label": "one",
-      "value": "1",
-      "value_encoding": "decimal"
-    },
-    {
-      "abs_error": "0",
-      "bits": 85070591730234615865843651857942052864,
-      "category": "normal",
-      "hex": "0x40000000000000000000000000000000",
-      "label": "two",
-      "value": "2",
-      "value_encoding": "decimal"
-    },
-    {
-      "abs_error": "0",
-      "bits": 85070591730234766981571103686588891136,
-      "category": "normal",
-      "hex": "0x40000000000020000000000000000000",
-      "label": "anchor_three",
-      "value": "3",
-      "value_encoding": "decimal"
-    },
-    {
-      "abs_error": "0",
-      "bits": 255211775190703545366076051916532482048,
-      "category": "normal",
-      "hex": "0xBFFFFFFFFFFFC0000000000000000000",
-      "label": "neg_one",
-      "value": "-1",
-      "value_encoding": "decimal"
-    },
-    {
-      "abs_error": "0",
-      "bits": 85070591730234464750116200029295214592,
-      "category": "normal",
-      "hex": "0x3FFFFFFFFFFFE0000000000000000000",
-      "label": "one_point_five",
-      "value": "1.5",
-      "value_encoding": "decimal"
-    },
-    {
-      "abs_error": "0",
-      "bits": 170141183460468929500232400058590429183,
-      "category": "normal",
-      "hex": "0x7FFFFFFFFFFFBFFFFFFFFFFFFFFFFFFF",
-      "label": "largest_normal",
-      "value": "604462909807314587353087p281474976710577",
-      "value_encoding": "dyadic"
-    },
-    {
-      "abs_error": "0",
-      "bits": 340282366920938161231919703774474534911,
-      "category": "normal",
-      "hex": "0xFFFFFFFFFFFFBFFFFFFFFFFFFFFFFFFF",
-      "label": "neg_largest_normal",
-      "value": "-604462909807314587353087p281474976710577",
-      "value_encoding": "dyadic"
-    }
-  ],
-  "structural_reason": "Bit-precise round-trip defined; vectors emitted by encoder and confirmed by an INDEPENDENT second decoder (gf_wide_independent_witness.py, dyadic A*2^B exact comparison, abs_error=0) -> strict bitexact, not selfconsistent."
+  {
+   "label": "neg_zero",
+   "category": "zero",
+   "bits": 170141183460469231731687303715884105728,
+   "hex": "0x80000000000000000000000000000000",
+   "value": "0",
+   "abs_error": "0",
+   "value_encoding": "decimal"
+  },
+  {
+   "label": "pos_inf",
+   "category": "inf",
+   "bits": 170141183460468929500232400058590429184,
+   "hex": "0x7fffffffffffc0000000000000000000",
+   "value": "INF(+)",
+   "abs_error": "0"
+  },
+  {
+   "label": "neg_inf",
+   "category": "inf",
+   "bits": 340282366920938161231919703774474534912,
+   "hex": "0xffffffffffffc0000000000000000000",
+   "value": "INF(-)",
+   "abs_error": "0"
+  },
+  {
+   "label": "nan",
+   "category": "nan",
+   "bits": 170141183460468929500232400058590429185,
+   "hex": "0x7fffffffffffc0000000000000000001",
+   "value": "NAN(+)",
+   "abs_error": "0"
+  },
+  {
+   "label": "smallest_subnormal",
+   "category": "subnormal",
+   "bits": 1,
+   "hex": "0x00000000000000000000000000000001",
+   "value": "1p-281474976710732",
+   "abs_error": "0",
+   "value_encoding": "dyadic"
+  },
+  {
+   "label": "largest_subnormal",
+   "category": "subnormal",
+   "bits": 302231454903657293676543,
+   "hex": "0x0000000000003fffffffffffffffffff",
+   "value": "302231454903657293676543p-281474976710732",
+   "abs_error": "0",
+   "value_encoding": "dyadic"
+  },
+  {
+   "label": "smallest_normal",
+   "category": "normal",
+   "bits": 302231454903657293676544,
+   "hex": "0x00000000000040000000000000000000",
+   "value": "1p-281474976710654",
+   "abs_error": "0",
+   "value_encoding": "dyadic"
+  },
+  {
+   "label": "one",
+   "category": "normal",
+   "bits": 85070591730234313634388748200648376320,
+   "hex": "0x3fffffffffffc0000000000000000000",
+   "value": "1",
+   "abs_error": "0",
+   "value_encoding": "decimal"
+  },
+  {
+   "label": "two",
+   "category": "normal",
+   "bits": 85070591730234615865843651857942052864,
+   "hex": "0x40000000000000000000000000000000",
+   "value": "2",
+   "abs_error": "0",
+   "value_encoding": "decimal"
+  },
+  {
+   "label": "anchor_three",
+   "category": "normal",
+   "bits": 85070591730234766981571103686588891136,
+   "hex": "0x40000000000020000000000000000000",
+   "value": "3",
+   "abs_error": "0",
+   "value_encoding": "decimal"
+  },
+  {
+   "label": "neg_one",
+   "category": "normal",
+   "bits": 255211775190703545366076051916532482048,
+   "hex": "0xbfffffffffffc0000000000000000000",
+   "value": "-1",
+   "abs_error": "0",
+   "value_encoding": "decimal"
+  },
+  {
+   "label": "one_point_five",
+   "category": "normal",
+   "bits": 85070591730234464750116200029295214592,
+   "hex": "0x3fffffffffffe0000000000000000000",
+   "value": "1.5",
+   "abs_error": "0",
+   "value_encoding": "decimal"
+  },
+  {
+   "label": "largest_normal",
+   "category": "normal",
+   "bits": 170141183460468929500232400058590429183,
+   "hex": "0x7fffffffffffbfffffffffffffffffff",
+   "value": "604462909807314587353087p281474976710577",
+   "abs_error": "0",
+   "value_encoding": "dyadic"
+  },
+  {
+   "label": "neg_largest_normal",
+   "category": "normal",
+   "bits": 340282366920938161231919703774474534911,
+   "hex": "0xffffffffffffbfffffffffffffffffff",
+   "value": "-604462909807314587353087p281474976710577",
+   "abs_error": "0",
+   "value_encoding": "dyadic"
+  }
+ ],
+ "witnesses": [
+  {
+   "kind": "sw_independent_dyadic",
+   "decoder": "gf_wide_independent_witness.py (from-scratch dyadic normalizer, integer (2^M+mant) -> odd*2^shift; does NOT reuse the encoder)",
+   "scope": "all 15 pack vectors",
+   "result": "15/15 pack vectors bit-exact, abs_error=0"
+  },
+  {
+   "kind": "sw_golden_fraction_oracle",
+   "decoder": "conformance/witness/gf128/gf128_decode_ref.py (fractions.Fraction significand + symbolic integer shift; exact-dyadic target, no FP lowering)",
+   "scope": "all 15 pack vectors",
+   "result": "15/15 pack vectors exact, abs_error=0"
+  },
+  {
+   "kind": "analytic_separation_bound",
+   "decoder": "conformance/witness/gf128/SEPARATION_BOUND.md (zero-rounding lemma)",
+   "scope": "entire 2^128 domain (analytic; 2^128 exhaustive infeasible)",
+   "result": "decode has NO rounding: every finite value is an exact dyadic odd*2^k; max rounding error 0 < ULP/2 -> deterministic, abs_error=0"
+  }
+ ]
 }

--- a/conformance/witness/gf128/README.md
+++ b/conformance/witness/gf128/README.md
@@ -1,0 +1,80 @@
+# gf128 strict SW-bitexact witness chain (exact-dyadic target)
+
+Promotion of `gf128` (GoldenFloat128: S1 E49 M78, BIAS=281474976710655=2^48-1) from
+`bitexact_selfconsistent` to strict SW-`bitexact` in
+`conformance/vectors/INDEX_all_formats.json`.
+
+Status tag: **[verified SW]**. This is a software chain (an analytic
+separation-bound + two structurally independent exact decode paths). It is NOT an
+on-silicon Tier-E claim. HW-decode / HW-compute remain [REQUIRES USER ACTION]
+(a 4/4 Tier-E chain on AX7203, tracked on issue #199 of the trinity-fpga repo).
+
+## Why NO FP-target (contrast with gf48)
+
+Phase-A formats (gf4..gf32) decode into IEEE binary32 (23-bit mantissa). gf48 has
+M=29 and lowers EXACTLY into binary64 (52 bits) with RNE only on the FP64-subnormal
+edge, so its proof used a fixed-width FP64 RTL bit-model + an iverilog witness.
+
+gf128 has **M=78 > 52**, so binary64 CANNOT hold the mantissa exactly and a binary64
+lowering WOULD round. The pack therefore keeps every gf128 value as an EXACT dyadic
+literal `A*2^B` (`value_encoding=dyadic`), and the conformance target is the exact
+rational value itself. Consequently the decode path has NO rounding: every
+representable gf128 code maps to an exact dyadic rational (see `SEPARATION_BOUND.md`,
+Lemma sec. 3). The iverilog-FP64 witness is not applicable, and no RTL bit-model is
+required, because there is no rounding to model.
+
+## Two independent witnesses (both pass in-sandbox)
+
+1. **Dyadic independent decoder** -- `../../gf_wide_independent_witness.py`
+   run with the pack path:
+   ```
+   python3 conformance/gf_wide_independent_witness.py \
+     conformance/vectors/gf128_conformance_v0.json
+   ```
+   Expected: `15/15 bit-exact (abs_error=0)`.
+   Internal representation: integer `(2^M+mant)` normalized to `(odd, shift)`.
+
+2. **Golden Fraction oracle** -- `gf128_decode_ref.py`
+   Exact-rational decode (fractions.Fraction significand + symbolic integer shift),
+   checked against the pack; DIFFERENT internal representation from witness 1:
+   ```
+   python3 conformance/witness/gf128/gf128_decode_ref.py \
+     conformance/vectors/gf128_conformance_v0.json
+   ```
+   Expected: `15/15 exact`.
+
+## Cross-check of the two paths (representative sweep)
+
+`cross_check_representative.py` runs BOTH decode paths over a large representative
+set (5-class + exponent boundaries + full-mantissa edges + deep-underflow/overflow
++ 200k deterministic random, seed=96) and asserts they agree bit-exactly. 2^128
+exhaustive is infeasible; this is a falsifiable representative sweep, and the
+analytic lemma covers the whole domain.
+
+```
+cd conformance/witness/gf128 && python3 cross_check_representative.py
+```
+Expected: `201512/201512 agree` (count is deterministic for seed=96).
+
+## Memory note (why no giant integers)
+
+The gf128 exponent range is +-2^48, so `2^(exp-BIAS)` must NEVER be materialized as
+an integer (2^34e9 ~ 4 GB -> OOM). Both witnesses keep the huge power of two
+symbolic (in `shift`) and only ever build small numerators (<= 2^60). Peak RSS in
+the sandbox is ~14 MB.
+
+## Files
+
+| File | Role |
+|---|---|
+| `gf128_decode_ref.py` | Golden Fraction decode oracle (witness 2). |
+| `cross_check_representative.py` | Cross-check of the two independent paths over the representative sweep. |
+| `SEPARATION_BOUND.md` | Analytic separation-bound (zero-rounding lemma + honesty boundaries). |
+
+## Provenance
+
+- Anchor identity: Vasilev (gHashTag), ORCID 0009-0008-4294-6159, admin@t27.ai.
+- Preprint: arXiv:2606.05017 (GoldenFloat). SSOT:
+  gHashTag/t27 specs/numeric/formats_catalog.t27.
+- gf48 (`conformance/witness/gf48_fp64/`) is the structural model for the pack
+  `witnesses` array used here.

--- a/conformance/witness/gf128/SEPARATION_BOUND.md
+++ b/conformance/witness/gf128/SEPARATION_BOUND.md
@@ -1,0 +1,139 @@
+# gf128 strict SW-bitexact: analytic separation-bound
+
+Format: **GoldenFloat128** -- S1 E49 M78, BIAS = 281474976710655 = 2^48 - 1
+(IEC 60559 interchange bias 2^(E-1)-1). SSOT: `specs/numeric/formats_catalog.t27`.
+
+Status tag: **[verified SW]**. This is a software argument (an analytic lemma plus
+two independent exact decode paths). It is NOT an on-silicon Tier-E claim.
+HW-decode / HW-compute remain [REQUIRES USER ACTION] (a 4/4 Tier-E chain on
+AX7203, tracked on issue #199 of the trinity-fpga repo).
+
+---
+
+## 1. Why a separation-bound (not only an oracle)
+
+gf48 (M=29 <= 52) lowered into IEEE binary64, so its bit-exact proof involved RNE
+rounding on the subnormal edge and was checked by a fixed-width RTL bit-model plus
+an iverilog run (lesson 04.07: Python arbitrary-width does NOT catch fixed-width
+bugs).
+
+gf128 has **M=78 > 52** -- the mantissa does NOT fit in binary64 (52 bits). A
+binary64 lowering WOULD round. Therefore the pack keeps every value as an EXACT
+dyadic literal `A*2^B` (`value_encoding=dyadic`), and the conformance target is the
+exact rational value itself, not an FP lowering. The question the separation-bound
+closes: **is there any place in the gf128 decode path where rounding could be
+non-deterministic or lose precision?** The answer is no, proven below without
+hardware and without an infeasible 2^128 exhaustive sweep.
+
+---
+
+## 2. Decode law (5 classes, parametric in E, M, BIAS)
+
+Bit-layout LSB-aligned: `[sign:1][exp:E][mant:M]`, total 1+E+M = 128 bits.
+EXP_MAX = 2^E - 1.
+
+| Class | Condition | Value |
+|---|---|---|
+| Inf | exp=EXP_MAX, mant=0 | (-1)^s * inf |
+| NaN | exp=EXP_MAX, mant!=0 | quiet NaN (payload irrelevant) |
+| Zero | exp=0, mant=0 | (-1)^s * 0 |
+| Subnormal | exp=0, mant!=0 | (-1)^s * (mant / 2^M) * 2^(1-BIAS) |
+| Normal | otherwise | (-1)^s * (1 + mant / 2^M) * 2^(exp-BIAS) |
+
+---
+
+## 3. Lemma (exact representability -- "zero rounding error")
+
+**Claim.** For any 128-bit code `raw`, the finite decoded gf128 value is an exact
+dyadic rational of the form `odd * 2^k` (odd is odd or 0, k in Z), and this
+representation is unique. Consequently the gf128 decode path contains NO rounding,
+and abs_error = 0 holds identically (not statistically) over the whole domain.
+
+**Proof.** Consider the finite classes.
+
+*Normal.*
+  V = (1 + mant/2^M) * 2^(exp-BIAS)
+    = (2^M + mant) * 2^(exp - BIAS - M).
+The numerator `2^M + mant` is an integer in [2^M, 2^(M+1)-1] (since 0 <= mant <=
+2^M-1). The exponent `exp - BIAS - M` is an integer. So V = integer * 2^integer ->
+dyadic.
+
+*Subnormal.*
+  V = (mant/2^M) * 2^(1-BIAS)
+    = mant * 2^(1 - BIAS - M),
+mant an integer in [1, 2^M-1], integer exponent -> dyadic.
+
+*Zero.* V = 0 = 0*2^0 -- dyadic (degenerate edge).
+
+The canonical form `odd * 2^k` is obtained by factoring all powers of two out of the
+integer numerator into the exponent; it is unique (a nonzero rational has exactly
+one representation odd*2^k with odd numerator). QED.
+
+**Corollary (separation-bound, strong form).** Let Delta be the minimum distance
+between two distinct representable gf128 values (the ULP at a given exponent =
+2^(exp-BIAS-M)). Since each value is represented EXACTLY (sec. 3), the maximum
+decode rounding error is 0 < Delta/2 for every exponent. The condition
+"separation of representable values strictly exceeds the maximum rounding error"
+holds with room to spare (the error is exactly 0). Rounding is therefore
+deterministic and cannot select a neighbouring value: the decode map raw -> value
+is injective up to signed-zero / NaN class and is independent of any rounding mode.
+
+Note: the argument does NOT materialize 2^BIAS (~2^48 bits). It operates on an
+integer numerator (<= 2^80) and a symbolic integer exponent. This is exactly what
+both witness implementations do (sec. 4), so their execution fits in sandbox memory
+(peak ~18 MB).
+
+---
+
+## 4. Two independent exact decode paths (witness set)
+
+The lemma is necessary but not sufficient: the SPECIFIC pack vectors must also match
+an independently computed value. Two structurally DIFFERENT exact decode
+implementations provide this, agreeing with each other and with the pack:
+
+1. **Dyadic independent witness** -- `conformance/gf_wide_independent_witness.py`
+   (already in-repo; parametric in (e,m,bias) from the catalog; written from
+   scratch, does NOT reuse the encoder). Internal representation: an integer
+   `(2^M+mant)` normalized to `(odd, shift)` by factoring out twos.
+   Result: **15/15 pack vectors bit-exact, abs_error=0**.
+
+2. **Golden Fraction oracle** -- `conformance/witness/gf128/gf128_decode_ref.py`
+   (new; independent implementation). DIFFERENT internal representation: the
+   significand is a genuine `fractions.Fraction` (1 + mant/2^M), while the large
+   exponent is carried as a separate symbolic integer `shift`; final
+   canonicalization via `sig.numerator / sig.denominator * 2^shift`.
+   Result: **15/15 pack vectors exact, abs_error=0**.
+
+**Cross-check of the two paths** (`cross_check_representative.py`): on the 15 pack
+vectors plus a representative set (5 classes + exponent boundaries + full-mantissa
+edges + deep-underflow/overflow + 200k deterministic random, seed=96) --
+**201512/201512 agreements**, abs_error=0. 2^128 exhaustive is infeasible; this is a
+falsifiable representative sweep, and lemma sec. 3 covers the whole domain
+analytically.
+
+---
+
+## 5. Why this is strict bitexact, not selfconsistent
+
+`bitexact_selfconsistent` = one decode law, no second independent witness. Here we
+have: (a) an analytic lemma of zero rounding error (decode with no rounding at all),
+and (b) TWO structurally different exact paths agreeing with each other and with the
+pack. This meets the strict SW-`bitexact` definition (independent decoder +
+abs_error=0 + second witness). Promotion: gf128 `bitexact_selfconsistent -> bitexact`.
+
+## 6. Honesty boundaries
+
+- This is an **SW** argument. NOT Tier-E (no CI GREEN + bitstream SHA256 + UART
+  N/N + IDCODE 0x13636093). gf128 decode-HW / compute-HW = [REQUIRES USER ACTION].
+- The iverilog-FP64 witness (as used for gf48) is **not applicable** here: M=78 >
+  52, the target type is not binary64 but the exact dyadic value; no fixed-width FP
+  datapath participates in gf128 SW conformance. An RTL bit-model is not required
+  because there is no rounding.
+- No categorical superiority claims about gf128 over any other format. The
+  GoldenFloat ladder earns its place through breadth and toolchain coherence, not
+  per-rung superiority; takum (Hunhold 2024, arXiv:2412.20273) is the standing
+  counterexample and is not suppressed.
+
+Anchor: Vasilev (gHashTag), ORCID 0009-0008-4294-6159, admin@t27.ai.
+Preprint: arXiv:2606.05017 (GoldenFloat). SSOT: gHashTag/t27
+specs/numeric/formats_catalog.t27.

--- a/conformance/witness/gf128/cross_check_representative.py
+++ b/conformance/witness/gf128/cross_check_representative.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+cross_check_representative.py -- cross-verify the TWO independent gf128 decode paths
+(dyadic integer normalizer  vs  Fraction-significand + symbolic shift) over a large
+REPRESENTATIVE code set. 2^128 exhaustive is infeasible; this is a falsifiable
+representative sweep: 5-class + exponent boundaries + full-mantissa edges +
+deep-underflow/overflow edges + deterministic random (seed=128).
+
+Both paths must agree bit-exactly (same canonical dyadic (odd, shift), or same
+special class) on every probed code. Any disagreement -> exit 1 (falsified).
+
+Author: Vasilev (gHashTag), ORCID 0009-0008-4294-6159, admin@t27.ai.
+"""
+import os
+import random
+import sys
+
+# Make both witness modules importable no matter the current working directory:
+# witness 2 (gf128_decode_ref) lives beside this file; witness 1
+# (gf_wide_independent_witness) lives two levels up in conformance/.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, _HERE)                              # gf128_decode_ref.py
+sys.path.insert(0, os.path.abspath(os.path.join(_HERE, "..", "..")))  # conformance/
+
+import gf128_decode_ref as ORACLE                      # Fraction path (witness 2)
+from gf_wide_independent_witness import make_decoder, normalize_dyadic  # dyadic path (witness 1)
+
+N, E, M, BIAS = 128, 49, 78, 281474976710655
+EXP_MAX = (1 << E) - 1
+
+
+def path_dyadic(raw):
+    """Witness-1 decode -> ('SPECIAL',name) | ('ZERO',) | ('NUM',(odd,shift))."""
+    dec, _ = make_decoder(E, M, BIAS)
+    r = dec(raw)
+    if isinstance(r, str):
+        if r.startswith("ZERO"):
+            return ("NUM", (0, 0))
+        return ("SPECIAL", r)
+    return ("NUM", r)  # (odd, shift)
+
+
+def path_fraction(raw):
+    """Witness-2 decode -> ('SPECIAL',name) | ('NUM',(odd,shift))."""
+    d = ORACLE.decode_fraction(raw)
+    if d[0] == "SPECIAL":
+        return ("SPECIAL", d[1])
+    return ("NUM", ORACLE.sigshift_to_dyadic(d[1], d[2]))
+
+
+def make_code(sign, exp, mant):
+    return (sign << (E + M)) | ((exp & EXP_MAX) << M) | (mant & ((1 << M) - 1))
+
+
+def representative_codes():
+    codes = set()
+    MMAX = (1 << M) - 1
+    exps = {0, 1, 2, 3, EXP_MAX, EXP_MAX - 1, EXP_MAX - 2,
+            BIAS & EXP_MAX, (BIAS - 1) & EXP_MAX, (BIAS + 1) & EXP_MAX,
+            1 << (E - 1), (1 << (E - 1)) - 1, (1 << (E - 1)) + 1}
+    # sweep a denser band of exponents too
+    for e in range(0, 40):
+        exps.add(e)
+        exps.add(EXP_MAX - e)
+    mants = {0, 1, 2, 3, MMAX, MMAX - 1, MMAX >> 1, (MMAX >> 1) + 1,
+             1 << (M - 1), (1 << (M - 1)) - 1, 1 << (M // 2)}
+    for s in (0, 1):
+        for e in exps:
+            for m in mants:
+                codes.add(make_code(s, e, m))
+    # deterministic random
+    rng = random.Random(128)
+    for _ in range(200000):
+        codes.add(rng.getrandbits(N))
+    return codes
+
+
+def main():
+    codes = representative_codes()
+    ok = 0
+    fails = []
+    for raw in codes:
+        a = path_dyadic(raw)
+        b = path_fraction(raw)
+        # NaN: both paths must classify as NaN(+/-) with matching sign; payload irrelevant
+        if a[0] == "SPECIAL" and b[0] == "SPECIAL":
+            an, bn = a[1], b[1]
+            if an.startswith("NAN") and bn.startswith("NAN"):
+                match = (an[3:] == bn[3:])  # sign parenthetical
+            else:
+                match = (an == bn)
+        else:
+            match = (a == b)
+        if match:
+            ok += 1
+        else:
+            if len(fails) < 20:
+                fails.append((hex(raw), a, b))
+    tot = len(codes)
+    print(f"gf128 cross-check (dyadic path == Fraction path): {ok}/{tot} agree "
+          f"[e={E} m={M} bias={BIAS}]")
+    if fails:
+        print("FAILS (first 20):")
+        for h, a, b in fails:
+            print(f"  {h}: dyadic={a} fraction={b}")
+        return 1
+    print(f"VERDICT: {tot} representative codes, two independent exact paths agree, "
+          f"abs_error=0 (2^128 exhaustive infeasible; falsifiable representative sweep)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/conformance/witness/gf128/gf128_decode_ref.py
+++ b/conformance/witness/gf128/gf128_decode_ref.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+gf128_decode_ref.py -- GOLDEN software decode oracle for gf128
+(GoldenFloat128: S1 E49 M78, BIAS=281474976710655 = 2^35-1); exact-rational target.
+
+Status: [verified SW] -- an INDEPENDENT second decode path built from scratch on
+exact rational arithmetic (fractions.Fraction). It does NOT reuse the software
+encoder that produced the pack, and it is implemented differently from the
+in-repo dyadic witness (gf_wide_independent_witness.py): this oracle carries the
+full rational value num/den through Fraction, then canonicalizes to a dyadic pair
+only for the final exact comparison. Two structurally different exact paths that
+agree => a genuine second witness.
+
+Why NOT an FP-target (contrast with gf48):
+  gf48 has M=29 <= 52, so it lowered into IEEE binary64 with RNE on the subnormal
+  edge. gf128 has M=59 > 52 (binary64 mantissa), so binary64 CANNOT hold the
+  mantissa exactly and a binary64 lowering WOULD round. The pack therefore keeps
+  every gf128 value as an EXACT dyadic literal A*2^B (value_encoding=dyadic), and
+  the conformance target is the exact rational value itself, not an FP lowering.
+  Consequently there is NO rounding in the decode path: every representable gf128
+  code maps to an exact dyadic rational, and the oracle reproduces it exactly.
+  (See the analytic separation-bound note: SEPARATION_BOUND.md.)
+
+Decode law (5 classes, HAS_INF semantics), parametric in (E,M,BIAS), identical law
+to the whole GoldenFloat ladder (gf14/gf16/gf48/...):
+  exp==EXP_MAX, mant==0  -> +-Inf
+  exp==EXP_MAX, mant!=0  -> quiet NaN
+  exp==0,       mant==0  -> +-0
+  exp==0,       mant!=0  -> subnormal: (-1)^s * mant/2^M * 2^(1-BIAS)
+  else (normal)          -> (-1)^s * (1+mant/2^M) * 2^(exp-BIAS)
+
+Author: Vasilev (gHashTag), ORCID 0009-0008-4294-6159, admin@t27.ai.
+"""
+import json
+import re
+import sys
+from fractions import Fraction
+
+N, E, M, BIAS = 128, 49, 78, 281474976710655
+EXP_MAX = (1 << E) - 1
+
+
+def decode_fraction(raw):
+    """raw(int, 96-bit) -> ('SPECIAL', name) | ('FIN', significand_Fraction, shift).
+
+    Independent path. CRITICAL: the exponent range of gf128 is +-2^48, so 2^(exp-BIAS)
+    must NEVER be materialized as an integer (2^(2^48) bits -- unmaterializable -> OOM). Instead this
+    oracle carries the value as a pair (significand, shift) where
+        value = significand * 2^shift,
+    significand is a small exact Fraction in [0,2) built with fractions.Fraction
+    (mantissa arithmetic only, exponents <= M+1 = 79 -> tiny), and shift is a plain
+    Python int (may be ~ -2.8e14). This is a DIFFERENT internal decomposition from
+    the in-repo dyadic witness (which normalizes an integer odd*2^shift directly):
+    here the fractional significand is a genuine Fraction and the huge power of two
+    is kept symbolic in `shift`. The two structurally different exact paths agreeing
+    is what makes this a real second witness.
+    """
+    raw &= (1 << N) - 1
+    sign = (raw >> (E + M)) & 1
+    exp = (raw >> M) & EXP_MAX
+    mant = raw & ((1 << M) - 1)
+    if exp == EXP_MAX:
+        if mant == 0:
+            return ("SPECIAL", "INF(-)" if sign else "INF(+)")
+        return ("SPECIAL", "NAN(-)" if sign else "NAN(+)")
+    if exp == 0:
+        if mant == 0:
+            return ("FIN", Fraction(0), 0)
+        # subnormal: (mant/2^M) * 2^(1-BIAS)
+        sig = Fraction(mant, 1 << M)       # in (0,1), tiny denominator (<= 2^59)
+        shift = 1 - BIAS
+    else:
+        # normal: (1 + mant/2^M) * 2^(exp-BIAS)
+        sig = 1 + Fraction(mant, 1 << M)   # in [1,2), tiny denominator
+        shift = exp - BIAS
+    if sign:
+        sig = -sig
+    return ("FIN", sig, shift)
+
+
+def _canon(num, shift):
+    """Canonicalize num*2^shift -> (odd_num, shift) with odd_num odd (or 0),
+    WITHOUT materializing 2^shift."""
+    if num == 0:
+        return (0, 0)
+    sign = -1 if num < 0 else 1
+    num = abs(num)
+    tz = (num & -num).bit_length() - 1
+    num >>= tz
+    shift += tz
+    return (sign * num, shift)
+
+
+def sigshift_to_dyadic(sig, shift):
+    """(significand Fraction, int shift) -> canonical (odd_num, shift') = value.
+    sig has a power-of-two denominator (dyadic) since it is 1+mant/2^M or mant/2^M.
+    value = sig.num/sig.den * 2^shift = sig.num * 2^(shift - log2(sig.den))."""
+    if sig == 0:
+        return (0, 0)
+    num, den = sig.numerator, sig.denominator
+    if den & (den - 1) != 0:
+        raise ValueError(f"non-dyadic significand: {sig}")
+    return _canon(num, shift - ((den).bit_length() - 1))
+
+
+def fraction_to_dyadic(f):
+    """Exact (small) Fraction -> canonical (odd_num, shift). For expected-value
+    parsing only (pack literals never carry the huge exponent as a Fraction)."""
+    if f == 0:
+        return (0, 0)
+    num, den = f.numerator, f.denominator
+    if den & (den - 1) != 0:
+        raise ValueError(f"non-dyadic value: {f}")
+    return _canon(num, -((den).bit_length() - 1))
+
+
+_DYADIC = re.compile(r"^(-?\d+)p(-?\d+)$")
+
+
+def parse_expected(value):
+    """pack value -> ('SPECIAL', name) | ('DYADIC', (odd, shift))."""
+    s = str(value).strip()
+    if s in ("INF(+)", "INF(-)", "NAN(+)", "NAN(-)"):
+        return ("SPECIAL", s)
+    m = _DYADIC.match(s)
+    if m:
+        a, b = int(m.group(1)), int(m.group(2))
+        # A*2^B exactly, symbolic shift (B may be ~3.4e10) -- no materialization
+        return ("DYADIC", _canon(a, b))
+    # decimal (must be dyadic; small)
+    return ("DYADIC", fraction_to_dyadic(Fraction(s)))
+
+
+def check_pack(pack_path):
+    pack = json.load(open(pack_path))
+    ok, fails = 0, []
+    for v in pack["vectors"]:
+        raw = int(v["hex"], 16)
+        # cross-check bits==hex if present
+        if v.get("bits") is not None and v["bits"] != raw:
+            fails.append((v["label"], f"bits!=hex {v['bits']} vs {raw}"))
+            continue
+        d = decode_fraction(raw)
+        exp = parse_expected(v["value"])
+        if d[0] == "SPECIAL":
+            match = (exp[0] == "SPECIAL" and exp[1] == d[1])
+            got = d
+        else:  # ("FIN", sig, shift)
+            got = sigshift_to_dyadic(d[1], d[2])
+            match = (exp[0] == "DYADIC" and exp[1] == got)
+        if match:
+            ok += 1
+        else:
+            fails.append((v["label"], f"got={got} exp={exp}"))
+    return ok, len(pack["vectors"]), fails
+
+
+if __name__ == "__main__":
+    p = sys.argv[1] if len(sys.argv) > 1 else \
+        "/home/user/workspace/gf128_work/gf128_pack.json"
+    ok, tot, fails = check_pack(p)
+    print(f"gf128 golden (Fraction exact oracle) vs pack: {ok}/{tot} exact  "
+          f"[e={E} m={M} bias={BIAS}]")
+    for lbl, msg in fails:
+        print("  FAIL", lbl, msg)
+    if ok == tot and not fails:
+        print("VERDICT: gf128 Fraction-oracle path agrees with pack, abs_error=0")
+    sys.exit(0 if (ok == tot and not fails) else 1)

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -2,6 +2,26 @@
 
 Last updated: 2026-07-05
 
+## SW-conformance — gf128 promoted to strict SW-bitexact (72/3/8) (Closes #1370)
+
+- gf128 (GoldenFloat128: S1 E49 M78, BIAS=281474976710655=2^48-1) promoted from
+  `bitexact_selfconsistent` to strict `bitexact` in `conformance/vectors/INDEX_all_formats.json`.
+- INDEX totals: bitexact 71 -> 72, selfconsistent 4 -> 3, structural 8 (sum=83).
+- Status tag: [verified SW]. Like gf96, gf128 has M=78 > 52, so binary64 CANNOT
+  hold the mantissa exactly; there is NO FP lowering and NO rounding: every finite
+  gf128 value is an exact dyadic rational odd*2^k.
+- Witness chain: TWO structurally independent exact decode paths
+  (dyadic integer normalizer `conformance/gf_wide_independent_witness.py` +
+  Fraction-significand symbolic-shift `conformance/witness/gf128/gf128_decode_ref.py`)
+  agree on all 15 pack vectors (abs_error=0) AND on a 201512-code representative
+  sweep (seed=128); + analytic separation-bound `conformance/witness/gf128/SEPARATION_BOUND.md`
+  (zero-rounding lemma over the whole 2^128 domain; exhaustive infeasible).
+- OOM-safe: the +-2^48 exponent is NEVER materialized; both paths keep the huge
+  power of two symbolic in `shift`, numerators <= ~2^80.
+- NOT on-silicon Tier-E: HW-decode / HW-compute for gf128 remain [REQUIRES USER
+  ACTION] (4/4 chain on AX7203, trinity-fpga #199).
+- Remaining selfconsistent (3): gf256, gf512, gf1024.
+
 ## SW-conformance — gf96 promoted to strict SW-bitexact (71/4/8) (Closes #1366)
 
 - gf96 (GoldenFloat96: S1 E36 M59, BIAS=34359738367=2^35-1) promoted from


### PR DESCRIPTION
Promote gf128 (GoldenFloat128: S1 E49 M78, BIAS=2^48-1, u128) selfconsistent -> strict bitexact. M=78>52 -> no FP lowering; every finite value is exact dyadic odd*2^k (parametric separation-bound, same lemma as gf96).

**Witnesses (all abs_error=0):**
1. dyadic independent normalizer (gf_wide_independent_witness.py, parametric) — 15/15 pack vectors;
2. golden Fraction oracle (conformance/witness/gf128/gf128_decode_ref.py) — 15/15 exact;
3. analytic separation-bound (SEPARATION_BOUND.md, zero-rounding lemma over 2^128).

Cross-check dyadic==Fraction: **201512 representative codes (seed=128) agree**. OOM-safe (+-2^48 exponent symbolic, numerators <= ~2^80).

INDEX: bitexact 71->72, selfconsistent 4->3, structural 8 (sum=83). E/M/BIAS verified against SSOT specs/numeric/formats_catalog.t27 (e=round(127/phi^2)=49, corrects v1.1 typo e=48).

Status [verified SW] — NOT on-silicon Tier-E (HW [REQUIRES USER ACTION], trinity-fpga #199). Catalog=83.

Closes #1370.