### PR TITLE
feat(ternary): 2-layer spec-first BitNet inference (dot/quantize/repack/dot)

### DIFF
--- a/.trinity/seals/ternary_BitnetMlp.json
+++ b/.trinity/seals/ternary_BitnetMlp.json
@@ -1,0 +1,11 @@
+{
+  "gen_hash_c": "sha256:e25d1ac6363e6bcef1b50cc1115a4c1ff23b361e9059a4f4e59c3c815a00c417",
+  "gen_hash_rust": "sha256:9173bde563e291b2990b63ffb71124c6f4786fc4d3334009c45d780366d293e2",
+  "gen_hash_verilog": "sha256:ccffe711a2aa14f46aa6bf8ab67a365f6ed5b1df0fb56d72a60409d08d1e32ff",
+  "gen_hash_zig": "sha256:2b10889a1a57c4e8f7f06091f4982136008122e6d6f0cf1661f63c4fa20034fa",
+  "module": "BitnetMlp",
+  "ring": 12,
+  "sealed_at": "2026-08-06T09:08:28Z",
+  "spec_hash": "sha256:ef76b7df5174a89b3ec92308edbdf4bf64bccb43c8588f13d7329a31c1178f58",
+  "spec_path": "specs/ternary/bitnet_mlp.t27"
+}

--- a/bootstrap/tests/bitnet_mlp.rs
+++ b/bootstrap/tests/bitnet_mlp.rs
@@ -1,0 +1,159 @@
+// ============================================================================
+// End-to-end check for the 2-layer spec-first BitNet inference
+// (specs/ternary/bitnet_mlp.t27, function `mlp2`): layer 1 (3 neurons over the
+// input activations) -> the 3 output trits are repacked into one hidden chunk
+// -> layer 2 (2 single-chunk neurons) -> 2 packed output trits.
+//
+// A hand testbench cross-checks `mlp2` against a fully independent reference
+// (both layers recomputed from scratch) over several uniform-chunk inputs, and
+// pins a low-threshold case that exercises non-Z layer-2 outputs. Chunks are
+// packed directly into the vectors (no array-literal call args, #1749). Skips
+// gracefully without iverilog/vvp.
+// ============================================================================
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn t27c() -> &'static str {
+    env!("CARGO_BIN_EXE_t27c")
+}
+
+fn spec_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("specs")
+        .join("ternary")
+        .join("bitnet_mlp.t27")
+}
+
+fn scratch_dir(label: &str) -> PathBuf {
+    let dir = env::temp_dir().join(format!("t27_mlp_{}_{}", std::process::id(), label));
+    if dir.exists() {
+        let _ = fs::remove_dir_all(&dir);
+    }
+    dir
+}
+
+fn tool_available(tool: &str) -> bool {
+    Command::new(tool)
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+const TESTBENCH: &str = r#"`timescale 1ns/1ps
+module tb;
+  reg [511:0] acts, wa0, wa1, wa2;
+  reg [63:0] wb0, wb1;
+  localparam [53:0] P = {27{2'b10}};
+  localparam [53:0] N = {27{2'b00}};
+  localparam [53:0] Z = {27{2'b01}};
+  integer fails=0;
+  task fill(output [511:0] v, input [53:0] cv); integer k; begin
+    v=0; for (k=0;k<8;k=k+1) v[k*64 +: 64]={10'd0,cv}; end
+  endtask
+  // Fully independent 2-layer reference.
+  function [7:0] refmlp(input [511:0] a, input [511:0] wa0i, input [511:0] wa1i,
+                        input [511:0] wa2i, input [63:0] wb0i, input [63:0] wb1i,
+                        input [31:0] nc, input signed [15:0] thr);
+    integer c, j, va, vb; reg signed [15:0] acc0,acc1,acc2,d0,d1;
+    reg [7:0] q0,q1,q2,r0,r1; reg [1:0] ta,tb; reg [53:0] h; begin
+    acc0=0;acc1=0;acc2=0;
+    for (c=0;c<8;c=c+1) if (c<nc) begin
+      for(j=0;j<27;j=j+1) begin ta=a[c*64+j*2 +:2]; tb=wa0i[c*64+j*2 +:2];
+        va=(ta==0)?-1:(ta==2)?1:0; vb=(tb==0)?-1:(tb==2)?1:0; acc0=acc0+va*vb; end
+      for(j=0;j<27;j=j+1) begin ta=a[c*64+j*2 +:2]; tb=wa1i[c*64+j*2 +:2];
+        va=(ta==0)?-1:(ta==2)?1:0; vb=(tb==0)?-1:(tb==2)?1:0; acc1=acc1+va*vb; end
+      for(j=0;j<27;j=j+1) begin ta=a[c*64+j*2 +:2]; tb=wa2i[c*64+j*2 +:2];
+        va=(ta==0)?-1:(ta==2)?1:0; vb=(tb==0)?-1:(tb==2)?1:0; acc2=acc2+va*vb; end
+    end
+    q0=(acc0>thr)?2:(acc0<-thr)?0:1;
+    q1=(acc1>thr)?2:(acc1<-thr)?0:1;
+    q2=(acc2>thr)?2:(acc2<-thr)?0:1;
+    h = Z; h[1:0]=q0[1:0]; h[3:2]=q1[1:0]; h[5:4]=q2[1:0];
+    d0=0; for(j=0;j<27;j=j+1) begin ta=h[j*2 +:2]; tb=wb0i[j*2 +:2];
+      va=(ta==0)?-1:(ta==2)?1:0; vb=(tb==0)?-1:(tb==2)?1:0; d0=d0+va*vb; end
+    d1=0; for(j=0;j<27;j=j+1) begin ta=h[j*2 +:2]; tb=wb1i[j*2 +:2];
+      va=(ta==0)?-1:(ta==2)?1:0; vb=(tb==0)?-1:(tb==2)?1:0; d1=d1+va*vb; end
+    r0=(d0>thr)?2:(d0<-thr)?0:1;
+    r1=(d1>thr)?2:(d1<-thr)?0:1;
+    refmlp = (r1<<2)|r0; end
+  endfunction
+  reg [7:0] got, exp;
+  task run(input [53:0] av, input [53:0] w0v, input [53:0] w1v, input [53:0] w2v,
+           input [53:0] b0v, input [53:0] b1v, input [31:0] nc, input signed [15:0] thr,
+           input [127:0] nm);
+    begin
+      fill(acts,av); fill(wa0,w0v); fill(wa1,w1v); fill(wa2,w2v);
+      wb0={10'd0,b0v}; wb1={10'd0,b1v};
+      got = dut.mlp2(acts,wa0,wa1,wa2,wb0,wb1,nc,thr);
+      exp = refmlp(acts,wa0,wa1,wa2,wb0,wb1,nc,thr);
+      if (got!==exp) begin fails=fails+1; $display("FAIL %0s got=%0d exp=%0d",nm,got,exp); end
+      else $display("PASS %0s=%0d",nm,got);
+    end
+  endtask
+  initial begin
+    run(P,P,N,P, P,N, 4, 16'sd10, "c1");
+    run(P,P,P,N, N,P, 2, 16'sd5,  "c2");
+    run(Z,Z,Z,Z, Z,Z, 8, 16'sd10, "c3");
+    run(N,P,N,P, P,N, 5, 16'sd7,  "c4");
+    // Discriminating low-threshold case: layer2 dot=+3 > 2 -> both P -> (P<<2)|P = 10.
+    run(P,P,P,P, P,P, 4, 16'sd2,  "c5_thr2");
+    if (got !== 8'd10) begin fails=fails+1; $display("FAIL c5 output not P,P: %0d", got); end
+    if (fails==0) $display("ALL_PASS"); else $display("FAILED %0d", fails);
+    $finish;
+  end
+  BitnetMlp dut(.clk(1'b0), .rst_n(1'b1), .en(1'b1), .ready());
+endmodule
+"#;
+
+#[test]
+fn spec_first_mlp2_two_layer_inference_matches_reference() {
+    if !tool_available("iverilog") || !tool_available("vvp") {
+        eprintln!("SKIP: iverilog/vvp not on PATH; skipping BitNet MLP check");
+        return;
+    }
+
+    let dir = scratch_dir("chk");
+    fs::create_dir_all(&dir).expect("create scratch dir");
+
+    let gen = Command::new(t27c())
+        .arg("gen-verilog")
+        .arg(spec_path())
+        .output()
+        .expect("invoke gen-verilog");
+    assert!(
+        gen.status.success(),
+        "gen-verilog of bitnet_mlp.t27 failed:\n{}",
+        String::from_utf8_lossy(&gen.stderr)
+    );
+    fs::write(dir.join("mlp.v"), &gen.stdout).expect("write mlp.v");
+    fs::write(dir.join("tb.v"), TESTBENCH).expect("write tb.v");
+
+    let vvp_path = dir.join("sim.vvp");
+    let compile = Command::new("iverilog")
+        .args(["-g2012", "-o", vvp_path.to_str().unwrap()])
+        .arg(dir.join("mlp.v"))
+        .arg(dir.join("tb.v"))
+        .output()
+        .expect("invoke iverilog");
+    assert!(
+        compile.status.success(),
+        "iverilog compile failed:\n{}",
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new("vvp").arg(&vvp_path).output().expect("invoke vvp");
+    let stdout = String::from_utf8_lossy(&run.stdout).into_owned();
+    let _ = fs::remove_dir_all(&dir);
+
+    assert!(
+        stdout.contains("ALL_PASS"),
+        "mlp2 two-layer inference did not match the reference:\n{}",
+        stdout
+    );
+    assert!(!stdout.contains("FAIL"), "mlp2 mismatch:\n{}", stdout);
+}

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,3 +1,16 @@
+# NOW — feat: 2-layer spec-first BitNet inference (dot/quantize/repack/dot) (2026-08-06)
+
+Last updated: 2026-08-06
+
+## feat: spec-first 2-layer BitNet inference mlp2 (Closes #1755)
+
+- Branch: `feat/spec-first-bitnet-mlp`
+
+### Что легло
+- `specs/ternary/bitnet_mlp.t27`: `mlp2` chains two layers — layer 1 (3 `neuronN` over the input activations) → `pack3` repacks the 3 output trits into one hidden chunk → layer 2 (2 single-chunk `neuron1`) → 2 packed output trits. New capability = **inter-layer trit repacking** (`pack3`), what a real multi-layer BitNet inference needs. Verified: typecheck 0 err; icarus-simulate 4/4 scalar test blocks; seal 3 backends MATCH; new `tests/bitnet_mlp.rs` cross-checks `mlp2` vs a fully independent 2-layer reference on 5 direct-packed cases incl. a low-threshold case exercising non-Z layer-2 outputs (P,P→10) = ALL_PASS. Runnable spec-first inference path complete: MAC(#1743)→neuron(#1747/#1752)→layer(#1754)→2-layer MLP. No compiler change, no reseal.
+
+---
+
 # NOW — feat: 2-neuron spec-first BitNet layer with packed trit output (2026-08-06)
 
 Last updated: 2026-08-06

--- a/specs/ternary/bitnet_mlp.t27
+++ b/specs/ternary/bitnet_mlp.t27
@@ -1,0 +1,57 @@
+module BitnetMlp;
+fn tmul(ta: u8, tb: u8) -> i8 {
+    if (ta == 1) { return 0; }
+    if (tb == 1) { return 0; }
+    if (ta == tb) { return 1; }
+    return -1;
+}
+fn dot27(a: u64, b: u64) -> i16 {
+    var acc : i16 = 0;
+    var i : u32 = 0;
+    while (i < 27) {
+        var ta : u8 = ((a >> (i << 1)) & 3) as u8;
+        var tb : u8 = ((b >> (i << 1)) & 3) as u8;
+        acc = acc + tmul(ta, tb) as i16;
+        i = i + 1;
+    }
+    return acc;
+}
+fn quantize(v: i16, threshold: i16) -> u8 {
+    if (v > threshold) { return 2; }
+    if (v < -threshold) { return 0; }
+    return 1;
+}
+fn neuronN(acts: [8]u64, weights: [8]u64, nchunks: u32, threshold: i16) -> u8 {
+    var acc : i16 = 0;
+    var c : u32 = 0;
+    while (c < nchunks) {
+        acc = acc + dot27(acts[c], weights[c]);
+        c = c + 1;
+    }
+    return quantize(acc, threshold);
+}
+fn neuron1(act: u64, weight: u64, threshold: i16) -> u8 {
+    return quantize(dot27(act, weight), threshold);
+}
+fn pack3(t0: u8, t1: u8, t2: u8) -> u64 {
+    var z : u64 = 6004799503160661;
+    var cleared : u64 = z & 18446744073709551552;
+    return cleared | (t0 as u64) | ((t1 as u64) << 2) | ((t2 as u64) << 4);
+}
+// 2-layer BitNet inference. Layer 1: 3 neurons over the input activations
+// (l1chunks chunks) -> 3 trits packed into one hidden chunk. Layer 2: 2
+// single-chunk neurons over that hidden chunk -> 2 packed output trits.
+pub fn mlp2(acts: [8]u64, wa0: [8]u64, wa1: [8]u64, wa2: [8]u64, wb0: u64, wb1: u64, l1chunks: u32, threshold: i16) -> u8 {
+    var t0 : u8 = neuronN(acts, wa0, l1chunks, threshold);
+    var t1 : u8 = neuronN(acts, wa1, l1chunks, threshold);
+    var t2 : u8 = neuronN(acts, wa2, l1chunks, threshold);
+    var h : u64 = pack3(t0, t1, t2);
+    var o0 : u8 = neuron1(h, wb0, threshold);
+    var o1 : u8 = neuron1(h, wb1, threshold);
+    return (o1 << 2) | o0;
+}
+test dot27_all_n { assert_eq(dot27(0, 0), 27); }
+test neuron1_p_p { assert_eq(neuron1(12009599006321322, 12009599006321322, 10), 2); }
+test pack3_zzz { assert_eq(pack3(1, 1, 1), 6004799503160661); }
+test quantize_band { assert_eq(quantize(5, 10), 1); }
+endmodule


### PR DESCRIPTION
Chains two spec-first BitNet layers into an end-to-end ternary inference.

Closes #1755

`specs/ternary/bitnet_mlp.t27`:
```
pub fn mlp2(acts: [8]u64, wa0,wa1,wa2: [8]u64, wb0,wb1: u64, l1chunks, threshold) -> u8 {
    var t0 = neuronN(acts, wa0, l1chunks, threshold);   // layer 1: 3 neurons
    var t1 = neuronN(acts, wa1, l1chunks, threshold);
    var t2 = neuronN(acts, wa2, l1chunks, threshold);
    var h  = pack3(t0, t1, t2);                          // repack trits -> hidden chunk
    var o0 = neuron1(h, wb0, threshold);                 // layer 2: 2 single-chunk neurons
    var o1 = neuron1(h, wb1, threshold);
    return (o1 << 2) | o0;
}
```
The new capability is `pack3` — the **inter-layer trit repacking** (layer-1 outputs become layer-2's activation chunk), which a real multi-layer BitNet inference needs. `neuron1` is a single-chunk neuron for layer 2.

### Verification
- `typecheck`: 0 errors; `icarus-simulate`: **4/4** scalar test blocks; `seal`: 3 backends MATCH.
- **New integration test `tests/bitnet_mlp.rs`** — cross-checks `mlp2` against a fully independent 2-layer reference (both layers recomputed from scratch) over **5** direct-packed cases, including a low-threshold case exercising non-Z layer-2 outputs (P,P → 10) = `ALL_PASS`.

Completes a runnable spec-first BitNet inference path: MAC (#1743) → neuron (#1747/#1752) → layer (#1754) → **2-layer MLP**. A ternary-native spec-first RTL inference no competitor (Ternary-NanoCore) has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)