### PR TITLE
feat(ternary): spec-first ternary MAC dot product (.t27), bit-exact vs handwritten

### DIFF
--- a/.trinity/seals/ternary_TernaryMac.json
+++ b/.trinity/seals/ternary_TernaryMac.json
@@ -1,0 +1,11 @@
+{
+  "gen_hash_c": "sha256:fef5c97fe95304b788e0033a723e6768e3a3c7656cb998d39fbbc9309524cde6",
+  "gen_hash_rust": "sha256:2427842a00eeedec1ec1118e81f1c8fa5041bfff6321bccb95f107299eee3ebf",
+  "gen_hash_verilog": "sha256:54ac62a12553193fba4b910dc5054773fca64a844de48f80de948f2d33b08797",
+  "gen_hash_zig": "sha256:3153a7a530fc2390c6fbd10c488161d2b78099b63158f7e2a0379e8b5fdb0910",
+  "module": "TernaryMac",
+  "ring": 12,
+  "sealed_at": "2026-08-05T18:31:57Z",
+  "spec_hash": "sha256:27457daab18863f147e98c1fbfbfb1881e1534122ee7604c20449a0495bfbd44",
+  "spec_path": "specs/ternary/ternary_mac.t27"
+}

--- a/bootstrap/tests/bitnet_mac_specfirst.rs
+++ b/bootstrap/tests/bitnet_mac_specfirst.rs
@@ -1,0 +1,139 @@
+// ============================================================================
+// Cross-check: the spec-first ternary MAC (specs/ternary/ternary_mac.t27,
+// function `dot27`) must compute the SAME dot product as the hand-written
+// `trit27_dot_product` (gen-trit-stdlib) for every input.
+//
+// This is the equivalence proof for porting the accelerator's core datapath to
+// the spec-first path (#1742): 300 random valid-trit vector pairs are fed to
+// both, and the results must match bit-for-bit via iverilog + vvp.
+//
+// Encoding: 2'b00 = -1, 2'b01 = 0, 2'b10 = +1; trit i at bits [2i+1:2i] of a
+// 54-bit chunk. Skips gracefully when iverilog/vvp are not on PATH.
+// ============================================================================
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn t27c() -> &'static str {
+    env!("CARGO_BIN_EXE_t27c")
+}
+
+fn spec_path() -> PathBuf {
+    // bootstrap/ -> repo root -> specs/ternary/ternary_mac.t27
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("specs")
+        .join("ternary")
+        .join("ternary_mac.t27")
+}
+
+fn scratch_dir(label: &str) -> PathBuf {
+    let dir = env::temp_dir().join(format!("t27_mac_specfirst_{}_{}", std::process::id(), label));
+    if dir.exists() {
+        let _ = fs::remove_dir_all(&dir);
+    }
+    dir
+}
+
+fn tool_available(tool: &str) -> bool {
+    Command::new(tool)
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+// Feeds the same random 54-bit vectors to the spec-first `dot27` (hierarchical
+// call into the generated `TernaryMac` module) and the hand-written
+// `trit27_dot_product`, and asserts equality over 300 vectors.
+const TESTBENCH: &str = r#"`timescale 1ns/1ps
+module tb;
+  reg [53:0] a, b;
+  wire signed [5:0] ref_r;
+  integer fails=0, iter, k;
+  trit27_dot_product refdut(.input_vec(a), .weight_vec(b), .result(ref_r));
+  function [1:0] tmap(input integer x); integer m; begin
+    m=x%3; if(m<0)m=m+3; tmap=(m==0)?2'b01:(m==1)?2'b10:2'b00; end
+  endfunction
+  initial begin
+    for (iter=0; iter<300; iter=iter+1) begin
+      for (k=0;k<27;k=k+1) begin a[k*2 +: 2]=tmap($random); b[k*2 +: 2]=tmap($random); end
+      #1;
+      if ($signed(spec.dot27({10'd0,a},{10'd0,b})) !== $signed(ref_r)) begin
+        fails=fails+1;
+        if (fails<=3) $display("FAIL[%0d] spec=%0d ref=%0d", iter,
+          $signed(spec.dot27({10'd0,a},{10'd0,b})), $signed(ref_r));
+      end
+    end
+    if (fails==0) $display("ALL_MATCH 300"); else $display("MISMATCH %0d", fails);
+    $finish;
+  end
+  TernaryMac spec(.clk(1'b0), .rst_n(1'b1), .en(1'b1), .ready());
+endmodule
+"#;
+
+#[test]
+fn spec_first_dot27_matches_handwritten_trit27_dot_product() {
+    if !tool_available("iverilog") || !tool_available("vvp") {
+        eprintln!("SKIP: iverilog/vvp not on PATH; skipping spec-first MAC cross-check");
+        return;
+    }
+
+    let dir = scratch_dir("xcheck");
+    fs::create_dir_all(&dir).expect("create scratch dir");
+
+    // Emit the spec-first MAC module from the .t27 spec.
+    let mac = Command::new(t27c())
+        .arg("gen-verilog")
+        .arg(spec_path())
+        .output()
+        .expect("invoke gen-verilog");
+    assert!(
+        mac.status.success(),
+        "gen-verilog of ternary_mac.t27 failed:\n{}",
+        String::from_utf8_lossy(&mac.stderr)
+    );
+    fs::write(dir.join("mac.v"), &mac.stdout).expect("write mac.v");
+
+    // Emit the hand-written reference (trit27_dot_product lives in the stdlib).
+    let stdlib = Command::new(t27c())
+        .arg("gen-trit-stdlib")
+        .output()
+        .expect("invoke gen-trit-stdlib");
+    assert!(stdlib.status.success(), "gen-trit-stdlib failed");
+    fs::write(dir.join("trit_stdlib.sv"), &stdlib.stdout).expect("write trit_stdlib.sv");
+
+    fs::write(dir.join("tb.v"), TESTBENCH).expect("write tb.v");
+
+    let vvp_path = dir.join("sim.vvp");
+    let compile = Command::new("iverilog")
+        .args(["-g2012", "-o", vvp_path.to_str().unwrap()])
+        .arg(dir.join("mac.v"))
+        .arg(dir.join("trit_stdlib.sv"))
+        .arg(dir.join("tb.v"))
+        .output()
+        .expect("invoke iverilog");
+    assert!(
+        compile.status.success(),
+        "iverilog compile failed:\n{}",
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new("vvp").arg(&vvp_path).output().expect("invoke vvp");
+    let stdout = String::from_utf8_lossy(&run.stdout).into_owned();
+
+    let _ = fs::remove_dir_all(&dir);
+
+    assert!(
+        stdout.contains("ALL_MATCH 300"),
+        "spec-first dot27 did not match trit27_dot_product on all 300 vectors:\n{}",
+        stdout
+    );
+    assert!(
+        !stdout.contains("MISMATCH") && !stdout.contains("FAIL"),
+        "spec-first dot27 mismatch vs reference:\n{}",
+        stdout
+    );
+}

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,3 +1,16 @@
+# NOW — feat: spec-first ternary MAC dot product (.t27), bit-exact vs handwritten (2026-08-05)
+
+Last updated: 2026-08-05
+
+## feat: spec-first ternary MAC dot27 (.t27) == trit27_dot_product (Closes #1742)
+
+- Branch: `feat/spec-first-ternary-mac`
+
+### Что легло
+- The accelerator's **core datapath** now has a spec-first form. `specs/ternary/ternary_mac.t27`: `tmul` (sign-only ternary multiply, no `*` since gen-verilog's `*`=unsigned `__mul_noop`) + `dot27(a: u64, b: u64) -> i8` (27-trit ternary dot product over 54-bit packed vectors). Written **loop-free** (27-term sum of per-position helpers) because gen-verilog can't lower a local-declaring `while` loop — filed that backend defect as **#1741** (reg decls after statements / inside loop blocks → iverilog syntax error). Verified: typecheck 0 err; icarus-simulate 4/4 (all-N×all-N=+27, all-N×all-P=-27, all-P×all-P=+27, all-Z=0); seal 3 backends MATCH; new Rust integration test `tests/bitnet_mac_specfirst.rs` **bit-exact cross-checks dot27 vs the hand-written trit27_dot_product on 300 random vectors (ALL_MATCH)**. Full suite green (excl. pre-existing #1726). No compiler change, no reseal.
+
+---
+
 # NOW — feat: self-contained BitNet bundle (bundles trit_stdlib, elaborates standalone) (2026-08-05)
 
 Last updated: 2026-08-05

--- a/specs/ternary/ternary_mac.t27
+++ b/specs/ternary/ternary_mac.t27
@@ -1,0 +1,27 @@
+module TernaryMac;
+// Sign-only ternary multiply of two packed trits {N=0b00, Z=0b01, P=0b10}.
+fn tmul(ta: u8, tb: u8) -> i8 {
+    if (ta == 1) { return 0; }
+    if (tb == 1) { return 0; }
+    if (ta == tb) { return 1; }
+    return -1;
+}
+// One trit position i of two 54-bit packed vectors (trit i at [2i+1:2i]).
+fn tp(a: u64, b: u64, i: u32) -> i8 {
+    return tmul(((a >> (i << 1)) & 3) as u8, ((b >> (i << 1)) & 3) as u8);
+}
+// 27-trit ternary dot product, loop-free (gen-verilog cannot yet lower a
+// local-declaring while loop -- see #1741). Result in [-27, +27].
+pub fn dot27(a: u64, b: u64) -> i8 {
+    return tp(a,b,0) + tp(a,b,1) + tp(a,b,2) + tp(a,b,3) + tp(a,b,4)
+         + tp(a,b,5) + tp(a,b,6) + tp(a,b,7) + tp(a,b,8) + tp(a,b,9)
+         + tp(a,b,10) + tp(a,b,11) + tp(a,b,12) + tp(a,b,13) + tp(a,b,14)
+         + tp(a,b,15) + tp(a,b,16) + tp(a,b,17) + tp(a,b,18) + tp(a,b,19)
+         + tp(a,b,20) + tp(a,b,21) + tp(a,b,22) + tp(a,b,23) + tp(a,b,24)
+         + tp(a,b,25) + tp(a,b,26);
+}
+test dot_all_n_x_all_n { assert_eq(dot27(0, 0), 27); }
+test dot_all_n_x_all_p { assert_eq(dot27(0, 12009599006321322), -27); }
+test dot_all_p_x_all_p { assert_eq(dot27(12009599006321322, 12009599006321322), 27); }
+test dot_all_z { assert_eq(dot27(6004799503160661, 6004799503160661), 0); }
+endmodule


### PR DESCRIPTION
The ternary MAC core (`trit27_dot_product`) — the accelerator's central datapath — was a hand-written Rust RTL emitter, **off the spec-first path**. This ports it to `.t27` and proves equivalence.

Closes #1742

### `specs/ternary/ternary_mac.t27`
- `tmul(ta, tb)` — sign-only ternary multiply of two packed trits `{N=00, Z=01, P=10}` (no `*`: gen-verilog's `*` is the unsigned `__mul_noop`, wrong for signed trits).
- `dot27(a: u64, b: u64) -> i8` — 27-trit ternary dot product over two 54-bit packed vectors, result in [-27, +27].

Written **loop-free** (a 27-term sum of per-position helpers) because gen-verilog cannot yet lower a local-declaring `while` loop — filed as **#1741** (emits `reg` decls after statements / inside loop blocks → iverilog syntax error).

### Verification
- `typecheck`: 0 errors.
- `icarus-simulate`: **4/4** test blocks (all-N×all-N=+27, all-N×all-P=−27, all-P×all-P=+27, all-Z=0).
- `seal --verify`: all 3 backends hash-MATCH.
- **New integration test `tests/bitnet_mac_specfirst.rs`** — bit-exact cross-check of `dot27` vs the hand-written `trit27_dot_product` on **300 random vectors** (iverilog + vvp): `ALL_MATCH`.
- Full suite green apart from the pre-existing, unrelated `bitnet_top` reds (#1726).

Puts the accelerator's core datapath on a ternary-native spec-first RTL flow — a differentiator no competitor (e.g. Ternary-NanoCore on Artix-7) has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)