### PR TITLE
feat(ternary): weighted_vote — same neuron, different named function via weights

### DIFF
--- a/.trinity/seals/ternary_BitnetMajority.json
+++ b/.trinity/seals/ternary_BitnetMajority.json
@@ -1,11 +1,11 @@
 {
-  "gen_hash_c": "sha256:e4dc8212def1f46f304cd4bd9cf79c950ec968bcf3e83f3fccf102b08a4da47e",
-  "gen_hash_rust": "sha256:1f782bfcbe261f136574f21436c4d53d1a76a8f3b662bf1962792b7f794a2e27",
-  "gen_hash_verilog": "sha256:5610ca9b5b29790e41365faf16a8f328cca27dac28a03cff7c2d91554376c865",
-  "gen_hash_zig": "sha256:180ce22e06c20bd475e2540002f22432216410f8ba4a141a479d115221ce8652",
+  "gen_hash_c": "sha256:5090f2a9d7c2437b4048df124f103dbb4bdc4001f9ac1522b0d7908c55a4aa61",
+  "gen_hash_rust": "sha256:0aecbf7881ab489731f8802f0c97075fdb7e8f05b4732b792bcfe7d7c2ffa7f6",
+  "gen_hash_verilog": "sha256:cd0d298a95115e721f72acf90753e75a02e3995996a0993cd065df49c349f749",
+  "gen_hash_zig": "sha256:778de2692ae686c5728c60f5d71a70d6546de5d350417164ed2780281c1fa32a",
   "module": "BitnetMajority",
   "ring": 12,
-  "sealed_at": "2026-08-06T09:50:06Z",
-  "spec_hash": "sha256:d855d0a5a89f42c122bb836c092d5105130d587c614961cd96e58b369f48cfdd",
+  "sealed_at": "2026-08-06T09:58:30Z",
+  "spec_hash": "sha256:2eb1e03a4339dec4215b765fe572b95ad02d53bbb971e1d326260b49945620a3",
   "spec_path": "specs/ternary/bitnet_majority.t27"
 }

--- a/bootstrap/tests/bitnet_majority.rs
+++ b/bootstrap/tests/bitnet_majority.rs
@@ -48,12 +48,21 @@ module tb;
   function integer dec(input [7:0] t); begin dec=(t==0)?-1:(t==2)?1:0; end endfunction
   initial begin
     fails=0; n=0;
+    // maj3 = sign(a + b + c)
     for (a=0;a<3;a=a+1) for (b=0;b<3;b=b+1) for (c=0;c<3;c=c+1) begin
       va=dec(a); vb=dec(b); vc=dec(c); s=va+vb+vc;
       exp = (s>0)?8'd2:(s<0)?8'd0:8'd1;
       got = dut.maj3(a[7:0], b[7:0], c[7:0]);
       n=n+1;
-      if (got!==exp) begin fails=fails+1; $display("FAIL a=%0d b=%0d c=%0d got=%0d exp=%0d",a,b,c,got,exp); end
+      if (got!==exp) begin fails=fails+1; $display("FAIL maj3 a=%0d b=%0d c=%0d got=%0d exp=%0d",a,b,c,got,exp); end
+    end
+    // weighted_vote = sign(a + b - c) (weights [+1,+1,-1])
+    for (a=0;a<3;a=a+1) for (b=0;b<3;b=b+1) for (c=0;c<3;c=c+1) begin
+      va=dec(a); vb=dec(b); vc=dec(c); s=va+vb-vc;
+      exp = (s>0)?8'd2:(s<0)?8'd0:8'd1;
+      got = dut.weighted_vote(a[7:0], b[7:0], c[7:0]);
+      n=n+1;
+      if (got!==exp) begin fails=fails+1; $display("FAIL wv a=%0d b=%0d c=%0d got=%0d exp=%0d",a,b,c,got,exp); end
     end
     if (fails==0) $display("ALL_PASS %0d", n); else $display("FAILED %0d/%0d", fails, n);
     $finish;
@@ -63,7 +72,7 @@ endmodule
 "#;
 
 #[test]
-fn spec_first_maj3_matches_ternary_majority_exhaustive() {
+fn spec_first_named_functions_exhaustive() {
     if !tool_available("iverilog") || !tool_available("vvp") {
         eprintln!("SKIP: iverilog/vvp not on PATH; skipping ternary majority check");
         return;
@@ -103,8 +112,8 @@ fn spec_first_maj3_matches_ternary_majority_exhaustive() {
     let _ = fs::remove_dir_all(&dir);
 
     assert!(
-        stdout.contains("ALL_PASS 27"),
-        "maj3 did not match ternary majority on all 27 inputs:\n{}",
+        stdout.contains("ALL_PASS 54"),
+        "maj3 did not match ternary majority on all 27+27 inputs:\n{}",
         stdout
     );
     assert!(!stdout.contains("FAIL"), "maj3 mismatch:\n{}", stdout);

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,3 +1,16 @@
+# NOW — feat: weighted_vote — weights define the function (toward trained model) (2026-08-06)
+
+Last updated: 2026-08-06
+
+## feat: weighted_vote named function (Closes #1767)
+
+- Branch: `feat/spec-first-weighted-vote`
+
+### Что легло
+- Added `weighted_vote(a,b,c)` to `specs/ternary/bitnet_majority.t27`: the SAME single BitNet neuron as `maj3`, but per-input weights `[+1,+1,-1]` make it compute `sign(a+b-c)` instead of `sign(a+b+c)`. Demonstrates the essence of a trained model — **weights define the function, not the topology** (weight P → +input, N → -input). Verified: typecheck 0 err; icarus-simulate 12/12 test blocks (7 maj3 + 5 wv); seal MATCH; `tests/bitnet_majority.rs` now exhaustively checks all 27+27=54 combinations of both functions vs independent references = ALL_PASS 54. No compiler change. Also (this iteration) filed **#1764** with a decomposed plan for the Phase-2 clocked construct — the spec-first path is combinational-only.
+
+---
+
 # NOW — feat: spec-first ternary majority gate (named function, exhaustive) (2026-08-06)
 
 Last updated: 2026-08-06

--- a/specs/ternary/bitnet_majority.t27
+++ b/specs/ternary/bitnet_majority.t27
@@ -40,6 +40,15 @@ pub fn maj3(a: u8, b: u8, c: u8) -> u8 {
     var w_all_p : u64 = 12009599006321322;
     return quantize(dot27(chunk, w_all_p), 0);
 }
+// The SAME single neuron computes a DIFFERENT named function when the weights
+// change -- the essence of a trained model. With per-input weights [+1, +1, -1]
+// it computes sign(a + b - c) (weight P contributes +input, weight N contributes
+// -input). Demonstrates that weights define the function, not the topology.
+pub fn weighted_vote(a: u8, b: u8, c: u8) -> u8 {
+    var chunk : u64 = pack3(a, b, c);
+    var weights : u64 = pack3(2, 2, 0);
+    return quantize(dot27(chunk, weights), 0);
+}
 test maj_p_p_n { assert_eq(maj3(2, 2, 0), 2); }
 test maj_p_n_z { assert_eq(maj3(2, 0, 1), 1); }
 test maj_n_n_p { assert_eq(maj3(0, 0, 2), 0); }
@@ -47,4 +56,10 @@ test maj_p_p_p { assert_eq(maj3(2, 2, 2), 2); }
 test maj_z_z_z { assert_eq(maj3(1, 1, 1), 1); }
 test maj_n_n_n { assert_eq(maj3(0, 0, 0), 0); }
 test maj_p_n_n { assert_eq(maj3(2, 0, 0), 0); }
+// weighted_vote = sign(a + b - c): flipping the 3rd weight to -1 changes the function.
+test wv_p_p_p { assert_eq(weighted_vote(2, 2, 2), 2); }
+test wv_p_z_p { assert_eq(weighted_vote(2, 0, 2), 0); }
+test wv_z_z_z { assert_eq(weighted_vote(1, 1, 1), 1); }
+test wv_p_n_n { assert_eq(weighted_vote(2, 0, 0), 2); }
+test wv_z_z_p { assert_eq(weighted_vote(1, 1, 2), 0); }
 endmodule


### PR DESCRIPTION
Adds `weighted_vote(a,b,c)` to `specs/ternary/bitnet_majority.t27`: the **same single BitNet neuron** as `maj3`, but with per-input weights `[+1,+1,-1]` it computes `sign(a + b - c)` instead of `sign(a + b + c)`.

Closes #1767

Demonstrates the key property of a trained model: **weights define the function, not the topology** (weight P contributes +input, N contributes −input).

### Verification
- `typecheck` 0 err; `icarus-simulate` **12/12** test blocks (7 maj3 + 5 weighted_vote); `seal` 3 backends MATCH.
- `tests/bitnet_majority.rs` now drives **all 27+27 = 54** input combinations of both functions vs independent references (`sign(a+b+c)` and `sign(a+b-c)`) = `ALL_PASS 54`. Exhaustive.

Related: filed #1764 with a decomposed plan for the Phase-2 clocked construct (the spec-first path is combinational-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)