### PR TITLE
fix(trit): ternary MAC adder_tree_27 overflow — wrong dot product on dense vectors

### DIFF
--- a/bootstrap/src/trit_stdlib.rs
+++ b/bootstrap/src/trit_stdlib.rs
@@ -394,8 +394,10 @@ module adder_tree_27 (
         end
     endgenerate
 
-    // Level 2: 3 groups of 3, range [-9, +9] -> signed [3:0].
-    wire signed [3:0] l2 [0:2];
+    // Level 2: 3 groups of 3, range [-9, +9] -> signed [4:0].
+    // (signed [3:0] holds only [-8, +7]: a group of 9 same-sign trits sums to
+    //  +/-9 and overflowed, e.g. all-P dot product read -21 instead of +27.)
+    wire signed [4:0] l2 [0:2];
     assign l2[0] = l1[0] + l1[1] + l1[2];
     assign l2[1] = l1[3] + l1[4] + l1[5];
     assign l2[2] = l1[6] + l1[7] + l1[8];

--- a/bootstrap/tests/bitnet_compute_mac.rs
+++ b/bootstrap/tests/bitnet_compute_mac.rs
@@ -1,0 +1,140 @@
+// ============================================================================
+// Functional testbench for the BitNet ternary MAC compute stage.
+//
+// The BitNet HLS modules were validated only by substring asserts on emitted
+// Verilog + (since #1730) a structural elaboration check. Neither proves the
+// datapath COMPUTES the right numbers. This golden-vector testbench drives
+// `pipeline_stage2_compute` (which wraps `trit27_dot_product`) with known trit
+// chunks and checks the accumulated dot product via iverilog + vvp.
+//
+// Encoding (trit_stdlib source of truth): 2'b00 = -1, 2'b01 = 0, 2'b10 = +1;
+// trit i occupies bits [2i+1:2i] of the 54-bit (27-trit) chunk.
+//
+// This test caught a real bug: `adder_tree_27` level-2 used `signed [3:0]`
+// (range [-8, +7]) while a group of 9 same-sign trits sums to +/-9, so an
+// all-+1 dot product read -21 instead of +27. Fixed by widening l2 to
+// `signed [4:0]`.
+//
+// Skips gracefully when `iverilog`/`vvp` are not on PATH.
+// ============================================================================
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn t27c() -> &'static str {
+    env!("CARGO_BIN_EXE_t27c")
+}
+
+fn scratch_dir(label: &str) -> PathBuf {
+    let dir = env::temp_dir().join(format!("t27_bitnet_mac_{}_{}", std::process::id(), label));
+    if dir.exists() {
+        let _ = fs::remove_dir_all(&dir);
+    }
+    dir
+}
+
+fn tool_available(tool: &str) -> bool {
+    Command::new(tool)
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+// Golden-vector testbench. Uses Verilog replication for unambiguous vectors:
+//   {27{2'b10}} = all +1,  {27{2'b00}} = all -1,  {27{2'b01}} = all 0.
+const TESTBENCH: &str = r#"`timescale 1ns/1ps
+module tb;
+  reg clk=0, rst_n=0, valid_in=0, first_chunk=0, last_chunk=0;
+  reg [53:0] input_chunk=0, weight_chunk=0;
+  wire valid_out, result_final;
+  wire signed [15:0] result;
+  integer fails=0;
+  pipeline_stage2_compute dut(.clk(clk), .rst_n(rst_n), .valid_in(valid_in),
+    .input_chunk(input_chunk), .weight_chunk(weight_chunk),
+    .first_chunk(first_chunk), .last_chunk(last_chunk),
+    .valid_out(valid_out), .result(result), .result_final(result_final));
+  always #5 clk = ~clk;
+  task drive(input [53:0] iv, input [53:0] wv, input f, input l);
+    begin
+      @(negedge clk); input_chunk=iv; weight_chunk=wv; valid_in=1; first_chunk=f; last_chunk=l;
+      @(posedge clk); @(negedge clk); valid_in=0;
+    end
+  endtask
+  task check(input signed [15:0] got, input signed [15:0] exp, input [255:0] name);
+    begin
+      if (got !== exp) begin fails=fails+1; $display("FAIL %0s got=%0d exp=%0d", name, got, exp); end
+      else $display("PASS %0s = %0d", name, got);
+    end
+  endtask
+  initial begin
+    rst_n=0; repeat(2) @(posedge clk); rst_n=1;
+    // Single-chunk dot products.
+    drive({27{2'b10}}, {27{2'b10}}, 1, 1); check(result, 16'sd27, "allP_x_allP");   // 27*(+1*+1)
+    drive({27{2'b10}}, {27{2'b00}}, 1, 1); check(result, -16'sd27, "allP_x_allN");  // 27*(+1*-1)
+    drive({27{2'b00}}, {27{2'b00}}, 1, 1); check(result, 16'sd27, "allN_x_allN");   // 27*(-1*-1)
+    drive({27{2'b01}}, {27{2'b10}}, 1, 1); check(result, 16'sd0,  "allZ");          // 0
+    drive({{26{2'b01}}, 2'b10}, {27{2'b10}}, 1, 1); check(result, 16'sd1, "oneP");  // single +1
+    // Multi-chunk accumulation: +27 then -27 = 0.
+    drive({27{2'b10}}, {27{2'b10}}, 1, 0);
+    drive({27{2'b10}}, {27{2'b00}}, 0, 1); check(result, 16'sd0, "accum_p27_m27");
+    if (fails==0) $display("ALL_PASS"); else $display("FAILED %0d", fails);
+    $finish;
+  end
+endmodule
+"#;
+
+#[test]
+fn bitnet_mac_compute_golden_vectors() {
+    if !tool_available("iverilog") || !tool_available("vvp") {
+        eprintln!("SKIP: iverilog/vvp not on PATH; skipping BitNet MAC functional test");
+        return;
+    }
+
+    let dir = scratch_dir("mac");
+    fs::create_dir_all(&dir).expect("create scratch dir");
+
+    // Emit the compute stage and the trit stdlib it depends on.
+    for (sub, file) in [
+        ("gen-pipeline-stage2", "compute.sv"),
+        ("gen-trit-stdlib", "trit_stdlib.sv"),
+    ] {
+        let out = Command::new(t27c()).arg(sub).output().expect("invoke t27c");
+        assert!(out.status.success(), "{} failed", sub);
+        fs::write(dir.join(file), &out.stdout).unwrap_or_else(|e| panic!("write {}: {}", file, e));
+    }
+    fs::write(dir.join("tb.v"), TESTBENCH).expect("write tb.v");
+
+    // Compile with Icarus and run.
+    let vvp_path = dir.join("sim.vvp");
+    let compile = Command::new("iverilog")
+        .args(["-g2012", "-o", vvp_path.to_str().unwrap()])
+        .arg(dir.join("compute.sv"))
+        .arg(dir.join("trit_stdlib.sv"))
+        .arg(dir.join("tb.v"))
+        .output()
+        .expect("invoke iverilog");
+    assert!(
+        compile.status.success(),
+        "iverilog compile failed:\n{}",
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new("vvp").arg(&vvp_path).output().expect("invoke vvp");
+    let stdout = String::from_utf8_lossy(&run.stdout).into_owned();
+
+    let _ = fs::remove_dir_all(&dir);
+
+    assert!(
+        stdout.contains("ALL_PASS"),
+        "MAC golden-vector check did not all pass:\n{}",
+        stdout
+    );
+    assert!(
+        !stdout.contains("FAIL"),
+        "MAC golden-vector check reported a failure:\n{}",
+        stdout
+    );
+}

--- a/bootstrap/tests/trit_stdlib.rs
+++ b/bootstrap/tests/trit_stdlib.rs
@@ -395,8 +395,9 @@ fn adder_tree_27_has_three_reduction_levels() {
         "adder_tree_27 must have a 9-entry signed [2:0] level1 array"
     );
     assert!(
-        body.contains("wire signed [3:0] l2 [0:2];"),
-        "adder_tree_27 must have a 3-entry signed [3:0] level2 array"
+        body.contains("wire signed [4:0] l2 [0:2];"),
+        "adder_tree_27 level2 array must be signed [4:0] to hold [-9, +9] \
+         without overflow (signed [3:0] truncated +/-9 -> wrong dot product)"
     );
     // Three explicit level-2 reductions and one final level-3 sum.
     assert!(body.contains("assign l2[0] = l1[0] + l1[1] + l1[2];"));

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,3 +1,16 @@
+# NOW — bug: fix ternary MAC adder_tree_27 overflow (wrong dot product) (2026-08-05)
+
+Last updated: 2026-08-05
+
+## bug: adder_tree_27 level-2 overflow + functional MAC testbench (Closes #1732)
+
+- Branch: `fix/mac-adder-tree-overflow`
+
+### Что легло
+- **Model-critical correctness bug in the ternary MAC core.** `adder_tree_27` (gen-trit-stdlib; wrapped by `trit27_dot_product`/`pipeline_stage2_compute`) declared level-2 as `signed [3:0]` (range [-8,+7]), but each `l2[j]` sums three `l1 in [-3,+3]` → range [-9,+9]. All-+1 dot product read **-21 instead of +27** (each group-of-9 = +9 wrapped to -7). Fixed by widening `l2` to `signed [4:0]`. Found by a NEW golden-vector functional testbench `tests/bitnet_compute_mac.rs` (iverilog+vvp): all-P/all-N/all-Z/single-trit/multi-chunk accumulation now match; skips w/o iverilog. Updated the unit test that had codified the buggy `signed [3:0]` width. trit_stdlib.rs is NOT under the FROZEN_HASH seal (only compiler.rs) → no reseal. Full suite green (excl. pre-existing #1726). This is the functional instrument that makes the engine-top datapath fix (input≡weight aliasing) provable next.
+
+---
+
 # NOW — test: iverilog elaboration instrument for the assembled BitNet engine (2026-08-05)
 
 Last updated: 2026-08-05


### PR DESCRIPTION
**Model-critical correctness bug in the ternary MAC core**, found by a new functional testbench.

### Bug
`adder_tree_27` (from `gen-trit-stdlib`, wrapped by `trit27_dot_product` → `pipeline_stage2_compute`) declared level-2 as `wire signed [3:0] l2 [0:2];` (range **[-8, +7]**). But each `l2[j] = l1[3j] + l1[3j+1] + l1[3j+2]` with `l1 ∈ [-3, +3]` has range **[-9, +9]** — so a group of 9 same-sign trits (sum ±9, or even ±8) overflows.

Symptom: `input = {27{+1}}, weight = {27{+1}}` → expected dot product **+27**, actual **−21** (each level-2 group of 9 wrapped +9 → −7; 3 × −7 = −21). Single-trit / sparse cases were correct, so the existing substring asserts never caught it.

### Fix
Widen `l2` to `signed [4:0]` (range [−16, +15]). Level-1 (`signed [2:0]` holds [−3,+3]) and level-3 (`signed [5:0]` holds [−27,+27]) were already correct.

### Verification
New golden-vector functional testbench `tests/bitnet_compute_mac.rs` (iverilog + vvp) drives `pipeline_stage2_compute` with known trit chunks:
- `allP×allP = +27`, `allP×allN = −27`, `allN×allN = +27`, `allZ = 0`, single-trit `= +1`, multi-chunk `+27` then `−27` accumulates to `0`.
All pass after the fix; `−21`/`+21` before it. Skips gracefully without iverilog. The unit test that had codified the buggy `signed [3:0]` width is updated.

`trit_stdlib.rs` is not under the FROZEN_HASH seal (only `compiler.rs`), so no reseal. Full suite green apart from the pre-existing, unrelated `bitnet_top` reds (#1726).

This is the functional instrument that makes the engine-top datapath fix (input≡weight aliasing at `bitnet_top.rs:217`) provable, per the observability-before-mutation discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1732
