### PR TITLE
test(gen-verilog): guard nested-if/else reg-decl hoist (#1741)

### DIFF
--- a/bootstrap/tests/verilog_decl_hoist.rs
+++ b/bootstrap/tests/verilog_decl_hoist.rs
@@ -107,3 +107,98 @@ fn while_loop_with_locals_lowers_and_elaborates() {
         stderr
     );
 }
+
+// A function that declares a SECOND top-level local after a leading statement
+// (`carry` then `sum`) AND a local inside a nested `if/else` branch (`result`)
+// -- the exact shape of GF-T's `gft_mul_offset_full_p` that motivated #1741.
+// Distinct from the while-loop case above: the offending decls are same-block
+// interleaved and inside an `else begin ... end`, not a loop. On the unfixed
+// emitter this produced `reg [31:0] sum;` after `carry = ...;`, which iverilog
+// rejects ("syntax error / Malformed statement").
+const SPEC_NESTED_IF: &str = r#"module DeclHoistIf;
+pub fn mul_offset(offset_a: u32, offset_b: u32, bias: u32, offset_max: u32) -> u32 {
+    let carry : u32 = offset_a & 1;
+    let sum : u32 = (offset_a + offset_b) + carry;
+    if (sum < bias) {
+        return 0;
+    } else {
+        let result : u32 = sum - bias;
+        if (result >= offset_max) {
+            return offset_max;
+        } else {
+            return result;
+        }
+    }
+}
+endmodule
+"#;
+
+#[test]
+fn nested_if_else_locals_lower_and_elaborate() {
+    let dir = scratch_dir("hoist_if");
+    fs::create_dir_all(&dir).expect("create scratch dir");
+    let spec = dir.join("declhoistif.t27");
+    fs::write(&spec, SPEC_NESTED_IF).expect("write spec");
+
+    let gen = Command::new(t27c())
+        .arg("gen-verilog")
+        .arg(&spec)
+        .output()
+        .expect("invoke gen-verilog");
+    assert!(
+        gen.status.success(),
+        "gen-verilog failed:\n{}",
+        String::from_utf8_lossy(&gen.stderr)
+    );
+    let v = String::from_utf8_lossy(&gen.stdout).into_owned();
+
+    // All three locals -- `carry` and `sum` (top-level) and `result` (nested in
+    // the else branch) -- must be declared before the first procedural
+    // statement in the body block. The first statement is `carry = ...`; no
+    // `reg` decl may follow it.
+    let body_start = v.find("begin : mul_offset_body").expect("body block present");
+    let body = &v[body_start..];
+    let first_assign = body.find("carry = ").expect("assignment present");
+    let decls_region = &body[..first_assign];
+    for name in ["carry", "sum", "result"] {
+        assert!(
+            decls_region.contains(&format!("reg [31:0] {};", name)),
+            "local `{}` not hoisted before first statement:\n{}",
+            name,
+            v
+        );
+    }
+    // No local `reg` may be re-declared after the first statement -- that
+    // interleaved form (`reg sum;` after `carry = ...;`, and `reg result;`
+    // inside the else block) is exactly what iverilog rejects.
+    let after_first_assign = &body[first_assign..];
+    for name in ["sum", "result"] {
+        assert!(
+            !after_first_assign.contains(&format!("reg [31:0] {};", name)),
+            "`{}` re-declared mid-block (interleaved decl regression):\n{}",
+            name,
+            v
+        );
+    }
+
+    if !iverilog_available() {
+        eprintln!("SKIP(elaborate): iverilog not on PATH");
+        let _ = fs::remove_dir_all(&dir);
+        return;
+    }
+
+    let vfile = dir.join("declhoistif.v");
+    fs::write(&vfile, v.as_bytes()).expect("write verilog");
+    let elab = Command::new("iverilog")
+        .args(["-g2012", "-t", "null"])
+        .arg(&vfile)
+        .output()
+        .expect("invoke iverilog");
+    let stderr = String::from_utf8_lossy(&elab.stderr);
+    let _ = fs::remove_dir_all(&dir);
+    assert!(
+        elab.status.success(),
+        "iverilog rejected the nested-if hoisted function (#1741 regression):\n{}",
+        stderr
+    );
+}

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,3 +1,16 @@
+# NOW — test: guard nested-if/else reg-decl hoist in gen-verilog (2026-08-06)
+
+Last updated: 2026-08-06
+
+## test: gen-verilog nested-if/else reg-decl hoist regression (Refs #1697)
+
+- Branch: `claude/youthful-dewdney-e29e8e`
+
+### Что легло
+- The #1741 emitter fix (hoist function-local `reg` decls to the `begin : <fn>_body` top) is in master, but its regression test `tests/verilog_decl_hoist.rs` only covered the `while`-loop shape. Added `nested_if_else_locals_lower_and_elaborate`, reproducing GF-T's `gft_mul_offset_full_p`: a second same-block local declared after a leading statement (`carry; carry = ...; sum;`) plus a local inside an `else` branch (`result`). Asserts all locals are hoisted before the first statement, none re-declared mid-block, and the output elaborates under `iverilog -g2012`. Verified it fails against the pre-#1741 emitter (interleaved `reg [31:0] sum;` -> iverilog exit 2) and passes on master. Test-only; no compiler change, no reseal. PR #1751.
+
+---
+
 # NOW — fix: gen-verilog array-param element index -> part-select (#1745) (2026-08-05)
 
 Last updated: 2026-08-05


### PR DESCRIPTION
## Summary

Adds a regression test for the `gen-verilog` function-local `reg` hoist, covering the **nested `if/else`** shape that the existing test (`while_loop_with_locals_lowers_and_elaborates`) did not exercise.

The emitter fix itself already landed in `master` via #1741 (`fix(gen-verilog): hoist function-local reg decls to body top`). This PR is **test-only** (plus a `docs/NOW.md` entry) — it locks in the exact scenario that motivated #1741 so it cannot silently regress.

Refs #1697 (harden the codegen backend / conformance).

## What the new test does

`nested_if_else_locals_lower_and_elaborate` reproduces the `gft_mul_offset_full_p` shape:
- a second same-block local declared after a leading statement (`carry; carry = ...; sum;`)
- a local declared inside an `else` branch (`result`)

It asserts:
1. all locals (`carry`, `sum`, `result`) are declared before the first statement in `begin : mul_offset_body`,
2. none are re-declared mid-block, and
3. the output elaborates under `iverilog -g2012` (skips gracefully when iverilog is absent).

Verified that this test **fails** against the pre-#1741 emitter (interleaved `reg [31:0] sum;` → iverilog exit 2) and **passes** on current `master`.

## Test

```
cargo test --release --test verilog_decl_hoist
# 2 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
