### PR TITLE
feat(ternary): spec-first ternary majority gate (named function, exhaustive)

### DIFF
--- a/.trinity/seals/ternary_BitnetMajority.json
+++ b/.trinity/seals/ternary_BitnetMajority.json
@@ -1,0 +1,11 @@
+{
+  "gen_hash_c": "sha256:e4dc8212def1f46f304cd4bd9cf79c950ec968bcf3e83f3fccf102b08a4da47e",
+  "gen_hash_rust": "sha256:1f782bfcbe261f136574f21436c4d53d1a76a8f3b662bf1962792b7f794a2e27",
+  "gen_hash_verilog": "sha256:5610ca9b5b29790e41365faf16a8f328cca27dac28a03cff7c2d91554376c865",
+  "gen_hash_zig": "sha256:180ce22e06c20bd475e2540002f22432216410f8ba4a141a479d115221ce8652",
+  "module": "BitnetMajority",
+  "ring": 12,
+  "sealed_at": "2026-08-06T09:50:06Z",
+  "spec_hash": "sha256:d855d0a5a89f42c122bb836c092d5105130d587c614961cd96e58b369f48cfdd",
+  "spec_path": "specs/ternary/bitnet_majority.t27"
+}

--- a/bootstrap/tests/bitnet_majority.rs
+++ b/bootstrap/tests/bitnet_majority.rs
@@ -1,0 +1,111 @@
+// ============================================================================
+// Exhaustive check for the spec-first ternary majority gate
+// (specs/ternary/bitnet_majority.t27, function `maj3`): the ternary majority of
+// three trits = sign of (a + b + c), realized as a single BitNet neuron (pack ->
+// dot with all-+1 -> quantize at 0). A recognizable named function computed by
+// the spec-first stack.
+//
+// Drives all 3^3 = 27 input combinations and checks against an independent
+// reference (decode {N=-1,Z=0,P=+1}, sum, sign). Skips without iverilog/vvp.
+// ============================================================================
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn t27c() -> &'static str {
+    env!("CARGO_BIN_EXE_t27c")
+}
+
+fn spec_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("specs")
+        .join("ternary")
+        .join("bitnet_majority.t27")
+}
+
+fn scratch_dir(label: &str) -> PathBuf {
+    let dir = env::temp_dir().join(format!("t27_maj_{}_{}", std::process::id(), label));
+    if dir.exists() {
+        let _ = fs::remove_dir_all(&dir);
+    }
+    dir
+}
+
+fn tool_available(tool: &str) -> bool {
+    Command::new(tool)
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+const TESTBENCH: &str = r#"`timescale 1ns/1ps
+module tb;
+  integer a,b,c,va,vb,vc,s,fails,n; reg [7:0] got,exp;
+  function integer dec(input [7:0] t); begin dec=(t==0)?-1:(t==2)?1:0; end endfunction
+  initial begin
+    fails=0; n=0;
+    for (a=0;a<3;a=a+1) for (b=0;b<3;b=b+1) for (c=0;c<3;c=c+1) begin
+      va=dec(a); vb=dec(b); vc=dec(c); s=va+vb+vc;
+      exp = (s>0)?8'd2:(s<0)?8'd0:8'd1;
+      got = dut.maj3(a[7:0], b[7:0], c[7:0]);
+      n=n+1;
+      if (got!==exp) begin fails=fails+1; $display("FAIL a=%0d b=%0d c=%0d got=%0d exp=%0d",a,b,c,got,exp); end
+    end
+    if (fails==0) $display("ALL_PASS %0d", n); else $display("FAILED %0d/%0d", fails, n);
+    $finish;
+  end
+  BitnetMajority dut(.clk(1'b0), .rst_n(1'b1), .en(1'b1), .ready());
+endmodule
+"#;
+
+#[test]
+fn spec_first_maj3_matches_ternary_majority_exhaustive() {
+    if !tool_available("iverilog") || !tool_available("vvp") {
+        eprintln!("SKIP: iverilog/vvp not on PATH; skipping ternary majority check");
+        return;
+    }
+
+    let dir = scratch_dir("chk");
+    fs::create_dir_all(&dir).expect("create scratch dir");
+
+    let gen = Command::new(t27c())
+        .arg("gen-verilog")
+        .arg(spec_path())
+        .output()
+        .expect("invoke gen-verilog");
+    assert!(
+        gen.status.success(),
+        "gen-verilog of bitnet_majority.t27 failed:\n{}",
+        String::from_utf8_lossy(&gen.stderr)
+    );
+    fs::write(dir.join("maj.v"), &gen.stdout).expect("write maj.v");
+    fs::write(dir.join("tb.v"), TESTBENCH).expect("write tb.v");
+
+    let vvp_path = dir.join("sim.vvp");
+    let compile = Command::new("iverilog")
+        .args(["-g2012", "-o", vvp_path.to_str().unwrap()])
+        .arg(dir.join("maj.v"))
+        .arg(dir.join("tb.v"))
+        .output()
+        .expect("invoke iverilog");
+    assert!(
+        compile.status.success(),
+        "iverilog compile failed:\n{}",
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new("vvp").arg(&vvp_path).output().expect("invoke vvp");
+    let stdout = String::from_utf8_lossy(&run.stdout).into_owned();
+    let _ = fs::remove_dir_all(&dir);
+
+    assert!(
+        stdout.contains("ALL_PASS 27"),
+        "maj3 did not match ternary majority on all 27 inputs:\n{}",
+        stdout
+    );
+    assert!(!stdout.contains("FAIL"), "maj3 mismatch:\n{}", stdout);
+}

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,3 +1,16 @@
+# NOW — feat: spec-first ternary majority gate (named function, exhaustive) (2026-08-06)
+
+Last updated: 2026-08-06
+
+## feat: spec-first ternary majority gate maj3 (Closes #1765)
+
+- Branch: `feat/spec-first-ternary-majority`
+
+### Что легло
+- `specs/ternary/bitnet_majority.t27`: `maj3(a,b,c)` = ternary majority of three trits = sign of (a+b+c), realized as a single BitNet neuron (pack3 → dot27 with an all-+1 weight → quantize at 0). First recognizable *named* function computed by the spec-first stack (not random vectors). Verified: typecheck 0 err; icarus-simulate 7/7 test blocks; seal 3 backends MATCH; new `tests/bitnet_majority.rs` drives **all 27 input combinations** vs an independent sign-of-sum reference = ALL_PASS 27 (exhaustive). No compiler change. **Also filed #1764:** the spec-first `.t27` path is combinational-only — clocked/streaming (Phase 2) needs a compiler clocked-process construct or the hand-written engine; `debug-hir` shows `always_blocks: []`, the AST→HIR lowering never populates them.
+
+---
+
 # NOW — docs: spec-first ternary NN cookbook skill (2026-08-06)
 
 Last updated: 2026-08-06

--- a/specs/ternary/bitnet_majority.t27
+++ b/specs/ternary/bitnet_majority.t27
@@ -1,0 +1,50 @@
+module BitnetMajority;
+// Sign-only ternary multiply of two packed trits {N=0b00, Z=0b01, P=0b10}.
+fn tmul(ta: u8, tb: u8) -> i8 {
+    if (ta == 1) { return 0; }
+    if (tb == 1) { return 0; }
+    if (ta == tb) { return 1; }
+    return -1;
+}
+// 27-trit ternary dot product of two 54-bit packed vectors.
+fn dot27(a: u64, b: u64) -> i16 {
+    var acc : i16 = 0;
+    var i : u32 = 0;
+    while (i < 27) {
+        var ta : u8 = ((a >> (i << 1)) & 3) as u8;
+        var tb : u8 = ((b >> (i << 1)) & 3) as u8;
+        acc = acc + tmul(ta, tb) as i16;
+        i = i + 1;
+    }
+    return acc;
+}
+// Ternary sign/threshold quantizer: v > +t -> P, v < -t -> N, else Z.
+fn quantize(v: i16, threshold: i16) -> u8 {
+    if (v > threshold) { return 2; }
+    if (v < -threshold) { return 0; }
+    return 1;
+}
+// Pack 3 trits into the low 3 lanes of a chunk; the rest are Z.
+fn pack3(t0: u8, t1: u8, t2: u8) -> u64 {
+    var z : u64 = 6004799503160661;
+    var cleared : u64 = z & 18446744073709551552;
+    return cleared | (t0 as u64) | ((t1 as u64) << 2) | ((t2 as u64) << 4);
+}
+// Ternary majority of three trits = sign of (a + b + c), realized as a spec-
+// first single ternary neuron: pack the inputs, dot with an all-+1 weight chunk
+// (so the dot product is exactly a + b + c over the three active lanes), then
+// quantize at threshold 0. A recognizable named function computed by the
+// BitNet stack. Inputs/output are packed trits {N=0, Z=1, P=2}.
+pub fn maj3(a: u8, b: u8, c: u8) -> u8 {
+    var chunk : u64 = pack3(a, b, c);
+    var w_all_p : u64 = 12009599006321322;
+    return quantize(dot27(chunk, w_all_p), 0);
+}
+test maj_p_p_n { assert_eq(maj3(2, 2, 0), 2); }
+test maj_p_n_z { assert_eq(maj3(2, 0, 1), 1); }
+test maj_n_n_p { assert_eq(maj3(0, 0, 2), 0); }
+test maj_p_p_p { assert_eq(maj3(2, 2, 2), 2); }
+test maj_z_z_z { assert_eq(maj3(1, 1, 1), 1); }
+test maj_n_n_n { assert_eq(maj3(0, 0, 0), 0); }
+test maj_p_n_n { assert_eq(maj3(2, 0, 0), 0); }
+endmodule


### PR DESCRIPTION
A recognizable, interpretable function computed by the spec-first ternary stack: `maj3(a,b,c)` = ternary majority of three trits = sign of (a+b+c).

Closes #1765

Realized as a single BitNet neuron: pack the 3 input trits, dot with an all-+1 weight chunk (so the dot product is exactly a+b+c over the active lanes), quantize at threshold 0. Shows the stack computes a meaningful **named** function, not just random vectors.

### Verification
- `typecheck` 0 err; `icarus-simulate` **7/7** test blocks; `seal` 3 backends MATCH.
- **New `tests/bitnet_majority.rs`** drives **all 3^3 = 27** input combinations vs an independent reference (decode {N=-1,Z=0,P=+1}, sum, sign) = `ALL_PASS 27`. Exhaustive.

Related: filed #1764 — the spec-first `.t27` path is combinational-only; clocked/streaming (Phase 2) needs a compiler clocked-process construct or the hand-written engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)