### PR TITLE
feat(ternary): spec-first BitNet neuron — dot-product accumulation + activation quantize

### DIFF
--- a/.trinity/seals/ternary_BitnetNeuron.json
+++ b/.trinity/seals/ternary_BitnetNeuron.json
@@ -1,0 +1,11 @@
+{
+  "gen_hash_c": "sha256:6988df85c98993c45fe567c7111716a90fd488197b679214d2f74923f858a91c",
+  "gen_hash_rust": "sha256:b857c4089311f4bb29d9a06e47546c37cf3690a0e9614fa5824424f91b81407b",
+  "gen_hash_verilog": "sha256:19276af8f7ab0e89e98f9beb2af7dc7346de01773942dc209ad6d513904efb04",
+  "gen_hash_zig": "sha256:93dc578ebfa5bf0bb79545cd6cbbb3859c5351bfb348edcc086c2c82d58a5012",
+  "module": "BitnetNeuron",
+  "ring": 12,
+  "sealed_at": "2026-08-05T19:03:02Z",
+  "spec_hash": "sha256:f5b614d92a468a96ade80546e89f9b43bedacde447987a4889595b320b2c4e16",
+  "spec_path": "specs/ternary/bitnet_neuron.t27"
+}

--- a/bootstrap/tests/bitnet_neuron_specfirst.rs
+++ b/bootstrap/tests/bitnet_neuron_specfirst.rs
@@ -1,0 +1,144 @@
+// ============================================================================
+// Functional cross-check for the spec-first BitNet neuron
+// (specs/ternary/bitnet_neuron.t27, function `neuron4`): accumulate the ternary
+// dot product over 4 (activation, weight) chunk pairs, then re-ternarize with a
+// threshold. Its `dot27` uses a real `while` loop (enabled by the gen-verilog
+// local-decl hoist fix, #1741).
+//
+// 200 random valid-trit chunk sets + random thresholds are fed to both the
+// generated `neuron4` and an independent in-testbench reference
+// (decode+multiply-accumulate over 4 chunks, then threshold), asserting
+// equality via iverilog + vvp. Skips gracefully without iverilog/vvp.
+// ============================================================================
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn t27c() -> &'static str {
+    env!("CARGO_BIN_EXE_t27c")
+}
+
+fn spec_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("specs")
+        .join("ternary")
+        .join("bitnet_neuron.t27")
+}
+
+fn scratch_dir(label: &str) -> PathBuf {
+    let dir = env::temp_dir().join(format!("t27_neuron_{}_{}", std::process::id(), label));
+    if dir.exists() {
+        let _ = fs::remove_dir_all(&dir);
+    }
+    dir
+}
+
+fn tool_available(tool: &str) -> bool {
+    Command::new(tool)
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+const TESTBENCH: &str = r#"`timescale 1ns/1ps
+module tb;
+  reg [53:0] a0,w0,a1,w1,a2,w2,a3,w3;
+  reg signed [15:0] thr;
+  integer fails=0, iter, k;
+  reg signed [15:0] acc; reg [7:0] exp;
+  function [1:0] tmap(input integer x); integer m; begin
+    m=x%3; if(m<0)m=m+3; tmap=(m==0)?2'b01:(m==1)?2'b10:2'b00; end
+  endfunction
+  function signed [15:0] dot_ref(input [53:0] a, input [53:0] b);
+    integer j, va, vb, s; reg [1:0] ta, tb; begin
+    s=0;
+    for (j=0;j<27;j=j+1) begin
+      ta=a[j*2 +: 2]; tb=b[j*2 +: 2];
+      va=(ta==2'b00)?-1:(ta==2'b10)?1:0;
+      vb=(tb==2'b00)?-1:(tb==2'b10)?1:0;
+      s=s+va*vb; end
+    dot_ref=s; end
+  endfunction
+  function [7:0] quant_ref(input signed [15:0] v, input signed [15:0] t); begin
+    if (v > t) quant_ref=2; else if (v < -t) quant_ref=0; else quant_ref=1; end
+  endfunction
+  task rnd(output [53:0] v); integer k2; begin
+    for (k2=0;k2<27;k2=k2+1) v[k2*2 +: 2]=tmap($random); end
+  endtask
+  initial begin
+    for (iter=0; iter<200; iter=iter+1) begin
+      rnd(a0); rnd(w0); rnd(a1); rnd(w1); rnd(a2); rnd(w2); rnd(a3); rnd(w3);
+      thr = ($random % 60); if (thr < 0) thr = -thr;
+      #1;
+      acc = dot_ref(a0,w0)+dot_ref(a1,w1)+dot_ref(a2,w2)+dot_ref(a3,w3);
+      exp = quant_ref(acc, thr);
+      if (dut.neuron4({10'd0,a0},{10'd0,w0},{10'd0,a1},{10'd0,w1},
+                      {10'd0,a2},{10'd0,w2},{10'd0,a3},{10'd0,w3}, thr) !== exp) begin
+        fails=fails+1;
+        if (fails<=3) $display("FAIL[%0d] got=%0d exp=%0d acc=%0d thr=%0d", iter,
+          dut.neuron4({10'd0,a0},{10'd0,w0},{10'd0,a1},{10'd0,w1},
+                      {10'd0,a2},{10'd0,w2},{10'd0,a3},{10'd0,w3}, thr), exp, acc, thr);
+      end
+    end
+    if (fails==0) $display("ALL_MATCH 200"); else $display("MISMATCH %0d", fails);
+    $finish;
+  end
+  BitnetNeuron dut(.clk(1'b0), .rst_n(1'b1), .en(1'b1), .ready());
+endmodule
+"#;
+
+#[test]
+fn spec_first_neuron4_matches_reference() {
+    if !tool_available("iverilog") || !tool_available("vvp") {
+        eprintln!("SKIP: iverilog/vvp not on PATH; skipping BitNet neuron cross-check");
+        return;
+    }
+
+    let dir = scratch_dir("xcheck");
+    fs::create_dir_all(&dir).expect("create scratch dir");
+
+    let gen = Command::new(t27c())
+        .arg("gen-verilog")
+        .arg(spec_path())
+        .output()
+        .expect("invoke gen-verilog");
+    assert!(
+        gen.status.success(),
+        "gen-verilog of bitnet_neuron.t27 failed:\n{}",
+        String::from_utf8_lossy(&gen.stderr)
+    );
+    fs::write(dir.join("neuron.v"), &gen.stdout).expect("write neuron.v");
+    fs::write(dir.join("tb.v"), TESTBENCH).expect("write tb.v");
+
+    let vvp_path = dir.join("sim.vvp");
+    let compile = Command::new("iverilog")
+        .args(["-g2012", "-o", vvp_path.to_str().unwrap()])
+        .arg(dir.join("neuron.v"))
+        .arg(dir.join("tb.v"))
+        .output()
+        .expect("invoke iverilog");
+    assert!(
+        compile.status.success(),
+        "iverilog compile failed:\n{}",
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new("vvp").arg(&vvp_path).output().expect("invoke vvp");
+    let stdout = String::from_utf8_lossy(&run.stdout).into_owned();
+    let _ = fs::remove_dir_all(&dir);
+
+    assert!(
+        stdout.contains("ALL_MATCH 200"),
+        "spec-first neuron4 did not match the reference on all 200 vectors:\n{}",
+        stdout
+    );
+    assert!(
+        !stdout.contains("MISMATCH") && !stdout.contains("FAIL"),
+        "spec-first neuron4 mismatch vs reference:\n{}",
+        stdout
+    );
+}

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,3 +1,16 @@
+# NOW — feat: spec-first BitNet neuron (.t27) — accumulation + quantize (2026-08-05)
+
+Last updated: 2026-08-05
+
+## feat: spec-first BitNet neuron4 (dot-product accumulation + quantize) (Closes #1746)
+
+- Branch: `feat/spec-first-bitnet-neuron`
+
+### Что легло
+- First spec-first BitNet **compute unit**. `specs/ternary/bitnet_neuron.t27`: `dot27` (27-trit dot product via a real `while` loop — now that #1741 unblocked loops) + `quantize` + `neuron4(a0,w0,...,a3,w3,threshold)` accumulating the ternary dot product over 4 chunk pairs then re-ternarizing. Chunks are separate scalar params because packed-array element indexing is broken (filed #1745). Verified: typecheck 0 err; icarus-simulate 5/5; new `tests/bitnet_neuron_specfirst.rs` cross-checks neuron4 vs an independent reference on **200 random vectors** (ALL_MATCH); seal 3 backends MATCH. Combines #1738 (quantizer) + #1743 (MAC) into a working neuron and demonstrates the #1741 loop fix end-to-end. No compiler change, no reseal.
+
+---
+
 # NOW — fix: gen-verilog hoist function-local reg decls to body top (#1741) (2026-08-05)
 
 Last updated: 2026-08-05

--- a/specs/ternary/bitnet_neuron.t27
+++ b/specs/ternary/bitnet_neuron.t27
@@ -1,0 +1,39 @@
+module BitnetNeuron;
+// Sign-only ternary multiply of two packed trits {N=0b00, Z=0b01, P=0b10}.
+fn tmul(ta: u8, tb: u8) -> i8 {
+    if (ta == 1) { return 0; }
+    if (tb == 1) { return 0; }
+    if (ta == tb) { return 1; }
+    return -1;
+}
+// 27-trit ternary dot product of two 54-bit packed vectors, via a real loop
+// (enabled by the gen-verilog local-decl hoist fix, #1741). Result in [-27,+27].
+fn dot27(a: u64, b: u64) -> i16 {
+    var acc : i16 = 0;
+    var i : u32 = 0;
+    while (i < 27) {
+        var ta : u8 = ((a >> (i << 1)) & 3) as u8;
+        var tb : u8 = ((b >> (i << 1)) & 3) as u8;
+        acc = acc + tmul(ta, tb) as i16;
+        i = i + 1;
+    }
+    return acc;
+}
+// Ternary activation re-quantizer: v > +t -> P(2), v < -t -> N(0), else Z(1).
+fn quantize(v: i16, threshold: i16) -> u8 {
+    if (v > threshold) { return 2; }
+    if (v < -threshold) { return 0; }
+    return 1;
+}
+// One BitNet neuron over 4 chunks: accumulate the ternary dot product across
+// four (activation, weight) chunk pairs, then re-ternarize with the threshold.
+pub fn neuron4(a0: u64, w0: u64, a1: u64, w1: u64, a2: u64, w2: u64, a3: u64, w3: u64, threshold: i16) -> u8 {
+    var acc : i16 = dot27(a0, w0) + dot27(a1, w1) + dot27(a2, w2) + dot27(a3, w3);
+    return quantize(acc, threshold);
+}
+test neuron_all_p { assert_eq(neuron4(12009599006321322,12009599006321322,12009599006321322,12009599006321322,12009599006321322,12009599006321322,12009599006321322,12009599006321322, 10), 2); }
+test neuron_all_p_x_n { assert_eq(neuron4(12009599006321322,0,12009599006321322,0,12009599006321322,0,12009599006321322,0, 10), 0); }
+test neuron_all_zero { assert_eq(neuron4(6004799503160661,6004799503160661,6004799503160661,6004799503160661,6004799503160661,6004799503160661,6004799503160661,6004799503160661, 10), 1); }
+test neuron_within_band { assert_eq(neuron4(12009599006321322,12009599006321322,6004799503160661,6004799503160661,6004799503160661,6004799503160661,6004799503160661,6004799503160661, 30), 1); }
+test dot27_all_n { assert_eq(dot27(0, 0), 27); }
+endmodule


### PR DESCRIPTION
The first spec-first BitNet **compute unit** (not just a primitive): `specs/ternary/bitnet_neuron.t27`.

Closes #1746

- `dot27(a, b) -> i16` — 27-trit ternary dot product via a real `while` loop, enabled by the gen-verilog local-decl hoist fix (#1741). Loops couldn't lower before.
- `quantize(v, threshold) -> u8` — ternary activation re-quantizer.
- `neuron4(a0,w0,…,a3,w3, threshold) -> u8` — accumulate `dot27` across 4 (activation, weight) chunk pairs, then re-ternarize.

Chunks are separate scalar params because packed-array element indexing is currently broken (#1745); a fully-parameterized `[N]` loop awaits that fix.

### Verification
- `typecheck`: 0 errors.
- `icarus-simulate`: **5/5** embedded test blocks (all-P→P, all-P×N→N, all-Z→Z, within-threshold→Z, dot27 all-N=+27).
- **New integration test `tests/bitnet_neuron_specfirst.rs`** — cross-checks `neuron4` vs an independent reference (decode+MAC over 4 chunks, then threshold) on **200 random vectors**: `ALL_MATCH`.
- `seal --verify`: all 3 backends hash-MATCH.

Combines the two spec-first primitives (#1738 quantizer, #1743 MAC) into a working neuron and demonstrates the #1741 loop fix end-to-end — a step toward a spec-first inference path no competitor (Ternary-NanoCore) has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)