### PR TITLE
test(bitnet): harden MAC coverage (overflow boundary + randomized reference sweep)

### DIFF
--- a/bootstrap/tests/bitnet_compute_mac.rs
+++ b/bootstrap/tests/bitnet_compute_mac.rs
@@ -3,17 +3,19 @@
 //
 // The BitNet HLS modules were validated only by substring asserts on emitted
 // Verilog + (since #1730) a structural elaboration check. Neither proves the
-// datapath COMPUTES the right numbers. This golden-vector testbench drives
-// `pipeline_stage2_compute` (which wraps `trit27_dot_product`) with known trit
-// chunks and checks the accumulated dot product via iverilog + vvp.
+// datapath COMPUTES the right numbers. This testbench drives
+// `pipeline_stage2_compute` (which wraps `trit27_dot_product`) with known and
+// randomized trit chunks and checks the accumulated dot product via
+// iverilog + vvp.
 //
 // Encoding (trit_stdlib source of truth): 2'b00 = -1, 2'b01 = 0, 2'b10 = +1;
 // trit i occupies bits [2i+1:2i] of the 54-bit (27-trit) chunk.
 //
-// This test caught a real bug: `adder_tree_27` level-2 used `signed [3:0]`
-// (range [-8, +7]) while a group of 9 same-sign trits sums to +/-9, so an
-// all-+1 dot product read -21 instead of +27. Fixed by widening l2 to
-// `signed [4:0]`.
+// This test found a real bug (#1733): `adder_tree_27` level-2 used `signed
+// [3:0]` (range [-8, +7]) while a group of 9 same-sign trits sums to +/-9, so
+// an all-+1 dot product read -21 instead of +27. It now also pins the exact
+// overflow boundary (a level-2 group summing to +/-8) and cross-checks 200
+// randomized vectors against an independent reference dot product.
 //
 // Skips gracefully when `iverilog`/`vvp` are not on PATH.
 // ============================================================================
@@ -43,44 +45,73 @@ fn tool_available(tool: &str) -> bool {
         .unwrap_or(false)
 }
 
-// Golden-vector testbench. Uses Verilog replication for unambiguous vectors:
+// Golden + boundary + randomized testbench.
 //   {27{2'b10}} = all +1,  {27{2'b00}} = all -1,  {27{2'b01}} = all 0.
+// `ref_dot` is an independent reference (decode + multiply-accumulate) that does
+// NOT use the DUT's reduction tree, so a discrepancy means a real DUT bug.
 const TESTBENCH: &str = r#"`timescale 1ns/1ps
 module tb;
   reg clk=0, rst_n=0, valid_in=0, first_chunk=0, last_chunk=0;
   reg [53:0] input_chunk=0, weight_chunk=0;
   wire valid_out, result_final;
   wire signed [15:0] result;
-  integer fails=0;
-  pipeline_stage2_compute dut(.clk(clk), .rst_n(rst_n), .valid_in(valid_in),
-    .input_chunk(input_chunk), .weight_chunk(weight_chunk),
-    .first_chunk(first_chunk), .last_chunk(last_chunk),
-    .valid_out(valid_out), .result(result), .result_final(result_final));
+  integer fails=0, k, iter;
+  reg [53:0] ra, rb;
+  reg signed [15:0] expected;
+  pipeline_stage2_compute dut(.clk(clk),.rst_n(rst_n),.valid_in(valid_in),
+    .input_chunk(input_chunk),.weight_chunk(weight_chunk),
+    .first_chunk(first_chunk),.last_chunk(last_chunk),
+    .valid_out(valid_out),.result(result),.result_final(result_final));
   always #5 clk = ~clk;
-  task drive(input [53:0] iv, input [53:0] wv, input f, input l);
-    begin
-      @(negedge clk); input_chunk=iv; weight_chunk=wv; valid_in=1; first_chunk=f; last_chunk=l;
-      @(posedge clk); @(negedge clk); valid_in=0;
-    end
+  // Map a random integer to a valid trit encoding {Z=01, P=10, N=00}.
+  function [1:0] tmap(input integer x); integer m; begin
+    m = x % 3; if (m < 0) m = m + 3;
+    tmap = (m==0)?2'b01:(m==1)?2'b10:2'b00; end
+  endfunction
+  // Independent reference dot product (does not use the DUT adder tree).
+  function signed [15:0] ref_dot(input [53:0] a, input [53:0] b);
+    integer j, va, vb, acc; reg [1:0] ta, tb; begin
+    acc = 0;
+    for (j=0;j<27;j=j+1) begin
+      ta=a[j*2 +: 2]; tb=b[j*2 +: 2];
+      va=(ta==2'b00)?-1:(ta==2'b10)?1:0;
+      vb=(tb==2'b00)?-1:(tb==2'b10)?1:0;
+      acc=acc+va*vb; end
+    ref_dot=acc; end
+  endfunction
+  task drive(input [53:0] iv, input [53:0] wv, input f, input l); begin
+    @(negedge clk); input_chunk=iv; weight_chunk=wv; valid_in=1; first_chunk=f; last_chunk=l;
+    @(posedge clk); @(negedge clk); valid_in=0; end
   endtask
-  task check(input signed [15:0] got, input signed [15:0] exp, input [255:0] name);
-    begin
-      if (got !== exp) begin fails=fails+1; $display("FAIL %0s got=%0d exp=%0d", name, got, exp); end
-      else $display("PASS %0s = %0d", name, got);
-    end
+  task check(input signed [15:0] got, input signed [15:0] exp, input [255:0] nm); begin
+    if (got!==exp) begin fails=fails+1; $display("FAIL %0s got=%0d exp=%0d",nm,got,exp); end
+    else $display("PASS %0s = %0d",nm,got); end
   endtask
   initial begin
     rst_n=0; repeat(2) @(posedge clk); rst_n=1;
     // Single-chunk dot products.
-    drive({27{2'b10}}, {27{2'b10}}, 1, 1); check(result, 16'sd27, "allP_x_allP");   // 27*(+1*+1)
-    drive({27{2'b10}}, {27{2'b00}}, 1, 1); check(result, -16'sd27, "allP_x_allN");  // 27*(+1*-1)
-    drive({27{2'b00}}, {27{2'b00}}, 1, 1); check(result, 16'sd27, "allN_x_allN");   // 27*(-1*-1)
-    drive({27{2'b01}}, {27{2'b10}}, 1, 1); check(result, 16'sd0,  "allZ");          // 0
-    drive({{26{2'b01}}, 2'b10}, {27{2'b10}}, 1, 1); check(result, 16'sd1, "oneP");  // single +1
+    drive({27{2'b10}},{27{2'b10}},1,1); check(result,16'sd27,"allP_x_allP");
+    drive({27{2'b10}},{27{2'b00}},1,1); check(result,-16'sd27,"allP_x_allN");
+    drive({27{2'b00}},{27{2'b00}},1,1); check(result,16'sd27,"allN_x_allN");
+    drive({27{2'b01}},{27{2'b10}},1,1); check(result,16'sd0,"allZ");
+    drive({{26{2'b01}},2'b10},{27{2'b10}},1,1); check(result,16'sd1,"oneP");
+    // Overflow boundary: a level-2 group summing to exactly +/-8 (the value the
+    // old signed [3:0] wrapped). 8 P (or N) in trits 0..7, the rest Z.
+    drive({19{2'b01}} << 16 | {8{2'b10}},{27{2'b10}},1,1); check(result,16'sd8,"eightP_boundary");
+    drive({19{2'b01}} << 16 | {8{2'b00}},{27{2'b10}},1,1); check(result,-16'sd8,"eightN_boundary");
     // Multi-chunk accumulation: +27 then -27 = 0.
-    drive({27{2'b10}}, {27{2'b10}}, 1, 0);
-    drive({27{2'b10}}, {27{2'b00}}, 0, 1); check(result, 16'sd0, "accum_p27_m27");
-    if (fails==0) $display("ALL_PASS"); else $display("FAILED %0d", fails);
+    drive({27{2'b10}},{27{2'b10}},1,0);
+    drive({27{2'b10}},{27{2'b00}},0,1); check(result,16'sd0,"accum_p27_m27");
+    // Randomized sweep vs the independent reference (fixed iverilog seed ->
+    // deterministic).
+    for (iter=0; iter<200; iter=iter+1) begin
+      for (k=0;k<27;k=k+1) begin ra[k*2 +: 2]=tmap($random); rb[k*2 +: 2]=tmap($random); end
+      expected=ref_dot(ra,rb);
+      drive(ra,rb,1,1);
+      if (result!==expected) begin fails=fails+1; $display("FAIL rand[%0d] got=%0d exp=%0d",iter,result,expected); end
+    end
+    $display("RAND_DONE 200");
+    if (fails==0) $display("ALL_PASS"); else $display("FAILED %0d",fails);
     $finish;
   end
 endmodule
@@ -128,13 +159,18 @@ fn bitnet_mac_compute_golden_vectors() {
     let _ = fs::remove_dir_all(&dir);
 
     assert!(
+        stdout.contains("RAND_DONE 200"),
+        "randomized sweep did not complete:\n{}",
+        stdout
+    );
+    assert!(
         stdout.contains("ALL_PASS"),
-        "MAC golden-vector check did not all pass:\n{}",
+        "MAC golden/boundary/random check did not all pass:\n{}",
         stdout
     );
     assert!(
         !stdout.contains("FAIL"),
-        "MAC golden-vector check reported a failure:\n{}",
+        "MAC check reported a failure:\n{}",
         stdout
     );
 }

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,3 +1,16 @@
+# NOW — test: harden ternary MAC coverage (boundary + randomized reference sweep) (2026-08-05)
+
+Last updated: 2026-08-05
+
+## test: MAC overflow-boundary + 200-vector randomized reference sweep (Closes #1734)
+
+- Branch: `test/mac-randomized-sweep-work`
+
+### Что легло
+- Follow-up to the MAC overflow fix (#1733). Hardened `tests/bitnet_compute_mac.rs`: (1) overflow-boundary vectors pinning a level-2 group summing to exactly +/-8 (the value the old `signed [3:0]` wrapped); (2) a 200-vector randomized sweep (deterministic iverilog seed) cross-checked against an **independent** in-TB `ref_dot` (decode + multiply-accumulate, not using the DUT reduction tree). All pass → the MAC bug class is dry in the searched space; future arithmetic regressions now caught. Test-only; no compiler/emitter change, no reseal.
+
+---
+
 # NOW — bug: fix ternary MAC adder_tree_27 overflow (wrong dot product) (2026-08-05)
 
 Last updated: 2026-08-05


### PR DESCRIPTION
Follow-up to the ternary MAC overflow fix (#1733). The functional testbench found that bug with 6 golden vectors; this hardens it so the bug class is provably dry and future arithmetic regressions are caught.

Closes #1734

### Added to `tests/bitnet_compute_mac.rs`
1. **Overflow-boundary vectors** — a level-2 group summing to exactly **±8** (8 P / 8 N in trits 0..7, rest Z, dotted with all-P). ±8 is the exact value the old `signed [3:0]` wrapped (it holds only +7), so this pins the fix at its boundary.
2. **Randomized reference sweep** — 200 random valid-trit vector pairs (deterministic iverilog seed), each cross-checked against an **independent** in-testbench `ref_dot` (decode + multiply-accumulate, *not* using the DUT reduction tree). Any discrepancy would mean a real DUT bug.

### Result
All golden + boundary + 200 random vectors pass → no further MAC arithmetic bug in the searched space. Test-only; no compiler/emitter change, no reseal. Skips gracefully without iverilog/vvp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)