### PR TITLE
ci(fpga): fix fpga-build flags that broke fpga-synthesis on every PR

### DIFF
--- a/.github/workflows/fpga-build.yml
+++ b/.github/workflows/fpga-build.yml
@@ -274,7 +274,7 @@ jobs:
         run: cargo build --release -p t27c
 
       - name: FPGA synthesis (Arty A7-100T, minimal profile)
-        run: ./target/release/t27c fpga-build --docker false --synth-only --board arty-a7 --profile minimal
+        run: ./target/release/t27c fpga-build --docker false --synth-only --minimal
 
       - name: Arty A7 synthesis check
         run: |
@@ -360,7 +360,7 @@ jobs:
       
       - name: Generate bitstream
         run: |
-          ./target/release/t27c fpga-build --board qmtech-a100t --profile minimal
+          ./target/release/t27c fpga-build --minimal
           ls -la build/fpga/
       
       - name: Upload bitstream artifact

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,3 +1,16 @@
+# NOW — ci: fix fpga-build flags in fpga-synthesis jobs (unblock red CI) (2026-08-05)
+
+Last updated: 2026-08-05
+
+## ci: fpga-build passes flags the subcommand rejects (Closes #1723)
+
+- Branch: `fix/ci-fpga-build-flags`
+
+### Что легло
+- `fpga-build.yml` invoked `t27c fpga-build ... --board <X> --profile minimal`, but the subcommand only defines `--device`/`--minimal` → `error: unexpected argument '--board'` (exit 2), making `fpga-synthesis-arty` red on **every** PR (it merged red on #1710/#1716/#1718/#1725/#1728). Replaced both bad invocations with `--minimal` (the `--device` default `xc7a100tcsg324-1` is already the Arty A7-100T part and matches the job's own chipdb placeholder; both jobs are synth/smoke where the exact part is immaterial). Verified: fixed command parses and proceeds to Verilog generation; old `--board` form still errors. Workflow-only change (no compiler, no reseal). Board-level UX (`--board`/`--profile`) could be added CLI-side later if desired.
+
+---
+
 # NOW — codegen: gen-c tuple lowering — closes tuple workstream across all backends (2026-08-05)
 
 Last updated: 2026-08-05


### PR DESCRIPTION
`fpga-synthesis-arty` (and the qmtech bitstream step) have been **red on every PR** because `fpga-build.yml` passes flags the `fpga-build` subcommand doesn't define:
```
./target/release/t27c fpga-build --docker false --synth-only --board arty-a7 --profile minimal
# error: unexpected argument '--board' found  (exit 2)
```
The subcommand's clap spec has `--device <String>` (default `xc7a100tcsg324-1`) and `--minimal` (bool) — no `--board`/`--profile`. It merged red on #1710/#1716/#1718/#1725/#1728.

### Fix
Both invocations → `--minimal`. These are synth/smoke jobs where the exact device part is immaterial; the `--device` default `xc7a100tcsg324-1` is already the Arty A7-100T part and matches the job's own `~/fpga/chipdb/xc7a100tcsg324-1.bin` placeholder.

Verified locally: the fixed command parses and proceeds to Verilog generation; the old `--board` form still errors (root cause). Workflow-only change; no compiler change, no reseal.

Board-level UX (`--board`/`--profile` as first-class flags) could be added CLI-side later if that abstraction is wanted.

Closes #1723

🤖 Generated with [Claude Code](https://claude.com/claude-code)