### PR TITLE
test(bitnet): elaborate the assembled engine bundle under iverilog

### DIFF
--- a/bootstrap/tests/bitnet_elaborate.rs
+++ b/bootstrap/tests/bitnet_elaborate.rs
@@ -1,0 +1,106 @@
+// ============================================================================
+// Integration test: the assembled BitNet engine bundle must ELABORATE under
+// Icarus Verilog, not merely pass string-assertions on the emitted text.
+//
+// Motivation: the BitNet HLS modules were validated only by substring checks on
+// the generated Verilog. Nothing elaborated the *assembled* engine, so a missing
+// module, a port/width mismatch, or a syntax error would stay invisible until
+// hardware -- the same structural blind spot that let the stale `bitnet_top`
+// asserts (#1726) sit red unnoticed. This test establishes that missing
+// independent instrument (#1730).
+//
+// It shells out to the built `t27c` via CARGO_BIN_EXE_t27c, writes into a unique
+// directory under std::env::temp_dir() (no tempfile crate on Cargo.toml), and
+// skips gracefully when `iverilog` is not on PATH.
+// ============================================================================
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn t27c() -> &'static str {
+    env!("CARGO_BIN_EXE_t27c")
+}
+
+fn scratch_dir(label: &str) -> PathBuf {
+    let dir = env::temp_dir().join(format!("t27_bitnet_elab_{}_{}", std::process::id(), label));
+    if dir.exists() {
+        let _ = fs::remove_dir_all(&dir);
+    }
+    dir
+}
+
+fn iverilog_available() -> bool {
+    Command::new("iverilog")
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+#[test]
+fn bitnet_engine_bundle_elaborates_under_iverilog() {
+    if !iverilog_available() {
+        eprintln!("SKIP: iverilog not on PATH; skipping BitNet engine elaboration test");
+        return;
+    }
+
+    let dir = scratch_dir("elab");
+    fs::create_dir_all(&dir).expect("create scratch dir");
+
+    // 1. Emit the full HLS bundle (9 RTL modules + SVA + manifest).
+    let bundle_ok = Command::new(t27c())
+        .args(["gen-bitnet-bundle", "--output-dir", dir.to_str().unwrap()])
+        .status()
+        .expect("failed to invoke gen-bitnet-bundle")
+        .success();
+    assert!(bundle_ok, "gen-bitnet-bundle failed");
+
+    // 2. The bundle instantiates `trit27_dot_product` but does NOT include the
+    //    trit stdlib that defines it (#1730), so emit the stdlib alongside it.
+    let stdlib = Command::new(t27c())
+        .arg("gen-trit-stdlib")
+        .output()
+        .expect("failed to invoke gen-trit-stdlib");
+    assert!(stdlib.status.success(), "gen-trit-stdlib failed");
+    fs::write(dir.join("trit_stdlib.sv"), &stdlib.stdout).expect("write trit_stdlib.sv");
+
+    // 3. Collect every RTL module: all .sv except the SVA property file, which
+    //    is not iverilog-parseable (SystemVerilog assertions).
+    let mut rtl: Vec<PathBuf> = fs::read_dir(&dir)
+        .expect("read scratch dir")
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.extension().map_or(false, |x| x == "sv"))
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .map_or(false, |n| !n.starts_with("behavior_sva"))
+        })
+        .collect();
+    rtl.sort();
+    assert!(!rtl.is_empty(), "no RTL .sv emitted into bundle");
+
+    // 4. Elaborate rooted at the engine top. `-t null` runs the full front-end
+    //    (parse + elaborate) with no code-generation backend -- a pure
+    //    structural check that catches missing modules and port mismatches.
+    let out = Command::new("iverilog")
+        .args(["-g2012", "-t", "null", "-s", "bitnet_engine_top"])
+        .args(&rtl)
+        .output()
+        .expect("failed to invoke iverilog");
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+
+    let _ = fs::remove_dir_all(&dir);
+
+    assert!(
+        out.status.success(),
+        "iverilog elaboration of bitnet_engine_top failed:\n{}",
+        stderr
+    );
+    assert!(
+        !stderr.to_lowercase().contains("error"),
+        "iverilog reported errors during elaboration:\n{}",
+        stderr
+    );
+}

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,3 +1,16 @@
+# NOW — test: iverilog elaboration instrument for the assembled BitNet engine (2026-08-05)
+
+Last updated: 2026-08-05
+
+## test: elaborate the assembled BitNet engine bundle under iverilog (Closes #1730)
+
+- Branch: `feat/bitnet-elaborate-test`
+
+### Что легло
+- The BitNet HLS modules were validated only by substring asserts on emitted Verilog; **nothing elaborated the assembled engine** — the same structural blind spot that let the stale `bitnet_top` asserts (#1726) sit red unnoticed. New integration test `tests/bitnet_elaborate.rs` generates `gen-bitnet-bundle` + `gen-trit-stdlib` and runs `iverilog -g2012 -t null -s bitnet_engine_top` over all RTL (excl. the SVA property file), asserting clean elaboration; skips gracefully when iverilog is absent. Proven meaningful — during bring-up the same instrument caught `Unknown module type: trit27_dot_product` (the bundle omits its trit-stdlib dependency; making the bundle self-contained is a follow-up on #1730). Test-only; no compiler change, no reseal. Establishes the observability needed before any engine-top datapath change (e.g. the input≡weight aliasing at `bitnet_top.rs:217`).
+
+---
+
 # NOW — ci: fix fpga-build flags in fpga-synthesis jobs (unblock red CI) (2026-08-05)
 
 Last updated: 2026-08-05


### PR DESCRIPTION
The BitNet HLS modules were validated only by substring assertions on the emitted Verilog. **Nothing elaborated the assembled engine**, so structural breakage (a missing module, a port/width mismatch, a syntax error) stayed invisible until hardware — the same blind spot that let the stale `bitnet_top` asserts (#1726) sit red unnoticed.

Closes #1730.

### What this adds
`tests/bitnet_elaborate.rs` — an integration test that:
1. Emits the full bundle (`gen-bitnet-bundle --output-dir`).
2. Emits the trit stdlib (`gen-trit-stdlib`) alongside it — the bundle instantiates `trit27_dot_product` but does **not** include the stdlib that defines it (a real gap; self-containing the bundle is a follow-up on #1730 since it shifts the index-based bundle tests).
3. Runs `iverilog -g2012 -t null -s bitnet_engine_top` over all RTL modules (excluding the SVA property file, which isn't iverilog-parseable) and asserts clean elaboration.
4. Skips gracefully when `iverilog` is not on PATH.

### Why it's meaningful (not a no-op)
During bring-up this exact instrument caught `Unknown module type: trit27_dot_product` — proving it detects real structural defects. It establishes the observability needed **before** any engine-top datapath change (e.g. the input≡weight aliasing at `bitnet_top.rs:217`, where both compute operands currently read the same weight BRAM).

Test-only; no compiler change, no reseal. Full local run green.

Pre-existing unrelated `bitnet_top::{top_busy..., top_mem_outputs_tied_off}` reds (#1726) are untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)