### PR TITLE
feat(ternary): spec-first 2-bit ripple-carry adder — multi-bit arithmetic datapath

### DIFF
--- a/.trinity/seals/ternary_TernaryRippleAdder.json
+++ b/.trinity/seals/ternary_TernaryRippleAdder.json
@@ -1,0 +1,11 @@
+{
+  "gen_hash_c": "sha256:09cbb6f37c40ff9bd5cd97d7a76d16e75c493995319e4bf4c3fef078080a87dd",
+  "gen_hash_rust": "sha256:254de9081f9f4ab0de41de147720ee6ea799b66c5aeeb25bb5f98cc2efd360a9",
+  "gen_hash_verilog": "sha256:2920e03dca7532eb70e3b05f7fe535fe078281afdd8c3f96e41d25af6d4dc93c",
+  "gen_hash_zig": "sha256:aa1a85d090bfb79ad4b1804840ce81c533f388e534f7da2f34f79bc30db2da3a",
+  "module": "TernaryRippleAdder",
+  "ring": 12,
+  "sealed_at": "2026-08-06T10:18:12Z",
+  "spec_hash": "sha256:a03b620c1848281acec4fde91e253fa9381ab96636cc11dae51aa83e5dc683ad",
+  "spec_path": "specs/ternary/ternary_ripple_adder.t27"
+}

--- a/bootstrap/tests/ternary_ripple_adder.rs
+++ b/bootstrap/tests/ternary_ripple_adder.rs
@@ -1,0 +1,117 @@
+// ============================================================================
+// Check for the spec-first 2-bit ternary ripple-carry adder
+// (specs/ternary/ternary_ripple_adder.t27, `add2`): two full adders (each
+// XOR + majority) with the carry threaded between them, over trit-embedded
+// binary bits {0 -> N, 1 -> P}. Output packs sum0 in bits[1:0], sum1 in [3:2],
+// carry-out in [5:4]. A real multi-bit arithmetic datapath built entirely from
+// the spec-first ternary stack.
+//
+// Exhaustively drives all 2^4 = 16 (a1a0, b1b0) input pairs and checks against
+// binary addition. Skips without iverilog/vvp.
+// ============================================================================
+
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn t27c() -> &'static str {
+    env!("CARGO_BIN_EXE_t27c")
+}
+
+fn spec_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("specs")
+        .join("ternary")
+        .join("ternary_ripple_adder.t27")
+}
+
+fn scratch_dir(label: &str) -> PathBuf {
+    let dir = env::temp_dir().join(format!("t27_add2_{}_{}", std::process::id(), label));
+    if dir.exists() {
+        let _ = fs::remove_dir_all(&dir);
+    }
+    dir
+}
+
+fn tool_available(tool: &str) -> bool {
+    Command::new(tool)
+        .arg("-V")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+// For each 2-bit a=(a1,a0), b=(b1,b0): s = a + b (0..6). Expected packed trits:
+// (s0?P:N) | (s1?P:N)<<2 | (s2?P:N)<<4, trit code P=2, N=0. Inputs to add2 are
+// trit codes: bit 1 -> 2, bit 0 -> 0.
+const TESTBENCH: &str = r#"`timescale 1ns/1ps
+module tb;
+  integer a0,a1,b0,b1,av,bv,s,s0,s1,s2,fails,n; reg [7:0] got,exp;
+  function [7:0] tc(input integer bit_); begin tc=(bit_==1)?8'd2:8'd0; end endfunction
+  initial begin
+    fails=0; n=0;
+    for (a0=0;a0<2;a0=a0+1) for (a1=0;a1<2;a1=a1+1)
+    for (b0=0;b0<2;b0=b0+1) for (b1=0;b1<2;b1=b1+1) begin
+      av = a1*2 + a0; bv = b1*2 + b0; s = av + bv;
+      s0 = s & 1; s1 = (s >> 1) & 1; s2 = (s >> 2) & 1;
+      exp = tc(s0) | (tc(s1) << 2) | (tc(s2) << 4);
+      got = dut.add2(tc(a0), tc(a1), tc(b0), tc(b1));
+      n=n+1;
+      if (got!==exp) begin fails=fails+1; $display("FAIL a=%0d b=%0d got=%0d exp=%0d",av,bv,got,exp); end
+    end
+    if (fails==0) $display("ALL_PASS %0d", n); else $display("FAILED %0d", fails);
+    $finish;
+  end
+  TernaryRippleAdder dut(.clk(1'b0), .rst_n(1'b1), .en(1'b1), .ready());
+endmodule
+"#;
+
+#[test]
+fn spec_first_add2_matches_binary_addition_exhaustive() {
+    if !tool_available("iverilog") || !tool_available("vvp") {
+        eprintln!("SKIP: iverilog/vvp not on PATH; skipping ripple adder check");
+        return;
+    }
+
+    let dir = scratch_dir("chk");
+    fs::create_dir_all(&dir).expect("create scratch dir");
+
+    let gen = Command::new(t27c())
+        .arg("gen-verilog")
+        .arg(spec_path())
+        .output()
+        .expect("invoke gen-verilog");
+    assert!(
+        gen.status.success(),
+        "gen-verilog of ternary_ripple_adder.t27 failed:\n{}",
+        String::from_utf8_lossy(&gen.stderr)
+    );
+    fs::write(dir.join("add2.v"), &gen.stdout).expect("write add2.v");
+    fs::write(dir.join("tb.v"), TESTBENCH).expect("write tb.v");
+
+    let vvp_path = dir.join("sim.vvp");
+    let compile = Command::new("iverilog")
+        .args(["-g2012", "-o", vvp_path.to_str().unwrap()])
+        .arg(dir.join("add2.v"))
+        .arg(dir.join("tb.v"))
+        .output()
+        .expect("invoke iverilog");
+    assert!(
+        compile.status.success(),
+        "iverilog compile failed:\n{}",
+        String::from_utf8_lossy(&compile.stderr)
+    );
+
+    let run = Command::new("vvp").arg(&vvp_path).output().expect("invoke vvp");
+    let stdout = String::from_utf8_lossy(&run.stdout).into_owned();
+    let _ = fs::remove_dir_all(&dir);
+
+    assert!(
+        stdout.contains("ALL_PASS 16"),
+        "add2 did not match binary addition on all 16 input pairs:\n{}",
+        stdout
+    );
+    assert!(!stdout.contains("FAIL"), "add2 mismatch:\n{}", stdout);
+}

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,3 +1,16 @@
+# NOW — feat: spec-first 2-bit ternary ripple-carry adder (multi-bit datapath) (2026-08-06)
+
+Last updated: 2026-08-06
+
+## feat: spec-first 2-bit ripple-carry adder add2 (Closes #1774)
+
+- Branch: `feat/spec-first-ripple-adder`
+
+### Что легло
+- `specs/ternary/ternary_ripple_adder.t27`: `add2(a0,a1,b0,b1)` — a 2-bit ripple-carry adder = two full adders (each XOR + majority) with the carry threaded between them, over trit-embedded bits {0→N,1→P}. Output packs sum0[1:0]+sum1[3:2]+carry-out[5:4]. Extends the stack from a single full adder into a **multi-bit arithmetic datapath** — the shape of a real ALU, all from the ternary neural primitives. Verified: typecheck 0 err; icarus-simulate 5/5; seal MATCH; new `tests/ternary_ripple_adder.rs` exhaustively drives all 2^4=16 input pairs vs binary addition = ALL_PASS 16. No compiler change. Also filed **#1773**: no cross-module imports → each spec re-defines the primitives (reuse/ergonomics gap for a real library).
+
+---
+
 # NOW — feat: spec-first ternary full adder (arithmetic from XOR + majority) (2026-08-06)
 
 Last updated: 2026-08-06

--- a/specs/ternary/ternary_ripple_adder.t27
+++ b/specs/ternary/ternary_ripple_adder.t27
@@ -1,0 +1,71 @@
+module TernaryRippleAdder;
+// Binary bits are embedded as trits: 0 -> N(0b00), 1 -> P(0b10). All logic is
+// the spec-first ternary stack; add2 is a 2-bit ripple-carry adder = two full
+// adders with the carry threaded between them.
+fn tmul(ta: u8, tb: u8) -> i8 {
+    if (ta == 1) { return 0; }
+    if (tb == 1) { return 0; }
+    if (ta == tb) { return 1; }
+    return -1;
+}
+fn dot27(a: u64, b: u64) -> i16 {
+    var acc : i16 = 0;
+    var i : u32 = 0;
+    while (i < 27) {
+        var ta : u8 = ((a >> (i << 1)) & 3) as u8;
+        var tb : u8 = ((b >> (i << 1)) & 3) as u8;
+        acc = acc + tmul(ta, tb) as i16;
+        i = i + 1;
+    }
+    return acc;
+}
+fn sign0(v: i16) -> u8 { if (v > 0) { return 2; } if (v < 0) { return 0; } return 1; }
+fn negate(t: u8) -> u8 { if (t == 2) { return 0; } if (t == 0) { return 2; } return 1; }
+fn pack2(t0: u8, t1: u8) -> u64 {
+    var z : u64 = 6004799503160661;
+    var cleared : u64 = z & 18446744073709551600;
+    return cleared | (t0 as u64) | ((t1 as u64) << 2);
+}
+fn pack3(t0: u8, t1: u8, t2: u8) -> u64 {
+    var z : u64 = 6004799503160661;
+    var cleared : u64 = z & 18446744073709551552;
+    return cleared | (t0 as u64) | ((t1 as u64) << 2) | ((t2 as u64) << 4);
+}
+fn bneuron(x: u64, w: u64, bias: i16) -> u8 { return sign0(dot27(x, w) + bias); }
+fn xor2(a: u8, b: u8) -> u8 {
+    var x : u64 = pack2(a, b);
+    var w : u64 = pack2(2, 2);
+    var h1 : u8 = bneuron(x, w, -1);
+    var h2 : u8 = bneuron(x, w, 1);
+    return bneuron(pack2(h2, negate(h1)), w, -1);
+}
+fn maj3(a: u8, b: u8, c: u8) -> u8 { return sign0(dot27(pack3(a, b, c), 12009599006321322)); }
+// One full adder: returns the sum trit in bits[1:0] and the carry trit in [3:2].
+fn full_adder(a: u8, b: u8, cin: u8) -> u8 {
+    var s : u8 = xor2(xor2(a, b), cin);
+    var carry : u8 = maj3(a, b, cin);
+    return (carry << 2) | s;
+}
+// 2-bit ripple-carry adder: a = {a1,a0}, b = {b1,b0} (LSB first), each bit a
+// trit-embedded binary. Threads carry0 -> full adder 1. Returns 3 result trits
+// packed: sum0 in [1:0], sum1 in [3:2], carry-out in [5:4].
+pub fn add2(a0: u8, a1: u8, b0: u8, b1: u8) -> u8 {
+    var fa0 : u8 = full_adder(a0, b0, 0);
+    var s0 : u8 = (fa0 & 3) as u8;
+    var c0 : u8 = ((fa0 >> 2) & 3) as u8;
+    var fa1 : u8 = full_adder(a1, b1, c0);
+    var s1 : u8 = (fa1 & 3) as u8;
+    var c1 : u8 = ((fa1 >> 2) & 3) as u8;
+    return (s0 as u64 | ((s1 as u64) << 2) | ((c1 as u64) << 4)) as u8;
+}
+// 0 + 0 = 00, carry 0 -> s0=N,s1=N,c=N -> 0
+test add_0_0 { assert_eq(add2(0, 0, 0, 0), 0); }
+// 1 + 1 = 10 (a=01,b=01): s0=N(0), s1=P(1), c=N -> (0)|(2<<2)|(0<<4)=8
+test add_1_1 { assert_eq(add2(2, 0, 2, 0), 8); }
+// 3 + 1 = 100 (a=11,b=01): s0=N, s1=N, c=P -> (0)|(0<<2)|(2<<4)=32
+test add_3_1 { assert_eq(add2(2, 2, 2, 0), 32); }
+// 3 + 3 = 110 (a=11,b=11): s0=N, s1=P, c=P -> 0|(2<<2)|(2<<4)=8|32=40
+test add_3_3 { assert_eq(add2(2, 2, 2, 2), 40); }
+// 2 + 1 = 011 (a=10,b=01): a0=N,a1=P,b0=P,b1=N -> s0=P, s1=P, c=N -> 2|(2<<2)|0=10
+test add_2_1 { assert_eq(add2(0, 2, 2, 0), 10); }
+endmodule


### PR DESCRIPTION
`specs/ternary/ternary_ripple_adder.t27`, `add2(a0,a1,b0,b1)`: a **2-bit ripple-carry adder** = two full adders (each = XOR + majority) with the carry threaded between them, over trit-embedded binary bits {0→N, 1→P}. Output packs sum0 in bits[1:0], sum1 in [3:2], carry-out in [5:4].

Closes #1774

Extends the spec-first stack from a single full adder into a **multi-bit arithmetic datapath** — the shape of a real ALU, built entirely from the ternary neural primitives.

### Verification
- `typecheck` 0 err; `icarus-simulate` **5/5** test blocks; `seal` 3 backends MATCH.
- New `tests/ternary_ripple_adder.rs` exhaustively drives all **2^4 = 16** input pairs vs binary addition = `ALL_PASS 16`.

Related: filed #1773 (no cross-module imports → each spec re-defines the primitives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)