### PR TITLE
feat(ternary): spec-first ternary XOR — a 2-layer net computes what a single neuron cannot

### DIFF
--- a/.trinity/seals/ternary_TernaryXor.json
+++ b/.trinity/seals/ternary_TernaryXor.json
@@ -1,0 +1,11 @@
+{
+  "gen_hash_c": "sha256:8f7c86e3e00ea8429d45fcd15bcc36db8c67f9965900b7fdce513d582ed59bd4",
+  "gen_hash_rust": "sha256:73a27e78d8ad9b8940be151ec8feb20535af9f0cec8261f6b6df1cb5ba2e9e2a",
+  "gen_hash_verilog": "sha256:11781d7a18cb518d7db11a7e579700c6a18ccc6ca52cafdf8d3da03d830ec790",
+  "gen_hash_zig": "sha256:5f370102c3f5441024b042535ae8b832700452963666e62b039f49e30a6697e9",
+  "module": "TernaryXor",
+  "ring": 12,
+  "sealed_at": "2026-08-06T10:06:15Z",
+  "spec_hash": "sha256:55c11f1e34587b8020b7c8af7cad2c1768eda245bc988fc1ea54c698c9e21292",
+  "spec_path": "specs/ternary/ternary_xor.t27"
+}

--- a/bootstrap/tests/ternary_xor.rs
+++ b/bootstrap/tests/ternary_xor.rs
@@ -1,0 +1,121 @@
+// ============================================================================
+// Check for the spec-first ternary XOR (specs/ternary/ternary_xor.t27,
+// `ternary_xor`). XOR is NOT linearly separable, so a single neuron cannot
+// compute it -- this is a genuine 2-layer network. On binary-embedded inputs
+// {N=-1, P=+1} the output must be exact XOR (P if inputs differ, N if match).
+//
+// Drives all 3^2 = 9 (a,b) input combinations and checks against an independent
+// reference that recomputes the same 2-layer construction, and asserts the four
+// binary cases equal true XOR. Skips without iverilog/vvp.
+// ============================================================================
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn t27c() -> &'static str {
+    env!("CARGO_BIN_EXE_t27c")
+}
+
+fn spec_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("specs")
+        .join("ternary")
+        .join("ternary_xor.t27")
+}
+
+fn scratch_dir(label: &str) -> PathBuf {
+    let dir = env::temp_dir().join(format!("t27_xor_{}_{}", std::process::id(), label));
+    if dir.exists() {
+        let _ = fs::remove_dir_all(&dir);
+    }
+    dir
+}
+
+fn tool_available(tool: &str) -> bool {
+    Command::new(tool)
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+const TESTBENCH: &str = r#"`timescale 1ns/1ps
+module tb;
+  integer a,b,va,vb,h1,h2,o,fails,n; reg [7:0] got,exp;
+  function integer dec(input [7:0] t); begin dec=(t==0)?-1:(t==2)?1:0; end endfunction
+  function [7:0] sg(input integer v); begin sg=(v>0)?8'd2:(v<0)?8'd0:8'd1; end endfunction
+  initial begin
+    fails=0; n=0;
+    for (a=0;a<3;a=a+1) for (b=0;b<3;b=b+1) begin
+      va=dec(a); vb=dec(b);
+      // reference: the same 2-layer construction
+      h1 = (va+vb-1 > 0) ? 1 : (va+vb-1 < 0) ? -1 : 0;   // sign(a+b-1)
+      h2 = (va+vb+1 > 0) ? 1 : (va+vb+1 < 0) ? -1 : 0;   // sign(a+b+1)
+      o  = h2 + (-h1) - 1;                                // h2 AND NOT h1
+      exp = sg(o);
+      got = dut.ternary_xor(a[7:0], b[7:0]);
+      n=n+1;
+      if (got!==exp) begin fails=fails+1; $display("FAIL a=%0d b=%0d got=%0d exp=%0d",a,b,got,exp); end
+    end
+    // The four BINARY cases must equal true XOR (differ -> P, match -> N).
+    if (dut.ternary_xor(8'd2,8'd2)!==8'd0) begin fails=fails+1; $display("FAIL xor(P,P)!=N"); end
+    if (dut.ternary_xor(8'd2,8'd0)!==8'd2) begin fails=fails+1; $display("FAIL xor(P,N)!=P"); end
+    if (dut.ternary_xor(8'd0,8'd2)!==8'd2) begin fails=fails+1; $display("FAIL xor(N,P)!=P"); end
+    if (dut.ternary_xor(8'd0,8'd0)!==8'd0) begin fails=fails+1; $display("FAIL xor(N,N)!=N"); end
+    if (fails==0) $display("ALL_PASS %0d", n); else $display("FAILED %0d", fails);
+    $finish;
+  end
+  TernaryXor dut(.clk(1'b0), .rst_n(1'b1), .en(1'b1), .ready());
+endmodule
+"#;
+
+#[test]
+fn spec_first_ternary_xor_is_a_two_layer_xor() {
+    if !tool_available("iverilog") || !tool_available("vvp") {
+        eprintln!("SKIP: iverilog/vvp not on PATH; skipping ternary XOR check");
+        return;
+    }
+
+    let dir = scratch_dir("chk");
+    fs::create_dir_all(&dir).expect("create scratch dir");
+
+    let gen = Command::new(t27c())
+        .arg("gen-verilog")
+        .arg(spec_path())
+        .output()
+        .expect("invoke gen-verilog");
+    assert!(
+        gen.status.success(),
+        "gen-verilog of ternary_xor.t27 failed:\n{}",
+        String::from_utf8_lossy(&gen.stderr)
+    );
+    fs::write(dir.join("xor.v"), &gen.stdout).expect("write xor.v");
+    fs::write(dir.join("tb.v"), TESTBENCH).expect("write tb.v");
+
+    let vvp_path = dir.join("sim.vvp");
+    let compile = Command::new("iverilog")
+        .args(["-g2012", "-o", vvp_path.to_str().unwrap()])
+        .arg(dir.join("xor.v"))
+        .arg(dir.join("tb.v"))
+        .output()
+        .expect("invoke iverilog");
+    assert!(
+        compile.status.success(),
+        "iverilog compile failed:\n{}",
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new("vvp").arg(&vvp_path).output().expect("invoke vvp");
+    let stdout = String::from_utf8_lossy(&run.stdout).into_owned();
+    let _ = fs::remove_dir_all(&dir);
+
+    assert!(
+        stdout.contains("ALL_PASS 9"),
+        "ternary_xor did not match the reference / true XOR:\n{}",
+        stdout
+    );
+    assert!(!stdout.contains("FAIL"), "ternary_xor mismatch:\n{}", stdout);
+}

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,3 +1,16 @@
+# NOW — feat: spec-first ternary XOR (a 2-layer net does what one neuron cannot) (2026-08-06)
+
+Last updated: 2026-08-06
+
+## feat: spec-first ternary XOR (Closes #1769)
+
+- Branch: `feat/spec-first-ternary-xor`
+
+### Что легло
+- `specs/ternary/ternary_xor.t27`: `ternary_xor(a,b)` — the canonical not-linearly-separable function. A single linear neuron cannot compute XOR; this is a genuine 2-layer network with biases (h1=sign(a+b-1) AND-like, h2=sign(a+b+1) OR-like, out=sign(h2-h1-1)). The bias is the neuron's threshold offset — what a trained net learns with the weights. On binary inputs {N,P} the output is exact XOR. Verified: typecheck 0 err; icarus-simulate 4/4; seal MATCH; new `tests/ternary_xor.rs` drives all 9 combos vs an independent 2-layer reference + asserts the 4 binary cases equal true XOR = ALL_PASS 9. A recognizable ML result (perceptron→MLP) from the spec-first ternary stack. Also refined **#1764**: the direct gen-verilog interface is fixed `(clk,rst_n,en,ready)` with no data ports → Phase 2 must go through the HIR path.
+
+---
+
 # NOW — feat: weighted_vote — weights define the function (toward trained model) (2026-08-06)
 
 Last updated: 2026-08-06

--- a/specs/ternary/ternary_xor.t27
+++ b/specs/ternary/ternary_xor.t27
@@ -1,0 +1,60 @@
+module TernaryXor;
+fn tmul(ta: u8, tb: u8) -> i8 {
+    if (ta == 1) { return 0; }
+    if (tb == 1) { return 0; }
+    if (ta == tb) { return 1; }
+    return -1;
+}
+fn dot27(a: u64, b: u64) -> i16 {
+    var acc : i16 = 0;
+    var i : u32 = 0;
+    while (i < 27) {
+        var ta : u8 = ((a >> (i << 1)) & 3) as u8;
+        var tb : u8 = ((b >> (i << 1)) & 3) as u8;
+        acc = acc + tmul(ta, tb) as i16;
+        i = i + 1;
+    }
+    return acc;
+}
+// Sign at zero: v > 0 -> P, v < 0 -> N, else Z.
+fn sign0(v: i16) -> u8 {
+    if (v > 0) { return 2; }
+    if (v < 0) { return 0; }
+    return 1;
+}
+// Trit negate: P<->N, Z fixed.
+fn negate(t: u8) -> u8 {
+    if (t == 2) { return 0; }
+    if (t == 0) { return 2; }
+    return 1;
+}
+// Pack 2 trits into lanes 0,1 of a chunk; the rest are Z.
+fn pack2(t0: u8, t1: u8) -> u64 {
+    var z : u64 = 6004799503160661;
+    var cleared : u64 = z & 18446744073709551600;
+    return cleared | (t0 as u64) | ((t1 as u64) << 2);
+}
+// Biased ternary neuron: sign(dot(x, w) + bias). The bias is the neuron's
+// threshold offset -- what a trained network learns alongside the weights.
+fn bneuron(x: u64, w: u64, bias: i16) -> u8 {
+    return sign0(dot27(x, w) + bias);
+}
+// Ternary XOR over binary-embedded inputs {N=-1, P=+1}: P if the inputs differ,
+// N if they match. XOR is NOT linearly separable -- a single neuron cannot
+// compute it -- so this is a genuine 2-LAYER network:
+//   h1 = sign(a + b - 1)   (AND-like)
+//   h2 = sign(a + b + 1)   (OR-like)
+//   out = sign(h2 + (-h1) - 1)   (h2 AND NOT h1)
+pub fn ternary_xor(a: u8, b: u8) -> u8 {
+    var x : u64 = pack2(a, b);
+    var w_pp : u64 = pack2(2, 2);
+    var h1 : u8 = bneuron(x, w_pp, -1);
+    var h2 : u8 = bneuron(x, w_pp, 1);
+    var hidden : u64 = pack2(h2, negate(h1));
+    return bneuron(hidden, w_pp, -1);
+}
+test xor_p_p { assert_eq(ternary_xor(2, 2), 0); }
+test xor_p_n { assert_eq(ternary_xor(2, 0), 2); }
+test xor_n_p { assert_eq(ternary_xor(0, 2), 2); }
+test xor_n_n { assert_eq(ternary_xor(0, 0), 0); }
+endmodule


### PR DESCRIPTION
`specs/ternary/ternary_xor.t27`: `ternary_xor(a, b)` — the canonical **not-linearly-separable** function. A single linear neuron *cannot* compute XOR; this is a genuine **2-layer** ternary network:
```
h1  = sign(a + b - 1)        # AND-like (bias -1)
h2  = sign(a + b + 1)        # OR-like  (bias +1)
out = sign(h2 + (-h1) - 1)   # h2 AND NOT h1
```
The bias is the neuron's threshold offset — what a trained network learns alongside the weights. On binary-embedded inputs {N=-1, P=+1} the output is exact XOR (P if the inputs differ, N if they match).

Closes #1769

### Verification
- `typecheck` 0 err; `icarus-simulate` **4/4** test blocks; `seal` 3 backends MATCH.
- New `tests/ternary_xor.rs` drives all **3^2 = 9** input combinations vs an independent 2-layer reference, and asserts the four binary cases equal true XOR = `ALL_PASS 9`.

A recognizable ML result — the perceptron→MLP story — computed by the spec-first ternary stack. Also refined #1764 (Phase-2 must go through the HIR path: the direct interface has no data ports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)