### PR TITLE
test(bitnet): fix stale sequencer_idle_arms_on_start assertion

### DIFF
--- a/bootstrap/tests/bitnet_pipeline.rs
+++ b/bootstrap/tests/bitnet_pipeline.rs
@@ -140,7 +140,10 @@ fn sequencer_emits_first_last_chunk_strobes() {
 #[test]
 fn sequencer_idle_arms_on_start() {
     let v = run_subcommand("gen-layer-sequencer", &[]);
-    assert!(v.contains("IDLE: if(start) begin state<=RUN; neuron_id<=0; chunk_id<=0; end"));
+    // IDLE deasserts `done` on entry (wave-36b) and arms the FSM on `start`.
+    assert!(v.contains(
+        "IDLE: begin done<=0; if(start) begin state<=RUN; neuron_id<=0; chunk_id<=0; end end"
+    ));
 }
 
 #[test]

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,3 +1,16 @@
+# NOW — test: fix stale sequencer_idle_arms_on_start assertion (2026-08-05)
+
+Last updated: 2026-08-05
+
+## test: fix stale IDLE assertion in bitnet_pipeline (Closes #1719)
+
+- Branch: `fix/sequencer-idle-test`
+
+### Что легло
+- `sequencer_idle_arms_on_start` was red on master: `gen-layer-sequencer` deasserts `done<=0` on IDLE entry (wave-36b) and emits `IDLE: begin done<=0; if(start) begin state<=RUN; neuron_id<=0; chunk_id<=0; end end`, but the test still asserted the pre-wave-36b string. Updated the expectation to the current correct output (test-only; no codegen change, no reseal). `bitnet_pipeline` now 20/20.
+
+---
+
 # NOW — codegen: gen-verilog tuple lowering (concat + destructuring) (2026-08-05)
 
 Last updated: 2026-08-05


### PR DESCRIPTION
`bitnet_pipeline::sequencer_idle_arms_on_start` was **red on `origin/master`** (reproduced on a clean build — see #1719).

`gen-layer-sequencer` deasserts `done<=0` on IDLE entry (wave-36b), emitting:
```
IDLE: begin done<=0; if(start) begin state<=RUN; neuron_id<=0; chunk_id<=0; end end
```
but the test still asserted the pre-wave-36b string. The generator output is correct; the test expectation was stale.

Test-only change (no codegen change, no reseal). `bitnet_pipeline` goes **19/20 → 20/20**.

Closes #1719

🤖 Generated with [Claude Code](https://claude.com/claude-code)