### PR TITLE
fix(codegen): lower Rust `+%` to wrapping_add (R7)

### DIFF
--- a/bootstrap/src/compiler.rs
+++ b/bootstrap/src/compiler.rs
@@ -11428,6 +11428,14 @@ impl RustCodegen {
                 if node.children.len() >= 2 {
                     let left = Self::expr_to_rust(&node.children[0]);
                     let right = Self::expr_to_rust(&node.children[1]);
+                    // The Zig-style wrapping-add operator `+%` has no infix form
+                    // in Rust; lower it to the `wrapping_add` method. Emitting
+                    // `a +% b` literally produced uncompilable Rust. Checked `+`
+                    // / `*` stay infix so the Rust backend keeps the same
+                    // overflow-panic semantics as the Zig backend.
+                    if node.extra_op == "+%" {
+                        return format!("({}).wrapping_add({})", left, right);
+                    }
                     let op = match node.extra_op.as_str() {
                         "and" => "&&",
                         "or" => "||",
@@ -25868,6 +25876,37 @@ mod tests_phase40_coverage {
         cg.gen_rust(&ast);
         let out = cg.into_string();
         assert!(out.contains("for i in 0..8"), "Rust output: {}", out);
+    }
+
+    // R7 regression: the Zig-style wrapping-add operator `+%` has no infix
+    // Rust form. The emitter used to pass it through literally, producing
+    // `a +% b`, which is not valid Rust and fails to compile. It must lower to
+    // the `wrapping_add` method. Checked `+` stays infix (overflow-panic
+    // parity with the Zig backend).
+    #[test]
+    fn test_wrapping_add_op_lowered_rust() {
+        let code = "module M { pub fn f(a: u32, b: u32) -> u32 { return a +% b; } }";
+        let out = Compiler::compile_rust(code).expect("compile should succeed");
+        assert!(
+            out.contains("wrapping_add"),
+            "`+%` not lowered to wrapping_add: {}",
+            out
+        );
+        assert!(
+            !out.contains("+%"),
+            "literal `+%` leaked into Rust output: {}",
+            out
+        );
+        // Plain `+` must remain a checked infix add (not silently wrapped).
+        let checked = Compiler::compile_rust(
+            "module M { pub fn g(a: u32, b: u32) -> u32 { return a + b; } }",
+        )
+        .expect("compile should succeed");
+        assert!(
+            !checked.contains("wrapping_add"),
+            "checked `+` was wrongly lowered to wrapping_add: {}",
+            checked
+        );
     }
 
     // #1401 regression: a `let` local binding must survive into generated

--- a/bootstrap/stage0/FROZEN_HASH
+++ b/bootstrap/stage0/FROZEN_HASH
@@ -1,1 +1,1 @@
-d6b51a3bcc20f2574add86e2e454ba03c0d3ea7017fa3c245122830d2f361a78 bootstrap/src/compiler.rs
+93cc42e3597c142e818dd5922474ec7f9c0243ace94e55d7b6765060e7b5df24 bootstrap/src/compiler.rs


### PR DESCRIPTION
### Problem
`t27c gen-rust` emitted the wrapping-add operator `+%` **literally** (`a +% b`), which is not valid Rust and fails to compile.

### Fix
Lower `+%` → `(lhs).wrapping_add(rhs)` in `Compiler::expr_to_rust`. Checked `+`/`*` deliberately stay infix — the Zig backend keeps them checked (overflow-panic in debug), and the two backends must agree. Blanket backend-wrapping (as the R7 backlog line suggested) would break that parity; see #1659 for the real hash-mixer story (missing `*%`/`-%`/`<<%` operators).

### Verification
- New test `test_wrapping_add_op_lowered_rust`: `+%` → `wrapping_add`, no literal `+%` leak, plain `+` NOT wrapped.
- Full compiler suite **1495 passed / 0 failed**. (`bitnet_pipeline::sequencer_idle_arms_on_start` fails identically on pristine master — pre-existing, unrelated.)
- End-to-end: `gen-rust` output now compiles under `rustc --edition 2021`.

### Constitution
- L2: emitter change, not a `gen/` edit.
- L4: regression test added.
- M5: FROZEN_HASH re-sealed (`93cc42e3…`).

Closes #1658
Relates #1659

🤖 Generated with [Claude Code](https://claude.com/claude-code)