### PR TITLE
feat(ternary): 2-neuron spec-first BitNet layer with packed trit output

### DIFF
--- a/.trinity/seals/ternary_BitnetLayer.json
+++ b/.trinity/seals/ternary_BitnetLayer.json
@@ -1,0 +1,11 @@
+{
+  "gen_hash_c": "sha256:18c0f6899ba765b40ffc7d3acdf50395f33a354a183d27dbad6e5ce85d85c285",
+  "gen_hash_rust": "sha256:e6febbf84236b3dabb8a44d2cab6465f18fe0171d4b9f56e9be1106e8f7e0499",
+  "gen_hash_verilog": "sha256:a0fd00d883082d260b2aec01409ffacdc816c4cfb126f0ae5202737985ca3b62",
+  "gen_hash_zig": "sha256:1eff40445d3fa25cbc6f869b21bcd8365926388f679ec773cc2a8f0ed117f548",
+  "module": "BitnetLayer",
+  "ring": 12,
+  "sealed_at": "2026-08-06T09:00:57Z",
+  "spec_hash": "sha256:e3bed8021f3e981f48a6c7c7dd5cc67ff9765cb7fe7d2825d51a9a8d74652373",
+  "spec_path": "specs/ternary/bitnet_layer.t27"
+}

--- a/bootstrap/tests/bitnet_layer.rs
+++ b/bootstrap/tests/bitnet_layer.rs
@@ -1,0 +1,125 @@
+// ============================================================================
+// Functional check for the 2-neuron spec-first BitNet layer
+// (specs/ternary/bitnet_layer.t27, function `layer2`): two `neuronN` units over
+// shared activations and per-neuron weights, packing the two output trits into
+// a byte (trit0 in bits[1:0], trit1 in bits[3:2]).
+//
+// A hand testbench packs uniform chunks directly into the 512-bit vectors (so
+// it does not depend on array-literal call args, #1749) and checks the packed
+// layer output for known per-neuron dot-product/quantize outcomes. Skips
+// gracefully without iverilog/vvp.
+// ============================================================================
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn t27c() -> &'static str {
+    env!("CARGO_BIN_EXE_t27c")
+}
+
+fn spec_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("specs")
+        .join("ternary")
+        .join("bitnet_layer.t27")
+}
+
+fn scratch_dir(label: &str) -> PathBuf {
+    let dir = env::temp_dir().join(format!("t27_layer_{}_{}", std::process::id(), label));
+    if dir.exists() {
+        let _ = fs::remove_dir_all(&dir);
+    }
+    dir
+}
+
+fn tool_available(tool: &str) -> bool {
+    Command::new(tool)
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+// Output packs trit1<<2 | trit0. P=2, Z=1, N=0.
+//   w0=P, w1=N (acts=P) -> (N<<2)|P = 2
+//   w0=P, w1=P          -> (P<<2)|P = 10
+//   w0=N, w1=P          -> (P<<2)|N = 8
+//   allZ                -> (Z<<2)|Z = 5
+//   nchunks=0           -> both Z   = 5
+const TESTBENCH: &str = r#"`timescale 1ns/1ps
+module tb;
+  reg [511:0] acts, w0, w1;
+  localparam [53:0] P = {27{2'b10}};
+  localparam [53:0] N = {27{2'b00}};
+  localparam [53:0] Z = {27{2'b01}};
+  integer fails=0;
+  task fill(output [511:0] v, input [53:0] cv); integer k; begin
+    v=0; for (k=0;k<8;k=k+1) v[k*64 +: 64]={10'd0,cv}; end
+  endtask
+  task chk(input [7:0] got, input [7:0] exp, input [127:0] nm); begin
+    if (got!==exp) begin fails=fails+1; $display("FAIL %0s got=%0d exp=%0d",nm,got,exp); end
+    else $display("PASS %0s=%0d",nm,got); end
+  endtask
+  initial begin
+    fill(acts,P); fill(w0,P); fill(w1,N); chk(dut.layer2(acts,w0,w1,4,16'sd10), 2,  "P_N");
+    fill(acts,P); fill(w0,P); fill(w1,P); chk(dut.layer2(acts,w0,w1,4,16'sd10), 10, "P_P");
+    fill(acts,P); fill(w0,N); fill(w1,P); chk(dut.layer2(acts,w0,w1,4,16'sd10), 8,  "N_P");
+    fill(acts,Z); fill(w0,Z); fill(w1,Z); chk(dut.layer2(acts,w0,w1,8,16'sd10), 5,  "Z_Z");
+    fill(acts,P); fill(w0,P); fill(w1,P); chk(dut.layer2(acts,w0,w1,0,16'sd10), 5,  "zero_chunks");
+    if (fails==0) $display("ALL_PASS"); else $display("FAILED %0d", fails);
+    $finish;
+  end
+  BitnetLayer dut(.clk(1'b0), .rst_n(1'b1), .en(1'b1), .ready());
+endmodule
+"#;
+
+#[test]
+fn spec_first_layer2_packs_two_neuron_trits() {
+    if !tool_available("iverilog") || !tool_available("vvp") {
+        eprintln!("SKIP: iverilog/vvp not on PATH; skipping BitNet layer check");
+        return;
+    }
+
+    let dir = scratch_dir("chk");
+    fs::create_dir_all(&dir).expect("create scratch dir");
+
+    let gen = Command::new(t27c())
+        .arg("gen-verilog")
+        .arg(spec_path())
+        .output()
+        .expect("invoke gen-verilog");
+    assert!(
+        gen.status.success(),
+        "gen-verilog of bitnet_layer.t27 failed:\n{}",
+        String::from_utf8_lossy(&gen.stderr)
+    );
+    fs::write(dir.join("layer.v"), &gen.stdout).expect("write layer.v");
+    fs::write(dir.join("tb.v"), TESTBENCH).expect("write tb.v");
+
+    let vvp_path = dir.join("sim.vvp");
+    let compile = Command::new("iverilog")
+        .args(["-g2012", "-o", vvp_path.to_str().unwrap()])
+        .arg(dir.join("layer.v"))
+        .arg(dir.join("tb.v"))
+        .output()
+        .expect("invoke iverilog");
+    assert!(
+        compile.status.success(),
+        "iverilog compile failed:\n{}",
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new("vvp").arg(&vvp_path).output().expect("invoke vvp");
+    let stdout = String::from_utf8_lossy(&run.stdout).into_owned();
+    let _ = fs::remove_dir_all(&dir);
+
+    assert!(
+        stdout.contains("ALL_PASS"),
+        "layer2 packed-output check failed:\n{}",
+        stdout
+    );
+    assert!(!stdout.contains("FAIL"), "layer2 mismatch:\n{}", stdout);
+}

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,3 +1,16 @@
+# NOW — feat: 2-neuron spec-first BitNet layer with packed trit output (2026-08-06)
+
+Last updated: 2026-08-06
+
+## feat: spec-first BitNet layer2 (two neurons, packed trits) (Closes #1753)
+
+- Branch: `feat/spec-first-bitnet-layer`
+
+### Что легло
+- `specs/ternary/bitnet_layer.t27`: `layer2(acts: [8]u64, w0: [8]u64, w1: [8]u64, nchunks, threshold)` runs two `neuronN` units over shared activations + per-neuron weights and packs the two output trits into a byte (`(t1<<2)|t0`). Array params pass straight through to `neuronN` — no new backend work. First spec-first BitNet **layer** (multiple output trits), composing quantizer (#1738) + MAC (#1743) + N-chunk neuron (#1752). Verified: typecheck 0 err; icarus-simulate 4/4 scalar test blocks; seal 3 backends MATCH; new `tests/bitnet_layer.rs` drives layer2 over direct-packed uniform chunks (w0=P,w1=N→2; P,P→10; N,P→8; allZ→5; 0chunks→5) = ALL_PASS. No compiler change, no reseal.
+
+---
+
 # NOW — feat: parameterized N-chunk spec-first BitNet neuron over packed arrays (2026-08-06)
 
 Last updated: 2026-08-06

--- a/specs/ternary/bitnet_layer.t27
+++ b/specs/ternary/bitnet_layer.t27
@@ -1,0 +1,44 @@
+module BitnetLayer;
+fn tmul(ta: u8, tb: u8) -> i8 {
+    if (ta == 1) { return 0; }
+    if (tb == 1) { return 0; }
+    if (ta == tb) { return 1; }
+    return -1;
+}
+fn dot27(a: u64, b: u64) -> i16 {
+    var acc : i16 = 0;
+    var i : u32 = 0;
+    while (i < 27) {
+        var ta : u8 = ((a >> (i << 1)) & 3) as u8;
+        var tb : u8 = ((b >> (i << 1)) & 3) as u8;
+        acc = acc + tmul(ta, tb) as i16;
+        i = i + 1;
+    }
+    return acc;
+}
+fn quantize(v: i16, threshold: i16) -> u8 {
+    if (v > threshold) { return 2; }
+    if (v < -threshold) { return 0; }
+    return 1;
+}
+fn neuronN(acts: [8]u64, weights: [8]u64, nchunks: u32, threshold: i16) -> u8 {
+    var acc : i16 = 0;
+    var c : u32 = 0;
+    while (c < nchunks) {
+        acc = acc + dot27(acts[c], weights[c]);
+        c = c + 1;
+    }
+    return quantize(acc, threshold);
+}
+// 2-neuron BitNet layer: shared activations, per-neuron weights. Packs the two
+// output trits into a byte (trit0 in bits[1:0], trit1 in bits[3:2]).
+pub fn layer2(acts: [8]u64, w0: [8]u64, w1: [8]u64, nchunks: u32, threshold: i16) -> u8 {
+    var t0 : u8 = neuronN(acts, w0, nchunks, threshold);
+    var t1 : u8 = neuronN(acts, w1, nchunks, threshold);
+    return (t1 << 2) | t0;
+}
+test dot27_all_n { assert_eq(dot27(0, 0), 27); }
+test quantize_pos { assert_eq(quantize(100, 10), 2); }
+test quantize_neg { assert_eq(quantize(-100, 10), 0); }
+test quantize_band { assert_eq(quantize(5, 10), 1); }
+endmodule


### PR DESCRIPTION
Composes the parameterized N-chunk neuron (#1752) into a spec-first BitNet **layer**.

Closes #1753

`specs/ternary/bitnet_layer.t27`:
```
pub fn layer2(acts: [8]u64, w0: [8]u64, w1: [8]u64, nchunks: u32, threshold: i16) -> u8 {
    var t0 : u8 = neuronN(acts, w0, nchunks, threshold);
    var t1 : u8 = neuronN(acts, w1, nchunks, threshold);
    return (t1 << 2) | t0;
}
```
Two `neuronN` units over shared activations + per-neuron weights; the two output trits pack into a byte (trit0 in bits[1:0], trit1 in bits[3:2]). Array params pass straight through to `neuronN` — no new backend work.

### Verification
- `typecheck`: 0 errors; `icarus-simulate`: **4/4** scalar dot27/quantize test blocks; `seal`: 3 backends MATCH.
- **New integration test `tests/bitnet_layer.rs`** — drives `layer2` over uniform chunks packed directly into 512-bit vectors: `w0=P,w1=N→2`, `P,P→10`, `N,P→8`, `allZ→5`, `0-chunks→5` = `ALL_PASS`.

The first spec-first BitNet **layer** producing multiple output trits — completing the spec-first stack quantizer(#1738) → MAC(#1743) → neuron(#1747/#1752) → layer. A ternary-native spec-first RTL flow no competitor (Ternary-NanoCore) has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)