### PR TITLE
docs(now): restore NOW.md coordination log truncated by #1710's script bug

### DIFF
--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -11,3 +11,903 @@ Last updated: 2026-08-05
 
 ---
 
+# NOW — lang: wrapping arithmetic operators -% and *% (2026-08-05)
+
+Last updated: 2026-08-05
+
+## lang: wrapping arithmetic operators -% and *% (Closes #1659)
+
+- Branch: `feat/wrapping-arith-ops`
+- PR: #1674
+
+### Что легло
+- Adds the Zig-style wrapping-operator family (only +% existed, and gen-rust mis-emitted it as invalid Rust). Lexer MinusPercent/StarPercent; parser -% additive, *% multiplicative; Rust -> wrapping_add/sub/mul; Verilog collapses to +/- and *% -> __mul_noop (HW wraps by width); C collapses to +/-/* (unsigned wraps); Zig native passthrough. Cross-backend test test_wrapping_ops_all_backends_1659; FROZEN_HASH re-sealed. Supersedes #1660.
+
+### Границы честности (BINDING)
+- Full compiler suite 1495/0; generated Rust compiles under rustc; Verilog/C emit no literal %-operator. Checked +/-/* stay infix -> same overflow-panic semantics as the Zig backend.
+
+---
+
+# NOW — chore: remove stray backup/patch artifacts + close gitignore gap (2026-08-05)
+
+Last updated: 2026-08-05
+
+## chore: remove stray backup/patch artifacts + close gitignore gap (Closes #1653)
+
+- Branch: `chore/r2-stray-artifacts`
+- PR: #1654
+
+### Что легло
+- Removed 5 tracked strays (compiler.rs.orig/.backup, two .trinity/state/*.patch, a .tex.bak3). Extended .gitignore: *.bak/*.orig missed numbered variants (.bak3) and .backup; also ignore root /*.patch.
+
+---
+
+# NOW — ci: wire dyadic wide-format witness into CI (gf48..gf1024) (2026-08-05)
+
+Last updated: 2026-08-05
+
+## ci: wire dyadic wide-format witness into CI (gf48..gf1024) (Closes #1580)
+
+- Branch: `ci/gf-wide-conformance`
+- PR: #1675
+
+### Что легло
+- gf_wide_independent_witness.py decodes GF rungs as exact dyadic pairs (gf1024 bias ~2.5e120) with no Fraction blowup, resolving #1580. Added gf-wide-conformance.yml matrix gate over gf14/gf48/gf96/gf128/gf256/gf512/gf1024; each exits 0, witness returns 1 on any mismatch.
+
+---
+
+# NOW — conformance: correct 5 stale gf16 vectors + wire oracle into CI (2026-08-05)
+
+Last updated: 2026-08-05
+
+## conformance: correct 5 stale gf16 vectors + wire oracle into CI (Closes #1579)
+
+- Branch: `fix/gf16-conformance-vectors`
+- Issue: #1579
+- PR: #1673
+
+### Что легло
+- gf16_ref.py exited non-zero on 5 named-constant vectors. Brute force over all 65536 codes proved the encoder picks the nearest GF16 code and decode is FPGA-consistent, so the vectors' expected.decoded values were phantom (not representable). Set expected.decoded to the true constant and tolerance_abs to the quantization bound (phase_transition widened to 0.0005). Added .github/workflows/gf16-conformance.yml so the oracle runs on every change.
+
+### Границы честности (BINDING)
+- The fix corrects test data, not the encoder/decoder — those are proven correct by roundtrip (19/19) and FPGA-consistency (32/32). Oracle now 35 pass / 0 fail.
+
+---
+
+# NOW — scripts: cocotb_ref_model is importable again (2026-08-01)
+
+Last updated: 2026-08-01
+
+## scripts: cocotb_ref_model is importable again (Closes #1592)
+
+- Branch: `fix/cocotb-forward-reference`
+- Issue: #1592
+- PR: #1589
+
+### Что легло
+- The module raised `NameError: name 'EvalContext' is not defined` at import: the class is annotated on parameters at lines 174 and 215 and defined at line 402. `from __future__ import annotations` defers annotation evaluation and the module loads.
+
+### Границы честности (BINDING)
+- Placement matters: a `__future__` import may be preceded only by the docstring, comments and blank lines. Putting it between shebang and docstring also loads the module but silently leaves `__doc__` as `None`. It goes after the docstring, confirmed with `ast.get_docstring`.
+- Found by running the EXEC bucket — the last 12 scripts in the repository never executed. No workflow references this file.
+
+---
+
+# NOW — ci: track the paper count the published version actually declares (2026-08-01)
+
+Last updated: 2026-08-01
+
+## ci: track the paper count the published version actually declares (Closes #1583)
+
+- Branch: `fix/stale-paper-count`
+- Issue: #1583
+- PR: #1584
+
+### Что легло
+- `check_catalog_count.py` printed, on every run, that the SSOT's 83 disagreed with a paper count of 84 and an erratum was required. `ERRATA_2026-06-14.md` recorded that erratum and the v2 replacement carried it out.
+- Fetching the current entry shows both the title and the abstract were corrected: *An 83-Format Numeric Catalog…*, arXiv:2606.09686v2, updated 2026-06-22. The constant tracked the withdrawn v1.
+
+### Границы честности (BINDING)
+- This is not the edit the existing comment forbids. The constant tracks what the PAPER declares, and the paper changed; matching it to the SSOT would defeat the gate.
+- The comment now carries the fetch command, version and date so the next reader can re-check in one line.
+- Alarm intact, verified by mutation: with a divergent constant the gate still warns and still exits 3 under `--strict-paper`.
+
+---
+
+# NOW — witness: wide-rung decode refs resolve their pack inside the repository (2026-08-01)
+
+Last updated: 2026-08-01
+
+## witness: wide-rung decode refs resolve their pack inside the repository (Closes #1581)
+
+- Branch: `fix/witness-default-paths`
+- Issue: #1581
+- PR: #1582
+
+### Что легло
+- All six wide-rung witness decode references defaulted to a path under `/home/user/workspace` when run with no argument, so the file a `witnesses[]` entry names failed on every machine but the one it was written on. The default now resolves relative to the script's own location.
+
+### Границы честности (BINDING)
+- The witnesses themselves were sound: given the in-repo pack explicitly, gf128 already reported 15/15 exact at abs_error=0. Only the default lookup was wrong; no decoding changes.
+- All six run standalone afterwards, gf48 through gf1024, each at abs_error=0.
+- The `cross_check_representative.py` scripts were never affected — they import these modules and never reach `__main__`.
+
+---
+
+# NOW — ci: gate INDEX_all_formats.json against the packs it summarises (2026-08-01)
+
+Last updated: 2026-08-01
+
+## ci: gate INDEX_all_formats.json against the packs it summarises (Closes #1577)
+
+- Branch: `gate/pack-index-consistency`
+- Issue: #1577
+- PR: #1578
+
+### Что легло
+- Nothing checked that the index agreed with the packs, which is how the pass-48 tier regression went unnoticed. `tools/pack_index_consistency_gate.py` locks digest, tier, witness count, header totals and index membership.
+- `--selftest` plants a mutant for every check and fails if any survives, following `wp18_selftest_gate.py`'s convention.
+
+### Границы честности (BINDING)
+- Selftest: every check FAIL-reachable.
+- Live corpus: verdict CLEAN, 0 failures, 5 informational notes about hand-curated packs that declare no `bitexact` flag.
+- Deliberately NOT checked: a bitexact pack with an empty `witnesses[]`. That is the normal case for the ~60 uncontested packs; demanding a witness everywhere would misstate honesty rule #10.
+
+---
+
+# NOW — conformance: the pack generator runs on a clean checkout (2026-08-01)
+
+Last updated: 2026-08-01
+
+## conformance: the pack generator runs on a clean checkout (Closes #1575)
+
+- Branch: `fix/conformance-generator-reproducible`
+- Issue: #1575
+- PR: #1576
+
+### Что легло
+- `gen_all_formats.py` read its catalog from a hardcoded `/tmp/catalog_lines.txt` that was never committed, so a fresh clone raised `FileNotFoundError` before writing a pack. It now reads the committed SSOT, `specs/numeric/formats_catalog.t27`, whose `// CATALOG:` rows are the same lines `catalog-count-gate.yml` counts.
+- Re-running the generator had silently reverted the 2026-07-05 promotions: the `SELFCONSISTENT` branch hardcoded `bitexact_selfconsistent`, rewriting the index from 75/0/8 back to 69/6/8. The tier now derives from the pack, which is the artefact of record for its own status.
+- The index carries a `witnesses` count per entry and a top-level `witnessed_packs`; a consumer could not previously tell which packs are witnessed without opening all 83.
+- `conformance/vectors/verify_regeneration.py` added as the regression test.
+
+### Границы честности (BINDING)
+- Regeneration reproduces the committed corpus exactly: 83/83 digests unchanged, 0 tiers changed.
+- Index changes are strictly additive — 0 entry fields changed or removed.
+- Both existing gates pass: `wp18_selftest_gate.py` all PASS, `wp18_conformance_gate.py` verdict CLEAN.
+
+---
+
+# NOW — Rust backend type fixes (2026-07-31)
+
+Last updated: 2026-07-31
+
+## gen-rust: array types, index casts, boolean coercion (Closes #1574)
+
+- Branch: `fix/rust-backend-types`
+- Issue: #1574
+- The Rust backend emitted code that does not compile; downstream tri-net had 32 errors and red CI since 2026-07-23.
+
+### Что легло
+- `t27_type_to_rust` — форма `[T; N]` больше не схлопывается в `Vec<>`; эмитится `[T; N as usize]`.
+- `ExprIndex` — нелитеральный индекс приводится к `usize`.
+- Целые и булевы согласованы: классификатор `expr_is_bool`, `!= 0` в условии, `as u32` в целочисленной позиции, `((x) == 0)` вместо побитового `!`.
+- Рекурсивный предпроход собирает функции `-> bool`, плюс `bool`-параметры и локальные, чтобы вызов булевой функции не получал лишний `!= 0`.
+
+### Границы честности (BINDING)
+- Проверено downstream: библиотека tri-net собирается, 101 тест проходит.
+- FROZEN_HASH переподписан механически; governance-часть церемонии M5 (GOLD-RING, одобрение Архитектора) не выполнялась.
+- `fpga-synthesis` падает на SystemVerilog-касте `8'(...)` в Verilog-бэкенде — воспроизведено на немодифицированном master, к этой работе отношения не имеет.
+
+---
+
+# NOW — conformance instance-пакеты + Lean φ-скелет (2026-07-29)
+
+Last updated: 2026-07-29
+
+## conformance: параметрические instance-пакеты (structural) + Lean-скелет φ-правила (Closes #1558)
+
+- Branch: `wave-loop-29-07b-swtracks`
+- Issue: #1558
+- Трек Wave-лупа 29.07b «улучшения без железа», SW-часть (encoding-уровень).
+
+### Что легло
+- `conformance/gen_structural_instances.py` + `conformance/README_structural_instances.md` — генератор instance-пакетов для structural-форматов.
+- 4 instance-пакета (`kind="instance"`, независимый Fraction-декодер, abs_error=0):
+  - `instance_q_format_Q4_4_v0.json` — канонич. round-trip 512/512.
+  - `instance_q_format_Q2_5_v0.json` — 256/256.
+  - `instance_minifloat_E2M1_v0.json` — 13/13.
+  - `instance_minifloat_E3M4_v0.json` — 225/225.
+- `proofs/lean4/Trinity/GoldenFloatRoundTrip.lean` — скелет φ-правила (e=round((N−1)/φ²), m=N−1−e, bias=2^(e−1)−1); field_budget+anchor_witness доказаны, gf16_fields/roundtrip_normal = `sorry` `[ТРЕБУЕТ lake build]`.
+
+### Границы честности (BINDING)
+- `kind="instance"` — КОНКРЕТНЫЕ параметризации structural-семейств, каталог НЕ меняют: **75 bitexact / 0 selfconsistent / 8 structural = 83**.
+- Всё `[verified SW]` (independent decoder), НЕ HW. encoding ≠ compute ≠ FPGA.
+
+---
+
+# NOW — Wave Loop 773 close-out / Wave Loop 774 setup (2026-07-24)
+
+Last updated: 2026-07-24
+
+## Wave Loop 773 — module-scope `[365][2]^6 Pt` packed array-of-struct from call with indexed signed writes (Closes #1481)
+
+- Branch: `wave-loop-773`
+- Issue: #1481
+- PR: #1482
+- Report: `docs/reports/FPGA_LOOP_CLOSEOUT_W773_2026-07-24.md`
+- Plan: `.claude/plans/wave-loop-773.md`
+- Cooperation W774: `.claude/plans/wave-loop-774.md`
+
+### What landed
+- `specs/scratch/w773_bench_module_365x2p6_aos_var_call_write.t27`
+  - 23,360 elements, 747,520-bit packed vector (~0.713 MiBit).
+  - Module-scope `pub var dst : [365][2]^6 Pt` initialized from a function call and
+    exercised with indexed signed field writes.
+  - `assert_eq` read-back in a `bench` block (Icarus path does not emit `assert_ne`).
+- `scripts/gen_w773.py`
+  - Generator for the W773 witness; `OUTER = 365`, `MID_IDX = 182`.
+- `bootstrap/tests/icarus_lowerable.rs`
+  - Added `accepts_w773_bench_module_365x2p6_aos_var_call_write`.
+- `.trinity/experience.md`, `.trinity/current-issue.md`, `.claude/plans/wave-loop-774.md`
+  - W773 learnings saved and W774 plan created.
+
+### Not changed
+- `bootstrap/src/compiler.rs` — zero compiler changes.
+- `bootstrap/stage0/FROZEN_HASH` — unchanged `68a0b933c00ba5efd7facb5997f00880c3eecae55e6ac5e8cea2aee399b92adc`.
+- `scripts/cocotb_ref_model.py` — unchanged.
+
+### Verification
+- `cargo build --release -p t27c`: OK.
+- `cargo test -p t27c --bin t27c`: 1494/0/2.
+- `cargo test -p tri`: 78/0.
+- `cargo test -p t27c --test icarus_lowerable`: 233/0.
+- `t27c parse|icarus-lowerable|icarus-simulate|icarus-cocotb|seal --save` W773: PASS.
+
+---
+
+## Wave Loop 774 — next odd outer-dimension `[367][2]^6 Pt` (Issue TBD)
+
+- Branch: `wave-loop-774` (to create after W773 merge)
+- Issue: TBD
+- Plan: `.claude/plans/wave-loop-774.md`
+
+### Candidate variants
+- Variant A (recommended): continue the odd outer-dimension ladder with `[367][2]^6 Pt`.
+- Variant B: keep width at ~0.713 MiBit but move the packed var to bench/function scope.
+- Variant C: add `if`-guarded indexed signed field writes at the current width.
+
+---
+
+## Wave Loop 772 — module-scope `[363][2]^6 Pt` packed array-of-struct from call with indexed signed writes (Closes #1743)
+
+- Branch: `wave-loop-772`
+- Issue: #1743
+- PR: #1480
+- Report: `docs/reports/FPGA_LOOP_CLOSEOUT_W772_2026-07-24.md`
+- Plan: `.claude/plans/wave-loop-772.md`
+- Cooperation W773: `.claude/plans/wave-loop-773.md`
+
+### What landed
+- `specs/scratch/w772_bench_module_363x2p6_aos_var_call_write.t27`
+  - 23,232 elements, 743,424-bit packed vector (~0.709 MiBit).
+  - Module-scope `pub var dst : [363][2]^6 Pt` initialized from a function call and
+    exercised with indexed signed field writes.
+  - `assert_eq` read-back in a `bench` block (Icarus path does not emit `assert_ne`).
+- `scripts/gen_w772.py`
+  - Generator for the W772 witness; `OUTER = 363`, `MID_IDX = 181`.
+- `bootstrap/tests/icarus_lowerable.rs`
+  - Added `accepts_w772_bench_module_363x2p6_aos_var_call_write`.
+- `.trinity/experience.md`, `.trinity/current-issue.md`, `.claude/plans/wave-loop-773.md`
+  - W772 learnings saved and W773 issue/plan created.
+
+### Not changed
+- `bootstrap/src/compiler.rs` — zero compiler changes.
+- `bootstrap/stage0/FROZEN_HASH` — unchanged `68a0b933c00ba5efd7facb5997f00880c3eecae55e6ac5e8cea2aee399b92adc`.
+- `scripts/cocotb_ref_model.py` — unchanged.
+
+### Verification
+- `cargo build --release -p t27c`: OK.
+- `cargo test -p t27c --bin t27c`: 1494/0/2.
+- `cargo test -p tri`: 78/0.
+- `cargo test -p t27c --test icarus_lowerable`: 232/0.
+- `t27c parse|icarus-lowerable|icarus-simulate|icarus-cocotb|seal --save` W772: PASS.
+
+---
+
+## Wave Loop 771 — module-scope `[361][2]^6 Pt` packed array-of-struct from call with indexed signed writes (Closes #1742)
+
+- Branch: `wave-loop-771`
+- Issue: #1742
+- PR: to open
+- Report: `docs/reports/FPGA_LOOP_CLOSEOUT_W771_2026-07-24.md`
+- Plan: `.claude/plans/wave-loop-771.md`
+- Cooperation W772: `.claude/plans/wave-loop-772.md`
+
+### What landed
+- `specs/scratch/w771_bench_module_361x2p6_aos_var_call_write.t27`
+  - 23,104 elements, 739,328-bit packed vector (~0.705 MiBit).
+  - Module-scope `pub var dst : [361][2]^6 Pt` initialized from a function call and
+    exercised with indexed signed field writes.
+  - `assert_eq` read-back in a `bench` block (Icarus path does not emit `assert_ne`).
+- `scripts/gen_w771.py`
+  - Generator for the W771 witness; `OUTER = 361`, `MID_IDX = 180`.
+- `bootstrap/tests/icarus_lowerable.rs`
+  - Added `accepts_w771_bench_module_361x2p6_aos_var_call_write`.
+- `.trinity/experience.md`, `.trinity/current-issue.md`, `.claude/plans/wave-loop-772.md`
+  - W771 learnings saved and W772 issue/plan created.
+
+### Not changed
+- `bootstrap/src/compiler.rs` — zero compiler changes.
+- `bootstrap/stage0/FROZEN_HASH` — unchanged `68a0b933c00ba5efd7facb5997f00880c3eecae55e6ac5e8cea2aee399b92adc`.
+- `scripts/cocotb_ref_model.py` — unchanged.
+
+### Verification
+- `cargo build --release -p t27c`: OK.
+- `cargo test -p t27c --bin t27c`: 1494/0/2.
+- `cargo test -p tri`: 78/0.
+- `cargo test -p t27c --test icarus_lowerable`: 231/0.
+- `t27c parse|icarus-lowerable|icarus-simulate|icarus-cocotb|seal --save` W771: PASS.
+
+---
+
+## Wave Loop 770 — module-scope `[359][2]^6 Pt` packed array-of-struct from call with indexed signed writes (Closes #1741)
+
+- Branch: `wave-loop-770`
+- Issue: #1741
+- PR: to open
+- Report: `docs/reports/FPGA_LOOP_CLOSEOUT_W770_2026-07-24.md`
+- Plan: `.claude/plans/wave-loop-770.md`
+- Cooperation W771: `.claude/plans/wave-loop-771.md`
+
+### What landed
+- `specs/scratch/w770_bench_module_359x2p6_aos_var_call_write.t27`
+  - 22,976 elements, 735,232-bit packed vector (~0.701 MiBit).
+  - Module-scope `pub var dst : [359][2]^6 Pt` initialized from a function call and
+    exercised with indexed signed field writes.
+  - `assert_eq` read-back in a `bench` block (Icarus path does not emit `assert_ne`).
+- `scripts/gen_w770.py`
+  - Generator for the W770 witness; `OUTER = 359`, `MID_IDX = 179`.
+- `bootstrap/tests/icarus_lowerable.rs`
+  - Added `accepts_w770_bench_module_359x2p6_aos_var_call_write`.
+- `.trinity/experience.md`, `.trinity/current-issue.md`, `.claude/plans/wave-loop-771.md`
+  - W770 learnings saved and W771 issue/plan created.
+
+### Not changed
+- `bootstrap/src/compiler.rs` — zero compiler changes.
+- `bootstrap/stage0/FROZEN_HASH` — unchanged `68a0b933c00ba5efd7facb5997f00880c3eecae55e6ac5e8cea2aee399b92adc`.
+- `scripts/cocotb_ref_model.py` — unchanged.
+
+### Verification
+- `cargo build --release -p t27c`: OK.
+- `cargo test -p t27c --bin t27c`: 1494/0/2.
+- `cargo test -p tri`: 78/0.
+- `cargo test -p t27c --test icarus_lowerable`: 230/0.
+- `t27c parse|icarus-lowerable|icarus-simulate|icarus-cocotb|seal --save` W770: PASS.
+
+---
+
+## Wave Loop 768 — next odd outer-dimension `[355][2]^6 Pt` (Issue #1739)
+
+- Branch: `wave-loop-768` (to create after W767 merge)
+- Issue: #1739
+- Plan: `.claude/plans/wave-loop-768.md`
+
+### Candidate variants
+- Variant A (recommended): continue the odd outer-dimension ladder with `[355][2]^6 Pt`.
+- Variant B: keep width at ~0.690 MiBit but move the packed var to bench/function scope.
+- Variant C: add `if`-guarded indexed signed field writes at the current width.
+
+---
+
+## Wave Loop 767 — next odd outer-dimension `[353][2]^6 Pt` (Issue #1738)
+
+- Branch: `wave-loop-767` (to create after W766 merge)
+- Issue: #1738
+- Plan: `.claude/plans/wave-loop-767.md`
+
+### Candidate variants
+- Variant A (recommended): continue the odd outer-dimension ladder with `[353][2]^6 Pt`.
+- Variant B: keep width at ~0.686 MiBit but move the packed var to bench/function scope.
+- Variant C: add `if`-guarded indexed signed field writes at the current width.
+
+---
+
+## Wave Loop 766 — next odd outer-dimension `[351][2]^6 Pt` (Issue #1737)
+
+- Branch: `wave-loop-766` (to create after W765 merge)
+- Issue: #1737
+- Plan: `.claude/plans/wave-loop-766.md`
+
+### Candidate variants
+- Variant A (recommended): continue the odd outer-dimension ladder with `[351][2]^6 Pt`.
+- Variant B: keep width at ~0.682 MiBit but move the packed var to bench/function scope.
+- Variant C: add `if`-guarded indexed signed field writes at the current width.
+
+---
+
+## Wave Loop 765 — next odd outer-dimension `[349][2]^6 Pt` (Issue #1736)
+
+- Branch: `wave-loop-765` (to create after W764 merge)
+- Issue: #1736
+- Plan: `.claude/plans/wave-loop-765.md`
+
+### Candidate variants
+- Variant A (recommended): continue the odd outer-dimension ladder with `[349][2]^6 Pt`.
+- Variant B: keep width at ~0.678 MiBit but move the packed var to bench/function scope.
+- Variant C: add `if`-guarded indexed signed field writes at the current width.
+
+---
+
+## Wave Loop 764 — next odd outer-dimension `[347][2]^6 Pt` (Issue #1735)
+
+- Branch: `wave-loop-764` (to create after W763 merge)
+- Issue: #1735
+- Plan: `.claude/plans/wave-loop-764.md`
+
+### Candidate variants
+- Variant A (recommended): continue the odd outer-dimension ladder with `[347][2]^6 Pt`.
+- Variant B: keep width at ~0.674 MiBit but move the packed var to bench/function scope.
+- Variant C: add `if`-guarded indexed signed field writes at the current width.
+
+---
+
+# NOW — IGLA cycle 1 + Wave Loop 469 context (2026-07-07)
+
+## t27c codegen: mut-inference for reassigned locals (Fixes #1463)
+
+- PR #1461 adds mutability inference to the Rust codegen backend.
+- `collect_mutable_names()` scans function bodies for assignment targets
+  (simple, index, field), emitting `let mut` where needed.
+- Eliminates 117 E0384 errors in tri-net specs.
+## t27c codegen: recursive optimizer scan for control-flow bodies (Fixes #1464)
+
+- PR #1462 fixes const_propagate, copy_propagate, dead_store_elim to recurse
+  into if/while/for bodies when checking for reassignment/reads.
+- Eliminates 182 E0425 errors in tri-net specs (208 -> 26).
+- Stacked on #1461.
+## IGLA cycle 1 — process debt needles (Refs #1438, #1440, #1442, #1444, #1446)
+
+- Charter: `docs/nona-03-manifest/IGLA_IMPROVEMENT_LOOP.md` + audit `docs/reports/IGLA_AUDIT_W470_2026-07-07.md`.
+- Open PRs:
+  - #1439: remove duplicate workflow directory, enforce `FROZEN_HASH`, unify L1 regexes.
+  - #1441: harden auto-merge and brain-seal-refresh workflows.
+  - #1445: align Vivado scripts/constraints with `HARDWARE_SSOT` XC7A200T-FGG676.
+- Completed: worktree cleanup (#1442); salvaged compiler postfix-array change to `salvage/ae9fe-postfix-array-notation`.
+- Blocked: W469 2D-struct-array Verilog lowering (#1443, blocked on `wave-loop-469`); Digilent FTDI `cli/dlc10` support (#1446, blocked on hardware access).
+
+## IGLA cycle 1 — auto-workflow hardening (Closes #1440)
+
+- PR #1441 hardens `.github/workflows/auto-merge-ready-prs.yml` and
+  `.github/workflows/brain-seal-refresh.yml` with explicit permissions,
+  L1 traceability gating, correct dry-run boolean handling, and change-detection
+  guards before `git commit`.
+- This closes issue #1440 (automated workflows could merge/commit without
+  issue linkage or review).
+
+## IGLA cycle 1 — FPGA target alignment (Closes #1444)
+
+- PR #1445 aligns Vivado synthesis scripts and the constraints header with the
+  `fpga/HARDWARE_SSOT.md` canonical device: `XC7A200T-FGG676` (`xc7a200tfgg676-1`).
+- This replaces the stale `XC7A100T-FGG676` hard-coding in `fpga/vivado/build.tcl`,
+  `build_gf16.tcl`, `build_gf16_matmul4x4.tcl`, and `specs/fpga/constraints/qmtech_a100t.xdc`.
+- This closes issue #1444 (synthesis scripts targeted the wrong FPGA device).
+
+## Architecture — ADR-007 documents de-jure/de-facto split for generated .v in specs/ (Closes #1435)
+
+- Fact-check on HEAD 6c704801: specs/**/*.v = 61 files, gen/**/*.v = 33. Issues
+  #960 and #1205 were closed as done, but the L2 GENERATION violation artifact
+  (61 generated .v in specs/, some already duplicated in gen/, e.g. specs/fpga/uart.v
+  vs canonical gen/verilog/fpga/uart.v) is still present on master.
+- #1205 body itself says "30/61 migrated, ~30 remain" with unchecked acceptance
+  criteria yet the issue is closed -> premature-closure pattern (text claim, not HEAD).
+- This PR adds architecture/ADR-007-verilog-in-specs.md ONLY (a decision record). It
+  does NOT delete any .v file: choice A (finish migration) vs B (legalize as golden
+  fixtures with a whitelist path) is left to the owner. SSOT=83 untouched.
+- Status tag: [доказано] for the counts; [ТРЕБУЕТ ДЕЙСТВИЯ ПОЛЬЗОВАТЕЛЯ] for A vs B.
+
+## Compiler — lexer accepts `let` as immutable-local synonym for `const` (Closes #1401)
+
+- Root cause of E0425 x2609 (93% of Rust codegen errors) and 1957 C-emitter sites:
+  the lexer recognized `const`/`var` but NOT `let`. tri-net specs write `let x = ...;`
+  in function bodies -> `let` tokenized as a bare `Ident` -> `parse_body_stmt`
+  (dispatches to `parse_local_decl` only for `KwConst || KwVar`, compiler.rs:1690)
+  fell through to expression parsing -> the binding was dropped entirely before every
+  backend emitter.
+- The issue diagnosis suspected the emitter -- that is INCORRECT. `gen_rust_stmt`
+  (compiler.rs:7912) and the C/Zig/Verilog `StmtLocal` branches are correct. The real
+  bug is in the lexer. A single alias line repairs Rust + C + Zig + Verilog at once,
+  because every emitter already handles `StmtLocal`.
+- Fix (additive): lexer (compiler.rs:341) `"let" => TokenKind::KwConst` -- `let` is an
+  immutable local (matches the `let` the Rust emitter already prints). Mutable local
+  stays `var`; there is no `let mut` spec form yet.
+- Tests: +3 regression tests (`test_let_binding_emitted_rust_1401`,
+  `test_let_binding_emitted_c_1401`, `test_let_is_immutable_local_1401`); replaced the
+  GAP-characterization test `let_binding_falls_back_to_todo_characterization` ->
+  `let_binding_is_lowered_1401` per its own note.
+- Status tag: [verified SW] (CI `check` job GREEN -- cargo tests ran and passed).
+  SSOT=83 untouched.
+
+## SW-conformance — gf256 promoted to strict SW-bitexact (75/0/8) (Closes #1397)
+
+- gf256 (GoldenFloat256: S1 E97 M158, BIAS=79228162514264337593543950335=2^96-1,
+  u256_software) promoted from `bitexact_selfconsistent` to strict `bitexact` in
+  `conformance/vectors/INDEX_all_formats.json`. This is the LAST selfconsistent rung.
+- INDEX totals: bitexact 74 -> 75, selfconsistent 1 -> 0, structural 8 (sum=83).
+  Horizon-A SW ceiling reached (75 bit-precise; 8 structural are terminal, no single
+  decode law; 83/83 SW-bitexact is NOT achievable).
+- Bias hold lifted: earlier NOW entries said gf256 "stays open (open bias R&D) -- do
+  NOT promote". The 2026-07-05 bias audit resolved this: the decode uses ONLY the
+  closed-form interchange bias 2^(E-1)-1 = 2^96-1 (identical rule to gf128/gf512).
+  The descriptive PHI_BIAS spec metadata is NOT part of the decode path and no
+  decoded value depends on it (red herring). Decode-definition is definitive.
+- Status tag: [verified SW]. M=158 >> 52 -> no FP lowering; every finite value is an
+  EXACT dyadic odd*2^k (analytic separation-bound, same lemma as gf128/gf512).
+- Witness chain: dyadic normalizer 2021/2021 + Fraction oracle 2021/2021 + analytic
+  separation-bound; cross-check dyadic==Fraction on 201512 representative codes
+  (seed=256) agree, abs_error=0. OOM-safe (+-2^96 exponent kept symbolic).
+- NOT on-silicon Tier-E: gf256 is u256_software, has NO RTL -> no decode-HW/compute-HW
+  cell exists for it; the Tier-E ceiling 71/83 (trinity-fpga #199) is unaffected.
+
+## SW-conformance — gf512 + gf1024 promoted to strict SW-bitexact (paired, 74/1/8) (Closes #1380)
+
+- gf512 (S1 E195 M316, BIAS=2^194-1, u512_software) and gf1024 (S1 E391 M632,
+  BIAS=2^390-1, u1024_software; lowest phi-distance in the ladder) promoted from
+  `bitexact_selfconsistent` to strict `bitexact` (paired).
+- INDEX totals: bitexact 72 -> 74, selfconsistent 3 -> 1, structural 8 (sum=83).
+- Status tag: [verified SW]. M=316/632 > 52 -> no FP lowering; every finite value
+  is an EXACT dyadic odd*2^k (parametric separation-bound, same lemma as gf96/gf128).
+- Witness chain (each format): dyadic normalizer 15/15 + Fraction oracle 15/15 +
+  analytic separation-bound; cross-check dyadic==Fraction on 201512 representative
+  codes (seed=512 / seed=1024) agree. OOM-safe (+-2^194 / +-2^390 symbolic).
+- NOT on-silicon Tier-E: HW decode/compute [REQUIRES USER ACTION] (trinity-fpga #199).
+- Remaining selfconsistent (1): gf256 (bias-open R&D, separate research).
+
+## SW-conformance — gf128 promoted to strict SW-bitexact (72/3/8) (Closes #1370)
+
+- gf128 (GoldenFloat128: S1 E49 M78, BIAS=281474976710655=2^48-1) promoted from
+  `bitexact_selfconsistent` to strict `bitexact` in `conformance/vectors/INDEX_all_formats.json`.
+- INDEX totals: bitexact 71 -> 72, selfconsistent 4 -> 3, structural 8 (sum=83).
+- Status tag: [verified SW]. Like gf96, gf128 has M=78 > 52, so binary64 CANNOT
+  hold the mantissa exactly; there is NO FP lowering and NO rounding: every finite
+  gf128 value is an exact dyadic rational odd*2^k.
+- Witness chain: TWO structurally independent exact decode paths
+  (dyadic integer normalizer `conformance/gf_wide_independent_witness.py` +
+  Fraction-significand symbolic-shift `conformance/witness/gf128/gf128_decode_ref.py`)
+  agree on all 15 pack vectors (abs_error=0) AND on a 201512-code representative
+  sweep (seed=128); + analytic separation-bound `conformance/witness/gf128/SEPARATION_BOUND.md`
+  (zero-rounding lemma over the whole 2^128 domain; exhaustive infeasible).
+- OOM-safe: the +-2^48 exponent is NEVER materialized; both paths keep the huge
+  power of two symbolic in `shift`, numerators <= ~2^80.
+- NOT on-silicon Tier-E: HW-decode / HW-compute for gf128 remain [REQUIRES USER
+  ACTION] (4/4 chain on AX7203, trinity-fpga #199).
+- Remaining selfconsistent (3): gf256, gf512, gf1024.
+
+## SW-conformance — gf96 promoted to strict SW-bitexact (71/4/8) (Closes #1366)
+
+- gf96 (GoldenFloat96: S1 E36 M59, BIAS=34359738367=2^35-1) promoted from
+  `bitexact_selfconsistent` to strict `bitexact` in
+  `conformance/vectors/INDEX_all_formats.json`.
+- INDEX totals: bitexact 70 -> 71, selfconsistent 5 -> 4, structural 8 (sum=83).
+- Status tag: [verified SW]. Unlike gf48, gf96 has M=59 > 52, so binary64 CANNOT
+  hold the mantissa exactly and there is NO FP lowering and NO rounding: every
+  finite gf96 value is an exact dyadic rational. The proof is therefore an
+  analytic zero-rounding separation-bound plus two structurally independent EXACT
+  decode paths (no RTL bit-model / iverilog needed, because there is nothing to
+  round). Witnesses pass in-sandbox:
+  (1) dyadic independent decoder 15/15 (abs_error=0);
+  (2) golden Fraction oracle 15/15 exact vs pack;
+  (3) two-path cross-check over 201512 representative codes (5-class + exponent
+      boundaries + full-mantissa edges + deep-underflow/overflow + 200k random
+      seed=96), both paths agree bit-exactly.
+- Witness chain + separation-bound lemma: `conformance/witness/gf96/README.md`
+  and `conformance/witness/gf96/SEPARATION_BOUND.md`. Memory note: the +-2^35
+  exponent means `2^(exp-BIAS)` is NEVER materialized as an integer (would OOM);
+  both paths keep the huge power symbolic (peak RSS ~14 MB).
+- NOT on-silicon Tier-E: HW-decode / HW-compute for gf96 remain [REQUIRES USER
+  ACTION] (4/4 chain on AX7203, trinity-fpga #199). encoding != compute != FPGA.
+- Remaining selfconsistent (4): gf128, gf256, gf512, gf1024.
+  gf256 stays open (bitexact:false, open bias R&D) -- do NOT promote.
+
+## SW-conformance — gf48 promoted to strict SW-bitexact (70/5/8) (Closes #1358)
+
+- gf48 (GoldenFloat48: S1 E18 M29, BIAS=131071) promoted from
+  `bitexact_selfconsistent` to strict `bitexact` in
+  `conformance/vectors/INDEX_all_formats.json`.
+- INDEX totals: bitexact 69 -> 70, selfconsistent 6 -> 5, structural 8 (sum=83).
+- Status tag: [verified SW]. Three independent SW witnesses pass in-sandbox:
+  (1) dyadic independent decoder 15/15 (abs_error=0);
+  (2) golden Fraction oracle 15/15 exact vs pack;
+  (3) FP64 fixed-width RTL bit-model 224255/224255 bit-exact (fails=0).
+- Witness chain + local-agent iverilog run instructions:
+  `conformance/witness/gf48_fp64/README.md`. The iverilog independent second
+  decoder (`gf_decode_param_fp64.v` + `tb_gf_decode_fp64.v`) is PREPARED for the
+  local agent (no iverilog in sandbox) = stronger witness, not yet run.
+- NOT on-silicon Tier-E: HW-decode / HW-compute for gf48 remain [REQUIRES USER
+  ACTION] (4/4 chain on AX7203, trinity-fpga #199). encoding != compute != FPGA.
+- Remaining selfconsistent (5 at the time of #1358): gf96, gf128, gf256, gf512,
+  gf1024. gf256 stays open (bitexact:false, open bias R&D) -- do NOT promote.
+  (gf96 later promoted, see the gf96 section above -> 4 remaining.)
+
+## Wave Loop 419 — Variant C fallback: VCD/CSV hardening, PVT monotonicity, standalone lake workflow (Closes #1357)
+
+- Branch: `wave-loop-419`
+- Issue: #1357
+- PR: #1360
+- Report: `docs/reports/WAVE_LOOP_419_REPORT.md`
+- Evidence: `docs/reports/FPGA_LOOP_EVIDENCE_W419_2026-07-05.md`
+- Cooperation W420: `docs/reports/FPGA_LOOP_COOPERATION_W420_2026-07-05.md`
+
+### What landed (Variant C — bench still blocked)
+- `cli/tri/src/fpga.rs`
+  - VCD `$comment` hardening: exact `$end` token terminator and regression test for embedded `$end`-like tokens.
+  - CSV multi-channel support: header auto-detection extended to `cclk`, `vccint`, `vccaux`, `ain`, `a0`, `channel0`; added `--csv-channel` explicit selection.
+  - PVT envelope monotonicity/antitonicity Rust tests (`test_pvt_half_ns_monotone_in_temp`, `test_pvt_half_ns_antitone_in_vccint`).
+  - Fixed `--standalone` output to remove invalid `import Trinity.BitstreamConfig`; updated integration test and string assertions.
+  - Added `test_parse_cclk_csv_explicit_channel_select`.
+- `proofs/lean4/Trinity/TernaryFPGABoot.lean`
+  - Added `pvt_half_ns_monotone_in_temp` and `pvt_half_ns_antitone_in_vccint`.
+- `fpga/HARDWARE_SSOT.md`
+  - Added §3.6.16 "Standalone lake-package workflow for generated theorems (W419)".
+
+### Not done (blocked on hardware)
+- Real P12 CCLK capture for `OSCFSEL=6/7` — P12 unwired, DLC10 cable missing.
+- Real relay cold-POR gate — no relay board / USB power switch available.
+
+### Verification
+- `cargo test -p tri vcd`: **PASS** (11 tests).
+- `cargo test -p tri csv`: **PASS** (11 tests).
+- `cargo test -p tri pvt`: **PASS** (9 tests).
+- `cargo test -p tri fpga::tests`: **PASS** (45 tests).
+- `cargo test -p tri test_measured_to_lean_standalone_lake_package_builds`: **PASS**.
+- `lake build Trinity.TernaryFPGABoot`: **PASS** (2967 jobs).
+- `./scripts/tri test`: parse/typecheck/GF16/gen-Zig/gen-Rust/gen-Verilog/seal/C/fixed-point PASS; gen-Verilog yosys smoke has 16 pre-existing failures from weak point #1245.
+
+---
+
+## Wave Loop 420 — physical capture, relay gate, or instrument-import depth (Issue #1361)
+
+- Branch: `wave-loop-420` (to create after W419 merge)
+- Issue: #1361
+- PR: to open after work
+- Report: `docs/reports/WAVE_LOOP_420_REPORT.md` (to create)
+- Evidence: `docs/reports/FPGA_LOOP_EVIDENCE_W420_2026-07-05.md` (to create)
+- Cooperation W421: `docs/reports/FPGA_LOOP_COOPERATION_W421_2026-07-05.md` (to create)
+
+### Candidate variants
+- Variant A: capture real CCLK for `OSCFSEL=6/7` once P12 is wired and the analyzer / DLC10 cable is available.
+- Variant B: implement a real `--relay-port` backend once a relay board or USB power switch is available.
+- Variant C: further instrument-import depth (VCD auto-threshold, CSV samplerate auto-detection), PVT envelope refinement with real curves if available, or one safe gen-verilog #1245 sub-fix.
+
+---
+
+## Wave Loop 418 — Variant C fallback: PVT regression, instrument import, and standalone Lean integration (Closes #1353)
+
+- Branch: `wave-loop-418`
+- Issue: #1353
+- PR: to open
+- Report: `docs/reports/WAVE_LOOP_418_REPORT.md`
+- Evidence: `docs/reports/FPGA_LOOP_EVIDENCE_W418_2026-07-04.md`
+- Cooperation W419: `docs/reports/FPGA_LOOP_COOPERATION_W419_2026-07-04.md`
+
+### What landed (Variant C — bench still blocked)
+- `cli/tri/src/fpga.rs`
+  - Added PVT-envelope lower-bound regression test across the operating rectangle
+    (`test_pvt_half_ns_lower_bound_across_operating_rectangle`).
+  - Hardened VCD parser to skip multi-line `$date`/`$version`/`$comment` header
+    sections (`test_parse_vcd_multiline_header_sections_skipped`).
+  - Improved analog CSV voltage-column auto-detection by header name
+    (`voltage`, `v`, `analog`) for multi-channel exports
+    (`test_parse_cclk_csv_named_voltage_column`).
+  - Added standalone Lean integration test that builds the generated theorem in
+    a temporary `lake` package
+    (`test_measured_to_lean_standalone_lake_package_builds`).
+- `proofs/lean4/Trinity/TernaryFPGABoot.lean`
+  - Added `n25q128_min_sck_half_ns_pvt` and the matching lower-bound lemma
+    `pvt_half_ns_at_least_nominal`.
+- `fpga/HARDWARE_SSOT.md`
+  - Added §3.6.14 "First real CCLK capture checklist".
+  - Added §3.6.15 "Replacing the placeholder PVT envelope coefficients" with
+    current coefficients and a replacement recipe.
+
+### Not done (blocked on hardware)
+- Real P12 CCLK capture for `OSCFSEL=6/7` — P12 unwired, DLC10 cable missing.
+- Real relay cold-POR gate — no relay board / USB power switch available.
+
+### Verification
+- `cargo test -p tri pvt`: **PASS** (3 tests).
+- `cargo test -p tri vcd`: **PASS** (11 tests).
+- `cargo test -p tri csv`: **PASS** (10 tests).
+- `cargo test -p tri test_measured_to_lean_standalone_lake_package_builds`: **PASS**.
+- `lake build Trinity.TernaryFPGABoot`: **PASS** (2967 jobs).
+
+---
+
+## Build unblock: docs Cyrillic scan warning-not-panic (Closes #1355)
+
+- Branch: `fix/now-md-grandfather`
+- Issue: #1355
+- PR: #1348
+- Scope: `bootstrap/build.rs` only. Three .md-scan sections downgraded from
+  `panic!` to `eprintln!("cargo:warning=...")`. `.rs` and `.t27`/`.tri`
+  scans stay hard `panic!` (code-critical, zero Cyrillic there).
+- Rationale: `cargo build --release --bin t27c` was panicking on the first
+  Cyrillic char in `docs/**/*.md` (~1113 files), which broke every
+  downstream that builds t27c fresh in CI. Chief downstream:
+  `tri-net/spec-drift-guard.yml` (31 specs × 3 backends = 93 drift checks)
+  — currently unable to run at all.
+- Verification (local): `cargo build --release --bin t27c` finishes with
+  0 panics; t27c self-tests: 20 passed.
+- Downstream: tri-net PR #39 (audit + 31-spec bench matrix) is blocked on
+  this fix landing; drift-guard CI will go green as soon as t27 master
+  contains the build.rs downgrade.
+- Anchor: phi^2 + phi^-2 = 3.
+
+## Wave Loop 417 — hygiene, reland W415/W416, and next-variant gate (Closes #1350)
+
+- Branch: `wave-loop-417`
+- Issue: #1350
+- PR: #1354
+- Report: `docs/reports/WAVE_LOOP_417_REPORT.md`
+- Evidence: `docs/reports/FPGA_LOOP_EVIDENCE_W417_2026-07-04.md`
+- Cooperation W418: `docs/reports/FPGA_LOOP_COOPERATION_W418_2026-07-04.md`
+
+### What landed
+- Rebased `wave-loop-415` onto current master; opened replacement PR #1351 and closed dirty PR #1346.
+- Rebased `wave-loop-416` onto current master; opened and merged PR #1352 with corrected `Closes #1349` link.
+- Closed superseded PR #1351 after its commits reached `master` via PR #1352.
+- Closed stale wave-loop PRs #1315, #1317, #1322, #1324, #1330 and issues #1313, #1316, #1318, #1323, #1325.
+- Created real tracking issues #1349 (W416), #1350 (W417), and #1353 (W418).
+- Updated `docs/BRANCHING_MODEL.md` to master-first Strategy P.
+- Allowlisted `conformance/vectors/CROSSWALK_sw_hw.md` in `docs/.legacy-non-english-docs` to unblock the `fpga-smoke` / `t27c` language-policy check while the file awaits translation.
+- Merged PR #1354 (wave-loop-417 → master).
+
+### Not done (blocked on hardware)
+- Real P12 CCLK capture for `OSCFSEL=6/7` — P12 unwired, DLC10 cable missing.
+- Real relay cold-POR gate — no relay board / USB power switch available.
+
+---
+
+## Wave Loop 416 — PVT-envelope CLI, VCD parser coverage, OSCFSEL transaction theorems (Closes #1349)
+
+- Branch: `wave-loop-416`
+- Issue: #1349
+- PR: #1352
+- Report: `docs/reports/WAVE_LOOP_416_REPORT.md`
+- Evidence: `docs/reports/FPGA_LOOP_EVIDENCE_W416_2026-07-04.md`
+- Cooperation W417: `docs/reports/FPGA_LOOP_COOPERATION_W417_2026-07-04.md`
+
+### What landed (Variant C — bench still blocked)
+- `cli/tri/src/fpga.rs`
+  - New `tri fpga pvt-envelope --pvt-context <ctx.json>` command prints the
+    PVT-derated N25Q128_3V `t_CL`/`t_CH` bound, margin over the nominal 6 ns
+    bound, and an envelope-validity warning for out-of-range contexts.
+  - VCD parser hardened for escaped identifiers with embedded spaces,
+    scalar `x`/`z`/`X`/`Z` transitions, and hex bus literals (`hFF !`).
+- `proofs/lean4/Trinity/TernaryFPGABoot.lean`
+  - PVT derating monotonicity lemmas: temperature monotone, voltage antitone,
+    process-corner ordering `ff ≤ tt ≤ ss`.
+  - OSCFSEL 0..7 `measured_transaction_ok` theorems linking each nominal
+    measured-CCLK rate to `transaction_satisfies_flash_spec`.
+- `fpga/HARDWARE_SSOT.md`
+  - Documented `tri fpga pvt-envelope` and the W416 VCD parser coverage.
+  - Updated the per-OSCFSEL transaction section to reference the new
+    transaction theorems.
+
+### Not done (blocked on hardware)
+- Real P12 CCLK capture for `OSCFSEL=6/7` — P12 unwired, DLC10 cable missing.
+- Real relay cold-POR gate — no relay board / USB power switch available.
+
+### Verification
+- `cargo test -p tri fpga::tests`: 38/38 PASS.
+- `lake build Trinity.TernaryFPGABoot`: PASS (2967 jobs).
+- Full repo sweep (`/Users/playra/t27/scripts/tri test`): parse/typecheck/GF16/gen-Zig/gen-Rust/gen-Verilog/seal/C/fixed-point PASS; gen-Verilog yosys smoke has 16 pre-existing failures from weak point #1245 (not introduced by W416).
+
+---
+
+# NOW — Wave Loop 415 close-out / Wave Loop 416 setup (2026-07-01)
+
+## Wave Loop 415 — PVT-aware CCLK validation + VCD robustness + OSCFSEL theorem library (Closes #1343)
+
+- Branch: `wave-loop-415`
+- Issue: #1343
+- PR: #1351 (relayed via clean rebase after #1346 became dirty)
+- Report: `docs/reports/WAVE_LOOP_415_REPORT.md`
+- Evidence: `docs/reports/FPGA_LOOP_EVIDENCE_W415_2026-07-01.md`
+- Cooperation W416: `docs/reports/FPGA_LOOP_COOPERATION_W416_2026-07-01.md`
+
+### What landed (Variant C — bench still blocked)
+- `cli/tri/src/fpga.rs`
+  - `--pvt-context <ctx.json>` added to `tri fpga measure-cclk --validate` and
+    `tri fpga measured-to-lean`.
+  - PVT-aware validation uses temperature/voltage/process-corner derating
+    (`0.02 ns/degC`, `0.005 ns/mV`, `0/2/4 ns` for ff/tt/ss) instead of the flat
+    6 ns or 12 ns placeholders.
+  - Generated Lean theorems link through `measured_cclk_with_pvt_implies_transaction_ok`
+    and `measured_cclk_from_raw_ns_with_pvt_implies_transaction_ok`.
+  - VCD parser hardened:
+    - multi-line `$var` declarations;
+    - mixed scalar / multi-bit bus dumps with targeted signal selection;
+    - duplicate transitions are ignored;
+    - `$dumpoff`/`$dumpon` regions are skipped.
+- `proofs/lean4/Trinity/TernaryFPGABoot.lean`
+  - Added OSCFSEL 0..7 measured-CCLK theorem library:
+    - nominal flash-spec theorems (`measured_cclk_satisfies_flash_spec`);
+    - worst-case PVT theorems (`measured_cclk_with_pvt_satisfies_flash_spec`,
+      85 degC, 900 mV, ss corner).
+  - All 16 theorems build with `decide`.
+- `fpga/HARDWARE_SSOT.md`
+  - Section 3.6.12 updated with `--pvt-context` JSON example and usage for
+    `measure-cclk` and `measured-to-lean`.
+
+### Not done (blocked on hardware)
+- Real P12 CCLK capture for `OSCFSEL=6/7` — P12 unwired, DLC10 cable missing.
+- Real relay cold-POR gate — no relay board / USB power switch available.
+
+### Verification
+- `cargo test -p tri fpga::tests`: 32/32 PASS.
+- `lake build Trinity.TernaryFPGABoot`: PASS (2967 jobs).
+- Full repo sweep: pending `./scripts/tri test` after NOW.md is clean.
+
+---
+
+# NOW — Wave Loop 418 setup
+
+## Wave Loop 418 — choose next variant after W417 land (Issue #1350)
+
+- Branch: `wave-loop-418` (to create after W417 merge)
+- Issue: #1350
+- Plan: `.claude/plans/wave-loop-418.md` (to create)
+- Report: `docs/reports/WAVE_LOOP_418_REPORT.md` (to create)
+- Cooperation W419: `docs/reports/FPGA_LOOP_COOPERATION_W419_2026-07-04.md` (to create)
+
+### Candidate variants
+- Variant A: resume physical CCLK capture once P12 is wired and the analyzer / DLC10 cable is available.
+- Variant B: implement real `--relay-port` backend once a relay board or USB power switch is available.
+- Variant C: further formal tooling if the bench remains blocked — see cooperation file for details.
+
+---
+
+# NOW — Wave Loop 414 close-out
+
+## Wave Loop 414 — PVT envelope + multi-bit/real VCD + `--validate` (Closes #1342)
+
+- Branch: `wave-loop-414`
+- Issue: #1342
+- PR: #1344
+- Report: `docs/reports/WAVE_LOOP_414_REPORT.md`
+- Evidence: `docs/reports/FPGA_LOOP_EVIDENCE_W414_2026-07-01.md`
+- Cooperation W415: `docs/reports/FPGA_LOOP_COOPERATION_W415_2026-07-01.md`
+
+### What landed (Variant C — bench still blocked)
+- `cli/tri/src/fpga.rs`
+  - `--validate` rejects out-of-spec captures before theorem generation.
+  - VCD parser extended to scalar nets, multi-bit logic buses (`--vcd-bit`), and real-valued nets (`--vcd-threshold-v`).
+  - CSV/VCD import paths for `measured-to-lean --raw-ns --standalone`.
+- `proofs/lean4/Trinity/TernaryFPGABoot.lean`
+  - PVT-aware timing predicates and implication theorems.
+  - Worst-case envelope: 85 degC, 900 mV, ss corner -> 13 ns derated t_CL/t_CH.
+- `fpga/HARDWARE_SSOT.md`
+  - PVT envelope documented in section 3.6.12.
+
+---
+
+# NOW — GF16-paper honesty fix (Closes #1341)
+
+## Honesty — GF16 paper: FPGA synthesis instead of "verified on silicon", shuttle TTSKY26b (Closes #1341)
+
+- Branch: `fix/gf16-paper-honesty-silicon-shuttle`
+- Issue: #1341
+- Files: `docs/arxiv-submission/trinity-gf16.tex`, `docs/arxiv-trinity-gf16-draft.md`
+
+### What landed
+- Abstract: "4x4 matmul verified on silicon, 35/35 RTL tests" -> "verified in FPGA synthesis and RTL simulation, 35/35 tests" (encoding != compute != FPGA; sim/synth != ASIC silicon).
+- Shuttle `TTSKY26a (May 2026)` -> `TTSKY26b TT4913 Gamma` per SSOT `conformance/FORMAT-SPEC-001.json` (`frozen_silicon_anchor.tapeout`); added "silicon not yet returned (expected late 2026), no on-chip measurement claimed" (TinyTapeout chips TTSKY26a/b return late 2026).
+- "actual hardware runs" -> "actual FPGA hardware runs (Artix-7 XC7A100T), not ASIC silicon".
+- Header + `\label` section 5 ASIC Path: TTSKY26a -> TTSKY26b TT4913 Gamma.
+
+### Not touched
+- Figures 323 MHz / 40350 LUT / 64 DSP48E1 / 35/35 / 12.8-41.2 GOPS (FPGA runs), spec 1/6/9 bias=31, phi-anchor.
+
+### Context
+- Linked to arXiv catalog article erratum track 2606.09686 (84->83, canonical `ERRATA_2026-06-14.md`).


### PR DESCRIPTION
PR #1710's NOW.md helper truncated `docs/NOW.md` from ~900 lines to 13 (a `open(w)`-before-read bug). This restores the full log from `11cfffcca` with the tuple-return entry kept on top (913 lines). No other change.

Closes #1713