### PR TITLE
feat(ternary): spec-first ternary full adder — arithmetic from XOR + majority

### DIFF
--- a/.trinity/seals/ternary_TernaryFullAdder.json
+++ b/.trinity/seals/ternary_TernaryFullAdder.json
@@ -1,0 +1,11 @@
+{
+  "gen_hash_c": "sha256:35768a7ddc4a34a161d8088d14e7b15730561f372c7aac31eebe1af52bdd59e9",
+  "gen_hash_rust": "sha256:c4c34fde067deceb2c139c43f235b4d1a6903e18e6f8ecb6b9e9ace11d37b803",
+  "gen_hash_verilog": "sha256:c1ebcb171446f0bfe4e114c75c0411adb0b01a5f838bd412780abae52a88e210",
+  "gen_hash_zig": "sha256:1881df803366599d752b8c04c16c3d8b7b03b074f85709da267c32aed93c3d8e",
+  "module": "TernaryFullAdder",
+  "ring": 12,
+  "sealed_at": "2026-08-06T10:12:09Z",
+  "spec_hash": "sha256:00f216f43b75c1212b6822d91a11838583aee0a195734419d79855111e19c54c",
+  "spec_path": "specs/ternary/ternary_full_adder.t27"
+}

--- a/bootstrap/tests/ternary_full_adder.rs
+++ b/bootstrap/tests/ternary_full_adder.rs
@@ -1,0 +1,117 @@
+// ============================================================================
+// Check for the spec-first ternary full adder (specs/ternary/ternary_full_adder
+// .t27, `full_adder`). A binary full adder over trit-embedded bits {0 -> N,
+// 1 -> P}: sum = a XOR b XOR cin (composed from the 2-layer XOR), carry =
+// majority(a, b, cin) (a single neuron). Output packs sum in bits[1:0], carry
+// in bits[3:2].
+//
+// Exhaustively drives all 2^3 = 8 binary inputs and checks against the arithmetic
+// full-adder truth table. Skips without iverilog/vvp.
+// ============================================================================
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn t27c() -> &'static str {
+    env!("CARGO_BIN_EXE_t27c")
+}
+
+fn spec_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("specs")
+        .join("ternary")
+        .join("ternary_full_adder.t27")
+}
+
+fn scratch_dir(label: &str) -> PathBuf {
+    let dir = env::temp_dir().join(format!("t27_fa_{}_{}", std::process::id(), label));
+    if dir.exists() {
+        let _ = fs::remove_dir_all(&dir);
+    }
+    dir
+}
+
+fn tool_available(tool: &str) -> bool {
+    Command::new(tool)
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+// For each binary (a,b,cin) with 0->N(code 0), 1->P(code 2): sum_bit = parity,
+// carry_bit = (a+b+cin >= 2). Packed output = (carry_trit << 2) | sum_trit,
+// trit code: 0->0(N), 1->2(P).
+const TESTBENCH: &str = r#"`timescale 1ns/1ps
+module tb;
+  integer a,b,c,s,cy,fails,n; reg [7:0] ea,eb,ec,got,exp,st,ct;
+  initial begin
+    fails=0; n=0;
+    for (a=0;a<2;a=a+1) for (b=0;b<2;b=b+1) for (c=0;c<2;c=c+1) begin
+      s  = (a + b + c) % 2;         // sum bit
+      cy = ((a + b + c) >= 2)?1:0;  // carry bit
+      st = (s==1)?8'd2:8'd0;        // trit code for the sum bit
+      ct = (cy==1)?8'd2:8'd0;       // trit code for the carry bit
+      exp = (ct << 2) | st;
+      ea = (a==1)?8'd2:8'd0; eb = (b==1)?8'd2:8'd0; ec = (c==1)?8'd2:8'd0;
+      got = dut.full_adder(ea, eb, ec);
+      n=n+1;
+      if (got!==exp) begin fails=fails+1; $display("FAIL a=%0d b=%0d c=%0d got=%0d exp=%0d",a,b,c,got,exp); end
+    end
+    if (fails==0) $display("ALL_PASS %0d", n); else $display("FAILED %0d", fails);
+    $finish;
+  end
+  TernaryFullAdder dut(.clk(1'b0), .rst_n(1'b1), .en(1'b1), .ready());
+endmodule
+"#;
+
+#[test]
+fn spec_first_full_adder_matches_binary_truth_table() {
+    if !tool_available("iverilog") || !tool_available("vvp") {
+        eprintln!("SKIP: iverilog/vvp not on PATH; skipping full adder check");
+        return;
+    }
+
+    let dir = scratch_dir("chk");
+    fs::create_dir_all(&dir).expect("create scratch dir");
+
+    let gen = Command::new(t27c())
+        .arg("gen-verilog")
+        .arg(spec_path())
+        .output()
+        .expect("invoke gen-verilog");
+    assert!(
+        gen.status.success(),
+        "gen-verilog of ternary_full_adder.t27 failed:\n{}",
+        String::from_utf8_lossy(&gen.stderr)
+    );
+    fs::write(dir.join("fa.v"), &gen.stdout).expect("write fa.v");
+    fs::write(dir.join("tb.v"), TESTBENCH).expect("write tb.v");
+
+    let vvp_path = dir.join("sim.vvp");
+    let compile = Command::new("iverilog")
+        .args(["-g2012", "-o", vvp_path.to_str().unwrap()])
+        .arg(dir.join("fa.v"))
+        .arg(dir.join("tb.v"))
+        .output()
+        .expect("invoke iverilog");
+    assert!(
+        compile.status.success(),
+        "iverilog compile failed:\n{}",
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new("vvp").arg(&vvp_path).output().expect("invoke vvp");
+    let stdout = String::from_utf8_lossy(&run.stdout).into_owned();
+    let _ = fs::remove_dir_all(&dir);
+
+    assert!(
+        stdout.contains("ALL_PASS 8"),
+        "full_adder did not match the binary full-adder truth table:\n{}",
+        stdout
+    );
+    assert!(!stdout.contains("FAIL"), "full_adder mismatch:\n{}", stdout);
+}

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,3 +1,16 @@
+# NOW — feat: spec-first ternary full adder (arithmetic from XOR + majority) (2026-08-06)
+
+Last updated: 2026-08-06
+
+## feat: spec-first ternary full adder (Closes #1771)
+
+- Branch: `feat/spec-first-full-adder`
+
+### Что легло
+- `specs/ternary/ternary_full_adder.t27`: `full_adder(a,b,cin)` — a binary full adder over trit-embedded bits {0→N,1→P}, built from the spec-first stack: `sum = a XOR b XOR cin` (composed from the 2-layer XOR #1769), `carry = majority(a,b,cin)` (a single neuron #1765), output packs sum[1:0]+carry[3:2]. Extends the stack from classification into **arithmetic** — a real datapath building block composed from already-verified named functions. Verified: typecheck 0 err; icarus-simulate 6/6; seal MATCH; new `tests/ternary_full_adder.rs` exhaustively drives all 2^3=8 binary inputs vs the arithmetic truth table = ALL_PASS 8. No compiler change.
+
+---
+
 # NOW — feat: spec-first ternary XOR (a 2-layer net does what one neuron cannot) (2026-08-06)
 
 Last updated: 2026-08-06

--- a/specs/ternary/ternary_full_adder.t27
+++ b/specs/ternary/ternary_full_adder.t27
@@ -1,0 +1,60 @@
+module TernaryFullAdder;
+// Ternary primitives (binary values embedded as {0 -> N=-1, 1 -> P=+1}).
+fn tmul(ta: u8, tb: u8) -> i8 {
+    if (ta == 1) { return 0; }
+    if (tb == 1) { return 0; }
+    if (ta == tb) { return 1; }
+    return -1;
+}
+fn dot27(a: u64, b: u64) -> i16 {
+    var acc : i16 = 0;
+    var i : u32 = 0;
+    while (i < 27) {
+        var ta : u8 = ((a >> (i << 1)) & 3) as u8;
+        var tb : u8 = ((b >> (i << 1)) & 3) as u8;
+        acc = acc + tmul(ta, tb) as i16;
+        i = i + 1;
+    }
+    return acc;
+}
+fn sign0(v: i16) -> u8 { if (v > 0) { return 2; } if (v < 0) { return 0; } return 1; }
+fn negate(t: u8) -> u8 { if (t == 2) { return 0; } if (t == 0) { return 2; } return 1; }
+fn pack2(t0: u8, t1: u8) -> u64 {
+    var z : u64 = 6004799503160661;
+    var cleared : u64 = z & 18446744073709551600;
+    return cleared | (t0 as u64) | ((t1 as u64) << 2);
+}
+fn pack3(t0: u8, t1: u8, t2: u8) -> u64 {
+    var z : u64 = 6004799503160661;
+    var cleared : u64 = z & 18446744073709551552;
+    return cleared | (t0 as u64) | ((t1 as u64) << 2) | ((t2 as u64) << 4);
+}
+fn bneuron(x: u64, w: u64, bias: i16) -> u8 { return sign0(dot27(x, w) + bias); }
+// XOR of two binary-embedded trits: a 2-layer network (not linearly separable).
+fn xor2(a: u8, b: u8) -> u8 {
+    var x : u64 = pack2(a, b);
+    var w : u64 = pack2(2, 2);
+    var h1 : u8 = bneuron(x, w, -1);
+    var h2 : u8 = bneuron(x, w, 1);
+    return bneuron(pack2(h2, negate(h1)), w, -1);
+}
+// Majority of three trits = sign(a+b+c): a single neuron with all-+1 weights.
+fn maj3(a: u8, b: u8, c: u8) -> u8 {
+    return sign0(dot27(pack3(a, b, c), 12009599006321322));
+}
+// Binary full adder over trit-embedded bits. sum = a XOR b XOR cin (composed
+// from the 2-layer XOR); carry = majority(a, b, cin) (a single neuron). Output
+// packs the two result trits: sum in bits[1:0], carry in bits[3:2]. A real
+// arithmetic building block built entirely from the spec-first ternary stack.
+pub fn full_adder(a: u8, b: u8, cin: u8) -> u8 {
+    var s : u8 = xor2(xor2(a, b), cin);
+    var carry : u8 = maj3(a, b, cin);
+    return (carry << 2) | s;
+}
+test fa_000 { assert_eq(full_adder(0, 0, 0), 0); }
+test fa_100 { assert_eq(full_adder(2, 0, 0), 2); }
+test fa_110 { assert_eq(full_adder(2, 2, 0), 8); }
+test fa_111 { assert_eq(full_adder(2, 2, 2), 10); }
+test fa_011 { assert_eq(full_adder(0, 2, 2), 8); }
+test fa_101 { assert_eq(full_adder(2, 0, 2), 8); }
+endmodule


### PR DESCRIPTION
`specs/ternary/ternary_full_adder.t27`, `full_adder(a, b, cin)`: a binary full adder over trit-embedded bits {0→N, 1→P}, built entirely from the spec-first ternary stack:
- `sum = a XOR b XOR cin` — composed from the **2-layer** XOR (#1769).
- `carry = majority(a, b, cin)` — a **single neuron** with all-+1 weights (#1765).
- output packs sum in bits[1:0], carry in bits[3:2].

Closes #1771

Extends the stack from classification into **arithmetic** — a real datapath building block, composed from already-verified named functions.

### Verification
- `typecheck` 0 err; `icarus-simulate` **6/6** test blocks; `seal` 3 backends MATCH.
- New `tests/ternary_full_adder.rs` exhaustively drives all **2^3 = 8** binary inputs vs the arithmetic full-adder truth table = `ALL_PASS 8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)