### PR TITLE
feat(ternary): spec-first activation quantizer (.t27) for the BitNet layer loop

### DIFF
--- a/.trinity/seals/ternary_ActivationQuantizer.json
+++ b/.trinity/seals/ternary_ActivationQuantizer.json
@@ -1,0 +1,11 @@
+{
+  "gen_hash_c": "sha256:de2e3a755d45d211a3ebef8ef7bf07d073adbe6c556d19c9a76be74aba01a196",
+  "gen_hash_rust": "sha256:3f409bfc09ce6dfb8e86657608bd123c27f53eea410c7eeb26557a80cf7a1e9d",
+  "gen_hash_verilog": "sha256:a791b80deb4adb2e8d8334cb83e15503bb7d819053a5aea65dad8edc81eee85d",
+  "gen_hash_zig": "sha256:10cf4efee5b65e92194c15e9606bb07c809ea6a4de819734b531f7c68c732196",
+  "module": "ActivationQuantizer",
+  "ring": 12,
+  "sealed_at": "2026-08-05T18:16:33Z",
+  "spec_hash": "sha256:a911eccefdb5ddc3cc09c3acc5bdbf0bbb3775c638bc5ef17a54d75d4a774590",
+  "spec_path": "specs/ternary/activation_quantizer.t27"
+}

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,3 +1,16 @@
+# NOW — feat: spec-first ternary activation quantizer (.t27) (2026-08-05)
+
+Last updated: 2026-08-05
+
+## feat: spec-first ternary activation quantizer (Closes #1737)
+
+- Branch: `feat/spec-first-activation-quantizer`
+
+### Что легло
+- First BitNet-relevant datapath primitive on the **spec-first** path (the whole accelerator was hand-written Rust emitters, off-constitution). `specs/ternary/activation_quantizer.t27`: `quantize(v: i16, threshold: i16) -> u8` re-ternarizes a signed accumulator to a packed trit `{N=00,Z=01,P=10}` with a symmetric threshold (`v>+t→P`, `v<-t→N`, else Z). gen-verilog emits a clean signed-compare nested-if function. Verified: `typecheck` 0/0; `icarus-simulate` **7/7** embedded test blocks pass (positive/negative/zero-band, both `v==±t` boundaries→Z, just-over/under→P/N); `seal --save/--verify` all 3 backends hash-MATCH. Provides the activation re-ternarizer the engine needs to chain MAC→quantize→next-layer, and proves the ternary-native spec-first path — a differentiator no competitor (Ternary-NanoCore) has.
+
+---
+
 # NOW — test: harden ternary MAC coverage (boundary + randomized reference sweep) (2026-08-05)
 
 Last updated: 2026-08-05

--- a/specs/ternary/activation_quantizer.t27
+++ b/specs/ternary/activation_quantizer.t27
@@ -1,0 +1,18 @@
+module ActivationQuantizer;
+// Ternary activation quantizer for the BitNet engine: re-ternarize a signed
+// accumulator to a packed trit {N=0b00, Z=0b01, P=0b10} using a symmetric
+// threshold. v > +t -> P, v < -t -> N, else Z.
+pub fn quantize(v: i16, threshold: i16) -> u8 {
+    if (v > threshold) { return 2; }
+    if (v < -threshold) { return 0; }
+    return 1;
+}
+
+test quantize_positive { assert_eq(quantize(100, 10), 2); }
+test quantize_negative { assert_eq(quantize(-100, 10), 0); }
+test quantize_zero_band { assert_eq(quantize(5, 10), 1); }
+test quantize_boundary_hi { assert_eq(quantize(10, 10), 1); }
+test quantize_boundary_lo { assert_eq(quantize(-10, 10), 1); }
+test quantize_just_over { assert_eq(quantize(11, 10), 2); }
+test quantize_just_under { assert_eq(quantize(-11, 10), 0); }
+endmodule


### PR DESCRIPTION
The BitNet accelerator is entirely hand-written Rust RTL emitters — **off the spec-first path** (the project's core differentiator). This adds the first BitNet-relevant datapath primitive *as a `.t27` spec*, and it's a genuinely useful one: the activation re-ternarizer the engine needs to close the layer loop.

Closes #1737

### `specs/ternary/activation_quantizer.t27`
`quantize(v: i16, threshold: i16) -> u8` re-ternarizes a signed accumulator to a packed trit `{N=0b00, Z=0b01, P=0b10}` with a symmetric threshold: `v > +t → P`, `v < -t → N`, else `Z`. gen-verilog lowers it to a clean signed-compare nested-if function.

### Verification
- `t27c typecheck`: **0 errors / 0 warnings**.
- `t27c icarus-simulate`: **7/7 embedded test blocks pass** (iverilog) — positive/negative/zero-band, both `v == ±t` boundaries (→ Z), just-over/just-under (→ P/N).
- `t27c seal --save/--verify`: all three backends (verilog / c / rust) hash-**MATCH** deterministically.

### Why it matters
- Puts a real ternary datapath primitive on the **spec-first** path (L2/L4) — the constitutional gap for the whole accelerator.
- Provides the activation quantizer needed to chain MAC → re-ternarize → next layer (the functional gap found while auditing the engine).
- A ternary-native spec-first RTL path is a differentiator no competitor (e.g. Ternary-NanoCore on Artix-7) has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)