### PR TITLE
perf: log-depth magsub across all GF-T specs (~2x smaller designs)

### DIFF
--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,6 +1,15 @@
-# NOW — feat: GF-T magsub log-depth optimization (2026-08-07)
+# NOW — perf: GF-T log-depth magsub applied globally (2026-08-07)
 
 Last updated: 2026-08-07
+
+## perf: log-depth magsub across all GF-T specs (~2x smaller) (Refs #1764)
+
+- Applied the proven LOG-DEPTH `magsub` normalize (binary-search priority-encoder 8/4/2/1 + single barrel shift, replacing the 12-iteration linear loop) to ALL 24 GF-T specs that used the old linear magsub
+- Every spec re-verified: all in-spec tests PASS after the swap (bit-identical; the magsub logic was proven identical over 17.4M (hi,lo) pairs)
+- Impact: magsub is the design-size bulk (every `sadd` uses it), so this shrinks EVERY GF-T core ~2x (measured: logistic 16.7M->9.62M, xorpercep 17.86M->9.1M). Brings trainers well under the ~17M openXC7 correctness ceiling
+- Specs touched: sgd_step, train1/2/2relu, hidden2, logistic, classify/classify3/classifier4, axpy, xornet, xortrain, xorpercep/xorpercep3, mlp2/3, layer3/4, neuron_full, bitnet_neuron, signed_dot4/mac, softmax4, softmax_grad4
+- Silicon reconfirmation pending an AX7203 power-cycle (board degraded mid-session)
+- Spec-only; no `gen/`/`coq/` edits; no new `*.sh`; Refs #1764
 
 ## feat: GF-T magsub log-depth normalize (~2x smaller designs) (Refs #1764)
 

--- a/specs/ternary/gft_axpy.t27
+++ b/specs/ternary/gft_axpy.t27
@@ -38,18 +38,16 @@ fn magsub(hi: i32, lo: i32) -> i32 {
     if (d >= 26) { la = 0; sticky = 1; }
     else { var ls : i32 = (512 + lm) << 14; la = ls >> d; if ((ls - (la << d)) > 0) { sticky = 1; } }
     var diff : i32 = hs - la; var off : i32 = ho;
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
+    var cap : i32 = 12; if (off - 1 < cap) { cap = off - 1; } if (cap < 0) { cap = 0; }
+    var sh : i32 = 0;
+    if (diff != 0) {
+        var t : i32 = diff;
+        if (t < 65536) { if (sh + 8 <= cap) { t = t << 8; sh = sh + 8; } }
+        if (t < 1048576) { if (sh + 4 <= cap) { t = t << 4; sh = sh + 4; } }
+        if (t < 4194304) { if (sh + 2 <= cap) { t = t << 2; sh = sh + 2; } }
+        if (t < 8388608) { if (sh + 1 <= cap) { t = t << 1; sh = sh + 1; } }
+    }
+    diff = diff << sh; off = off - sh;
     var q : i32 = diff >> 14; var rem : i32 = diff - (q << 14); var half : i32 = 8192; var mant : i32 = q - 512;
     if (rem > half) { mant = mant + 1; }
     else { if (rem == half) { if (sticky == 1) { mant = mant + 1; } else { if ((q & 1) == 1) { mant = mant + 1; } } } }

--- a/specs/ternary/gft_bitnet_neuron.t27
+++ b/specs/ternary/gft_bitnet_neuron.t27
@@ -40,19 +40,16 @@ fn magsub(hi: i32, lo: i32) -> i32 {
     if (d >= 26) { la = 0; sticky = 1; }
     else { var ls : i32 = (512 + lm) << 14; la = ls >> d; if ((ls - (la << d)) > 0) { sticky = 1; } }
     var diff : i32 = hs - la; var off : i32 = ho;
-    // flat (unrolled) left-normalization -- max ~9 shifts; no loop -> yosys-synthesizable.
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
+    var cap : i32 = 12; if (off - 1 < cap) { cap = off - 1; } if (cap < 0) { cap = 0; }
+    var sh : i32 = 0;
+    if (diff != 0) {
+        var t : i32 = diff;
+        if (t < 65536) { if (sh + 8 <= cap) { t = t << 8; sh = sh + 8; } }
+        if (t < 1048576) { if (sh + 4 <= cap) { t = t << 4; sh = sh + 4; } }
+        if (t < 4194304) { if (sh + 2 <= cap) { t = t << 2; sh = sh + 2; } }
+        if (t < 8388608) { if (sh + 1 <= cap) { t = t << 1; sh = sh + 1; } }
+    }
+    diff = diff << sh; off = off - sh;
     var q : i32 = diff >> 14; var rem : i32 = diff - (q << 14); var half : i32 = 8192; var mant : i32 = q - 512;
     if (rem > half) { mant = mant + 1; }
     else { if (rem == half) { if (sticky == 1) { mant = mant + 1; } else { if ((q & 1) == 1) { mant = mant + 1; } } } }

--- a/specs/ternary/gft_classifier4.t27
+++ b/specs/ternary/gft_classifier4.t27
@@ -40,18 +40,16 @@ fn magsub(hi: i32, lo: i32) -> i32 {
     if (d >= 26) { la = 0; sticky = 1; }
     else { var ls : i32 = (512 + lm) << 14; la = ls >> d; if ((ls - (la << d)) > 0) { sticky = 1; } }
     var diff : i32 = hs - la; var off : i32 = ho;
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
+    var cap : i32 = 12; if (off - 1 < cap) { cap = off - 1; } if (cap < 0) { cap = 0; }
+    var sh : i32 = 0;
+    if (diff != 0) {
+        var t : i32 = diff;
+        if (t < 65536) { if (sh + 8 <= cap) { t = t << 8; sh = sh + 8; } }
+        if (t < 1048576) { if (sh + 4 <= cap) { t = t << 4; sh = sh + 4; } }
+        if (t < 4194304) { if (sh + 2 <= cap) { t = t << 2; sh = sh + 2; } }
+        if (t < 8388608) { if (sh + 1 <= cap) { t = t << 1; sh = sh + 1; } }
+    }
+    diff = diff << sh; off = off - sh;
     var q : i32 = diff >> 14; var rem : i32 = diff - (q << 14); var half : i32 = 8192; var mant : i32 = q - 512;
     if (rem > half) { mant = mant + 1; }
     else { if (rem == half) { if (sticky == 1) { mant = mant + 1; } else { if ((q & 1) == 1) { mant = mant + 1; } } } }

--- a/specs/ternary/gft_classify.t27
+++ b/specs/ternary/gft_classify.t27
@@ -38,18 +38,16 @@ fn magsub(hi: i32, lo: i32) -> i32 {
     if (d >= 26) { la = 0; sticky = 1; }
     else { var ls : i32 = (512 + lm) << 14; la = ls >> d; if ((ls - (la << d)) > 0) { sticky = 1; } }
     var diff : i32 = hs - la; var off : i32 = ho;
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
+    var cap : i32 = 12; if (off - 1 < cap) { cap = off - 1; } if (cap < 0) { cap = 0; }
+    var sh : i32 = 0;
+    if (diff != 0) {
+        var t : i32 = diff;
+        if (t < 65536) { if (sh + 8 <= cap) { t = t << 8; sh = sh + 8; } }
+        if (t < 1048576) { if (sh + 4 <= cap) { t = t << 4; sh = sh + 4; } }
+        if (t < 4194304) { if (sh + 2 <= cap) { t = t << 2; sh = sh + 2; } }
+        if (t < 8388608) { if (sh + 1 <= cap) { t = t << 1; sh = sh + 1; } }
+    }
+    diff = diff << sh; off = off - sh;
     var q : i32 = diff >> 14; var rem : i32 = diff - (q << 14); var half : i32 = 8192; var mant : i32 = q - 512;
     if (rem > half) { mant = mant + 1; }
     else { if (rem == half) { if (sticky == 1) { mant = mant + 1; } else { if ((q & 1) == 1) { mant = mant + 1; } } } }

--- a/specs/ternary/gft_classify3.t27
+++ b/specs/ternary/gft_classify3.t27
@@ -38,18 +38,16 @@ fn magsub(hi: i32, lo: i32) -> i32 {
     if (d >= 26) { la = 0; sticky = 1; }
     else { var ls : i32 = (512 + lm) << 14; la = ls >> d; if ((ls - (la << d)) > 0) { sticky = 1; } }
     var diff : i32 = hs - la; var off : i32 = ho;
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
+    var cap : i32 = 12; if (off - 1 < cap) { cap = off - 1; } if (cap < 0) { cap = 0; }
+    var sh : i32 = 0;
+    if (diff != 0) {
+        var t : i32 = diff;
+        if (t < 65536) { if (sh + 8 <= cap) { t = t << 8; sh = sh + 8; } }
+        if (t < 1048576) { if (sh + 4 <= cap) { t = t << 4; sh = sh + 4; } }
+        if (t < 4194304) { if (sh + 2 <= cap) { t = t << 2; sh = sh + 2; } }
+        if (t < 8388608) { if (sh + 1 <= cap) { t = t << 1; sh = sh + 1; } }
+    }
+    diff = diff << sh; off = off - sh;
     var q : i32 = diff >> 14; var rem : i32 = diff - (q << 14); var half : i32 = 8192; var mant : i32 = q - 512;
     if (rem > half) { mant = mant + 1; }
     else { if (rem == half) { if (sticky == 1) { mant = mant + 1; } else { if ((q & 1) == 1) { mant = mant + 1; } } } }

--- a/specs/ternary/gft_hidden2.t27
+++ b/specs/ternary/gft_hidden2.t27
@@ -38,18 +38,16 @@ fn magsub(hi: i32, lo: i32) -> i32 {
     if (d >= 26) { la = 0; sticky = 1; }
     else { var ls : i32 = (512 + lm) << 14; la = ls >> d; if ((ls - (la << d)) > 0) { sticky = 1; } }
     var diff : i32 = hs - la; var off : i32 = ho;
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
+    var cap : i32 = 12; if (off - 1 < cap) { cap = off - 1; } if (cap < 0) { cap = 0; }
+    var sh : i32 = 0;
+    if (diff != 0) {
+        var t : i32 = diff;
+        if (t < 65536) { if (sh + 8 <= cap) { t = t << 8; sh = sh + 8; } }
+        if (t < 1048576) { if (sh + 4 <= cap) { t = t << 4; sh = sh + 4; } }
+        if (t < 4194304) { if (sh + 2 <= cap) { t = t << 2; sh = sh + 2; } }
+        if (t < 8388608) { if (sh + 1 <= cap) { t = t << 1; sh = sh + 1; } }
+    }
+    diff = diff << sh; off = off - sh;
     var q : i32 = diff >> 14; var rem : i32 = diff - (q << 14); var half : i32 = 8192; var mant : i32 = q - 512;
     if (rem > half) { mant = mant + 1; }
     else { if (rem == half) { if (sticky == 1) { mant = mant + 1; } else { if ((q & 1) == 1) { mant = mant + 1; } } } }

--- a/specs/ternary/gft_layer3.t27
+++ b/specs/ternary/gft_layer3.t27
@@ -40,19 +40,16 @@ fn magsub(hi: i32, lo: i32) -> i32 {
     if (d >= 26) { la = 0; sticky = 1; }
     else { var ls : i32 = (512 + lm) << 14; la = ls >> d; if ((ls - (la << d)) > 0) { sticky = 1; } }
     var diff : i32 = hs - la; var off : i32 = ho;
-    // flat (unrolled) left-normalization -- no loop -> yosys-synthesizable.
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
+    var cap : i32 = 12; if (off - 1 < cap) { cap = off - 1; } if (cap < 0) { cap = 0; }
+    var sh : i32 = 0;
+    if (diff != 0) {
+        var t : i32 = diff;
+        if (t < 65536) { if (sh + 8 <= cap) { t = t << 8; sh = sh + 8; } }
+        if (t < 1048576) { if (sh + 4 <= cap) { t = t << 4; sh = sh + 4; } }
+        if (t < 4194304) { if (sh + 2 <= cap) { t = t << 2; sh = sh + 2; } }
+        if (t < 8388608) { if (sh + 1 <= cap) { t = t << 1; sh = sh + 1; } }
+    }
+    diff = diff << sh; off = off - sh;
     var q : i32 = diff >> 14; var rem : i32 = diff - (q << 14); var half : i32 = 8192; var mant : i32 = q - 512;
     if (rem > half) { mant = mant + 1; }
     else { if (rem == half) { if (sticky == 1) { mant = mant + 1; } else { if ((q & 1) == 1) { mant = mant + 1; } } } }

--- a/specs/ternary/gft_layer4.t27
+++ b/specs/ternary/gft_layer4.t27
@@ -40,19 +40,16 @@ fn magsub(hi: i32, lo: i32) -> i32 {
     if (d >= 26) { la = 0; sticky = 1; }
     else { var ls : i32 = (512 + lm) << 14; la = ls >> d; if ((ls - (la << d)) > 0) { sticky = 1; } }
     var diff : i32 = hs - la; var off : i32 = ho;
-    // flat (unrolled) left-normalization -- no loop -> yosys-synthesizable.
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
+    var cap : i32 = 12; if (off - 1 < cap) { cap = off - 1; } if (cap < 0) { cap = 0; }
+    var sh : i32 = 0;
+    if (diff != 0) {
+        var t : i32 = diff;
+        if (t < 65536) { if (sh + 8 <= cap) { t = t << 8; sh = sh + 8; } }
+        if (t < 1048576) { if (sh + 4 <= cap) { t = t << 4; sh = sh + 4; } }
+        if (t < 4194304) { if (sh + 2 <= cap) { t = t << 2; sh = sh + 2; } }
+        if (t < 8388608) { if (sh + 1 <= cap) { t = t << 1; sh = sh + 1; } }
+    }
+    diff = diff << sh; off = off - sh;
     var q : i32 = diff >> 14; var rem : i32 = diff - (q << 14); var half : i32 = 8192; var mant : i32 = q - 512;
     if (rem > half) { mant = mant + 1; }
     else { if (rem == half) { if (sticky == 1) { mant = mant + 1; } else { if ((q & 1) == 1) { mant = mant + 1; } } } }

--- a/specs/ternary/gft_logistic.t27
+++ b/specs/ternary/gft_logistic.t27
@@ -38,18 +38,16 @@ fn magsub(hi: i32, lo: i32) -> i32 {
     if (d >= 26) { la = 0; sticky = 1; }
     else { var ls : i32 = (512 + lm) << 14; la = ls >> d; if ((ls - (la << d)) > 0) { sticky = 1; } }
     var diff : i32 = hs - la; var off : i32 = ho;
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
+    var cap : i32 = 12; if (off - 1 < cap) { cap = off - 1; } if (cap < 0) { cap = 0; }
+    var sh : i32 = 0;
+    if (diff != 0) {
+        var t : i32 = diff;
+        if (t < 65536) { if (sh + 8 <= cap) { t = t << 8; sh = sh + 8; } }
+        if (t < 1048576) { if (sh + 4 <= cap) { t = t << 4; sh = sh + 4; } }
+        if (t < 4194304) { if (sh + 2 <= cap) { t = t << 2; sh = sh + 2; } }
+        if (t < 8388608) { if (sh + 1 <= cap) { t = t << 1; sh = sh + 1; } }
+    }
+    diff = diff << sh; off = off - sh;
     var q : i32 = diff >> 14; var rem : i32 = diff - (q << 14); var half : i32 = 8192; var mant : i32 = q - 512;
     if (rem > half) { mant = mant + 1; }
     else { if (rem == half) { if (sticky == 1) { mant = mant + 1; } else { if ((q & 1) == 1) { mant = mant + 1; } } } }

--- a/specs/ternary/gft_mlp2.t27
+++ b/specs/ternary/gft_mlp2.t27
@@ -40,18 +40,16 @@ fn magsub(hi: i32, lo: i32) -> i32 {
     if (d >= 26) { la = 0; sticky = 1; }
     else { var ls : i32 = (512 + lm) << 14; la = ls >> d; if ((ls - (la << d)) > 0) { sticky = 1; } }
     var diff : i32 = hs - la; var off : i32 = ho;
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
+    var cap : i32 = 12; if (off - 1 < cap) { cap = off - 1; } if (cap < 0) { cap = 0; }
+    var sh : i32 = 0;
+    if (diff != 0) {
+        var t : i32 = diff;
+        if (t < 65536) { if (sh + 8 <= cap) { t = t << 8; sh = sh + 8; } }
+        if (t < 1048576) { if (sh + 4 <= cap) { t = t << 4; sh = sh + 4; } }
+        if (t < 4194304) { if (sh + 2 <= cap) { t = t << 2; sh = sh + 2; } }
+        if (t < 8388608) { if (sh + 1 <= cap) { t = t << 1; sh = sh + 1; } }
+    }
+    diff = diff << sh; off = off - sh;
     var q : i32 = diff >> 14; var rem : i32 = diff - (q << 14); var half : i32 = 8192; var mant : i32 = q - 512;
     if (rem > half) { mant = mant + 1; }
     else { if (rem == half) { if (sticky == 1) { mant = mant + 1; } else { if ((q & 1) == 1) { mant = mant + 1; } } } }

--- a/specs/ternary/gft_mlp3.t27
+++ b/specs/ternary/gft_mlp3.t27
@@ -42,18 +42,16 @@ fn magsub(hi: i32, lo: i32) -> i32 {
     if (d >= 26) { la = 0; sticky = 1; }
     else { var ls : i32 = (512 + lm) << 14; la = ls >> d; if ((ls - (la << d)) > 0) { sticky = 1; } }
     var diff : i32 = hs - la; var off : i32 = ho;
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
+    var cap : i32 = 12; if (off - 1 < cap) { cap = off - 1; } if (cap < 0) { cap = 0; }
+    var sh : i32 = 0;
+    if (diff != 0) {
+        var t : i32 = diff;
+        if (t < 65536) { if (sh + 8 <= cap) { t = t << 8; sh = sh + 8; } }
+        if (t < 1048576) { if (sh + 4 <= cap) { t = t << 4; sh = sh + 4; } }
+        if (t < 4194304) { if (sh + 2 <= cap) { t = t << 2; sh = sh + 2; } }
+        if (t < 8388608) { if (sh + 1 <= cap) { t = t << 1; sh = sh + 1; } }
+    }
+    diff = diff << sh; off = off - sh;
     var q : i32 = diff >> 14; var rem : i32 = diff - (q << 14); var half : i32 = 8192; var mant : i32 = q - 512;
     if (rem > half) { mant = mant + 1; }
     else { if (rem == half) { if (sticky == 1) { mant = mant + 1; } else { if ((q & 1) == 1) { mant = mant + 1; } } } }

--- a/specs/ternary/gft_neuron_full.t27
+++ b/specs/ternary/gft_neuron_full.t27
@@ -38,19 +38,16 @@ fn magsub(hi: i32, lo: i32) -> i32 {
     if (d >= 26) { la = 0; sticky = 1; }
     else { var ls : i32 = (512 + lm) << 14; la = ls >> d; if ((ls - (la << d)) > 0) { sticky = 1; } }
     var diff : i32 = hs - la; var off : i32 = ho;
-    // flat (unrolled) left-normalization -- no loop -> yosys-synthesizable.
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
+    var cap : i32 = 12; if (off - 1 < cap) { cap = off - 1; } if (cap < 0) { cap = 0; }
+    var sh : i32 = 0;
+    if (diff != 0) {
+        var t : i32 = diff;
+        if (t < 65536) { if (sh + 8 <= cap) { t = t << 8; sh = sh + 8; } }
+        if (t < 1048576) { if (sh + 4 <= cap) { t = t << 4; sh = sh + 4; } }
+        if (t < 4194304) { if (sh + 2 <= cap) { t = t << 2; sh = sh + 2; } }
+        if (t < 8388608) { if (sh + 1 <= cap) { t = t << 1; sh = sh + 1; } }
+    }
+    diff = diff << sh; off = off - sh;
     var q : i32 = diff >> 14; var rem : i32 = diff - (q << 14); var half : i32 = 8192; var mant : i32 = q - 512;
     if (rem > half) { mant = mant + 1; }
     else { if (rem == half) { if (sticky == 1) { mant = mant + 1; } else { if ((q & 1) == 1) { mant = mant + 1; } } } }

--- a/specs/ternary/gft_sgd_step.t27
+++ b/specs/ternary/gft_sgd_step.t27
@@ -38,18 +38,16 @@ fn magsub(hi: i32, lo: i32) -> i32 {
     if (d >= 26) { la = 0; sticky = 1; }
     else { var ls : i32 = (512 + lm) << 14; la = ls >> d; if ((ls - (la << d)) > 0) { sticky = 1; } }
     var diff : i32 = hs - la; var off : i32 = ho;
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
+    var cap : i32 = 12; if (off - 1 < cap) { cap = off - 1; } if (cap < 0) { cap = 0; }
+    var sh : i32 = 0;
+    if (diff != 0) {
+        var t : i32 = diff;
+        if (t < 65536) { if (sh + 8 <= cap) { t = t << 8; sh = sh + 8; } }
+        if (t < 1048576) { if (sh + 4 <= cap) { t = t << 4; sh = sh + 4; } }
+        if (t < 4194304) { if (sh + 2 <= cap) { t = t << 2; sh = sh + 2; } }
+        if (t < 8388608) { if (sh + 1 <= cap) { t = t << 1; sh = sh + 1; } }
+    }
+    diff = diff << sh; off = off - sh;
     var q : i32 = diff >> 14; var rem : i32 = diff - (q << 14); var half : i32 = 8192; var mant : i32 = q - 512;
     if (rem > half) { mant = mant + 1; }
     else { if (rem == half) { if (sticky == 1) { mant = mant + 1; } else { if ((q & 1) == 1) { mant = mant + 1; } } } }

--- a/specs/ternary/gft_signed_dot4.t27
+++ b/specs/ternary/gft_signed_dot4.t27
@@ -50,19 +50,16 @@ fn magsub(hi: i32, lo: i32) -> i32 {
     if (d >= 26) { la = 0; sticky = 1; }
     else { var ls : i32 = (512 + lm) << 14; la = ls >> d; if ((ls - (la << d)) > 0) { sticky = 1; } }
     var diff : i32 = hs - la; var off : i32 = ho;
-    // flat (unrolled) left-normalization -- max ~9 shifts; no loop -> yosys-synthesizable.
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
+    var cap : i32 = 12; if (off - 1 < cap) { cap = off - 1; } if (cap < 0) { cap = 0; }
+    var sh : i32 = 0;
+    if (diff != 0) {
+        var t : i32 = diff;
+        if (t < 65536) { if (sh + 8 <= cap) { t = t << 8; sh = sh + 8; } }
+        if (t < 1048576) { if (sh + 4 <= cap) { t = t << 4; sh = sh + 4; } }
+        if (t < 4194304) { if (sh + 2 <= cap) { t = t << 2; sh = sh + 2; } }
+        if (t < 8388608) { if (sh + 1 <= cap) { t = t << 1; sh = sh + 1; } }
+    }
+    diff = diff << sh; off = off - sh;
     var q : i32 = diff >> 14; var rem : i32 = diff - (q << 14); var half : i32 = 8192; var mant : i32 = q - 512;
     if (rem > half) { mant = mant + 1; }
     else { if (rem == half) { if (sticky == 1) { mant = mant + 1; } else { if ((q & 1) == 1) { mant = mant + 1; } } } }

--- a/specs/ternary/gft_signed_mac.t27
+++ b/specs/ternary/gft_signed_mac.t27
@@ -72,40 +72,24 @@ fn magadd(a: i32, b: i32) -> i32 {
 // --- RNE magnitude subtract, hi >= lo. Returns 0 on exact cancellation. G=14 guard bits. ---
 fn magsub(hi: i32, lo: i32) -> i32 {
     if (hi == lo) { return 0; }
-    var ho : i32 = hi >> 9;
-    var hm : i32 = hi & 511;
-    var lo_o : i32 = lo >> 9;
-    var lm : i32 = lo & 511;
-    var d : i32 = ho - lo_o;
-    var hs : i32 = (512 + hm) << 14;
-    var la : i32 = 0;
-    var sticky : i32 = 0;
+    var ho : i32 = hi >> 9; var hm : i32 = hi & 511;
+    var lo_o : i32 = lo >> 9; var lm : i32 = lo & 511;
+    var d : i32 = ho - lo_o; var hs : i32 = (512 + hm) << 14;
+    var la : i32 = 0; var sticky : i32 = 0;
     if (d >= 26) { la = 0; sticky = 1; }
-    else {
-        var ls : i32 = (512 + lm) << 14;
-        la = ls >> d;
-        if ((ls - (la << d)) > 0) { sticky = 1; }
+    else { var ls : i32 = (512 + lm) << 14; la = ls >> d; if ((ls - (la << d)) > 0) { sticky = 1; } }
+    var diff : i32 = hs - la; var off : i32 = ho;
+    var cap : i32 = 12; if (off - 1 < cap) { cap = off - 1; } if (cap < 0) { cap = 0; }
+    var sh : i32 = 0;
+    if (diff != 0) {
+        var t : i32 = diff;
+        if (t < 65536) { if (sh + 8 <= cap) { t = t << 8; sh = sh + 8; } }
+        if (t < 1048576) { if (sh + 4 <= cap) { t = t << 4; sh = sh + 4; } }
+        if (t < 4194304) { if (sh + 2 <= cap) { t = t << 2; sh = sh + 2; } }
+        if (t < 8388608) { if (sh + 1 <= cap) { t = t << 1; sh = sh + 1; } }
     }
-    var diff : i32 = hs - la;
-    var off : i32 = ho;
-    // left-normalize into [512<<14, 1024<<14); bounded (max ~9 shifts).
-    // flat (unrolled) left-normalization -- no loop -> yosys-synthesizable.
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    var q : i32 = diff >> 14;
-    var rem : i32 = diff - (q << 14);
-    var half : i32 = 8192;
-    var mant : i32 = q - 512;
+    diff = diff << sh; off = off - sh;
+    var q : i32 = diff >> 14; var rem : i32 = diff - (q << 14); var half : i32 = 8192; var mant : i32 = q - 512;
     if (rem > half) { mant = mant + 1; }
     else { if (rem == half) { if (sticky == 1) { mant = mant + 1; } else { if ((q & 1) == 1) { mant = mant + 1; } } } }
     if (mant >= 512) { mant = 0; off = off + 1; if (off >= 80) { off = 80; } }

--- a/specs/ternary/gft_softmax4.t27
+++ b/specs/ternary/gft_softmax4.t27
@@ -39,18 +39,16 @@ fn magsub(hi: i32, lo: i32) -> i32 {
     if (d >= 26) { la = 0; sticky = 1; }
     else { var ls : i32 = (512 + lm) << 14; la = ls >> d; if ((ls - (la << d)) > 0) { sticky = 1; } }
     var diff : i32 = hs - la; var off : i32 = ho;
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
+    var cap : i32 = 12; if (off - 1 < cap) { cap = off - 1; } if (cap < 0) { cap = 0; }
+    var sh : i32 = 0;
+    if (diff != 0) {
+        var t : i32 = diff;
+        if (t < 65536) { if (sh + 8 <= cap) { t = t << 8; sh = sh + 8; } }
+        if (t < 1048576) { if (sh + 4 <= cap) { t = t << 4; sh = sh + 4; } }
+        if (t < 4194304) { if (sh + 2 <= cap) { t = t << 2; sh = sh + 2; } }
+        if (t < 8388608) { if (sh + 1 <= cap) { t = t << 1; sh = sh + 1; } }
+    }
+    diff = diff << sh; off = off - sh;
     var q : i32 = diff >> 14; var rem : i32 = diff - (q << 14); var half : i32 = 8192; var mant : i32 = q - 512;
     if (rem > half) { mant = mant + 1; }
     else { if (rem == half) { if (sticky == 1) { mant = mant + 1; } else { if ((q & 1) == 1) { mant = mant + 1; } } } }

--- a/specs/ternary/gft_softmax_grad4.t27
+++ b/specs/ternary/gft_softmax_grad4.t27
@@ -38,18 +38,16 @@ fn magsub(hi: i32, lo: i32) -> i32 {
     if (d >= 26) { la = 0; sticky = 1; }
     else { var ls : i32 = (512 + lm) << 14; la = ls >> d; if ((ls - (la << d)) > 0) { sticky = 1; } }
     var diff : i32 = hs - la; var off : i32 = ho;
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
+    var cap : i32 = 12; if (off - 1 < cap) { cap = off - 1; } if (cap < 0) { cap = 0; }
+    var sh : i32 = 0;
+    if (diff != 0) {
+        var t : i32 = diff;
+        if (t < 65536) { if (sh + 8 <= cap) { t = t << 8; sh = sh + 8; } }
+        if (t < 1048576) { if (sh + 4 <= cap) { t = t << 4; sh = sh + 4; } }
+        if (t < 4194304) { if (sh + 2 <= cap) { t = t << 2; sh = sh + 2; } }
+        if (t < 8388608) { if (sh + 1 <= cap) { t = t << 1; sh = sh + 1; } }
+    }
+    diff = diff << sh; off = off - sh;
     var q : i32 = diff >> 14; var rem : i32 = diff - (q << 14); var half : i32 = 8192; var mant : i32 = q - 512;
     if (rem > half) { mant = mant + 1; }
     else { if (rem == half) { if (sticky == 1) { mant = mant + 1; } else { if ((q & 1) == 1) { mant = mant + 1; } } } }

--- a/specs/ternary/gft_train1.t27
+++ b/specs/ternary/gft_train1.t27
@@ -38,18 +38,16 @@ fn magsub(hi: i32, lo: i32) -> i32 {
     if (d >= 26) { la = 0; sticky = 1; }
     else { var ls : i32 = (512 + lm) << 14; la = ls >> d; if ((ls - (la << d)) > 0) { sticky = 1; } }
     var diff : i32 = hs - la; var off : i32 = ho;
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
+    var cap : i32 = 12; if (off - 1 < cap) { cap = off - 1; } if (cap < 0) { cap = 0; }
+    var sh : i32 = 0;
+    if (diff != 0) {
+        var t : i32 = diff;
+        if (t < 65536) { if (sh + 8 <= cap) { t = t << 8; sh = sh + 8; } }
+        if (t < 1048576) { if (sh + 4 <= cap) { t = t << 4; sh = sh + 4; } }
+        if (t < 4194304) { if (sh + 2 <= cap) { t = t << 2; sh = sh + 2; } }
+        if (t < 8388608) { if (sh + 1 <= cap) { t = t << 1; sh = sh + 1; } }
+    }
+    diff = diff << sh; off = off - sh;
     var q : i32 = diff >> 14; var rem : i32 = diff - (q << 14); var half : i32 = 8192; var mant : i32 = q - 512;
     if (rem > half) { mant = mant + 1; }
     else { if (rem == half) { if (sticky == 1) { mant = mant + 1; } else { if ((q & 1) == 1) { mant = mant + 1; } } } }

--- a/specs/ternary/gft_train2.t27
+++ b/specs/ternary/gft_train2.t27
@@ -38,18 +38,16 @@ fn magsub(hi: i32, lo: i32) -> i32 {
     if (d >= 26) { la = 0; sticky = 1; }
     else { var ls : i32 = (512 + lm) << 14; la = ls >> d; if ((ls - (la << d)) > 0) { sticky = 1; } }
     var diff : i32 = hs - la; var off : i32 = ho;
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
+    var cap : i32 = 12; if (off - 1 < cap) { cap = off - 1; } if (cap < 0) { cap = 0; }
+    var sh : i32 = 0;
+    if (diff != 0) {
+        var t : i32 = diff;
+        if (t < 65536) { if (sh + 8 <= cap) { t = t << 8; sh = sh + 8; } }
+        if (t < 1048576) { if (sh + 4 <= cap) { t = t << 4; sh = sh + 4; } }
+        if (t < 4194304) { if (sh + 2 <= cap) { t = t << 2; sh = sh + 2; } }
+        if (t < 8388608) { if (sh + 1 <= cap) { t = t << 1; sh = sh + 1; } }
+    }
+    diff = diff << sh; off = off - sh;
     var q : i32 = diff >> 14; var rem : i32 = diff - (q << 14); var half : i32 = 8192; var mant : i32 = q - 512;
     if (rem > half) { mant = mant + 1; }
     else { if (rem == half) { if (sticky == 1) { mant = mant + 1; } else { if ((q & 1) == 1) { mant = mant + 1; } } } }

--- a/specs/ternary/gft_train2relu.t27
+++ b/specs/ternary/gft_train2relu.t27
@@ -38,18 +38,16 @@ fn magsub(hi: i32, lo: i32) -> i32 {
     if (d >= 26) { la = 0; sticky = 1; }
     else { var ls : i32 = (512 + lm) << 14; la = ls >> d; if ((ls - (la << d)) > 0) { sticky = 1; } }
     var diff : i32 = hs - la; var off : i32 = ho;
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
+    var cap : i32 = 12; if (off - 1 < cap) { cap = off - 1; } if (cap < 0) { cap = 0; }
+    var sh : i32 = 0;
+    if (diff != 0) {
+        var t : i32 = diff;
+        if (t < 65536) { if (sh + 8 <= cap) { t = t << 8; sh = sh + 8; } }
+        if (t < 1048576) { if (sh + 4 <= cap) { t = t << 4; sh = sh + 4; } }
+        if (t < 4194304) { if (sh + 2 <= cap) { t = t << 2; sh = sh + 2; } }
+        if (t < 8388608) { if (sh + 1 <= cap) { t = t << 1; sh = sh + 1; } }
+    }
+    diff = diff << sh; off = off - sh;
     var q : i32 = diff >> 14; var rem : i32 = diff - (q << 14); var half : i32 = 8192; var mant : i32 = q - 512;
     if (rem > half) { mant = mant + 1; }
     else { if (rem == half) { if (sticky == 1) { mant = mant + 1; } else { if ((q & 1) == 1) { mant = mant + 1; } } } }

--- a/specs/ternary/gft_xornet.t27
+++ b/specs/ternary/gft_xornet.t27
@@ -38,18 +38,16 @@ fn magsub(hi: i32, lo: i32) -> i32 {
     if (d >= 26) { la = 0; sticky = 1; }
     else { var ls : i32 = (512 + lm) << 14; la = ls >> d; if ((ls - (la << d)) > 0) { sticky = 1; } }
     var diff : i32 = hs - la; var off : i32 = ho;
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
+    var cap : i32 = 12; if (off - 1 < cap) { cap = off - 1; } if (cap < 0) { cap = 0; }
+    var sh : i32 = 0;
+    if (diff != 0) {
+        var t : i32 = diff;
+        if (t < 65536) { if (sh + 8 <= cap) { t = t << 8; sh = sh + 8; } }
+        if (t < 1048576) { if (sh + 4 <= cap) { t = t << 4; sh = sh + 4; } }
+        if (t < 4194304) { if (sh + 2 <= cap) { t = t << 2; sh = sh + 2; } }
+        if (t < 8388608) { if (sh + 1 <= cap) { t = t << 1; sh = sh + 1; } }
+    }
+    diff = diff << sh; off = off - sh;
     var q : i32 = diff >> 14; var rem : i32 = diff - (q << 14); var half : i32 = 8192; var mant : i32 = q - 512;
     if (rem > half) { mant = mant + 1; }
     else { if (rem == half) { if (sticky == 1) { mant = mant + 1; } else { if ((q & 1) == 1) { mant = mant + 1; } } } }

--- a/specs/ternary/gft_xorpercep.t27
+++ b/specs/ternary/gft_xorpercep.t27
@@ -38,18 +38,16 @@ fn magsub(hi: i32, lo: i32) -> i32 {
     if (d >= 26) { la = 0; sticky = 1; }
     else { var ls : i32 = (512 + lm) << 14; la = ls >> d; if ((ls - (la << d)) > 0) { sticky = 1; } }
     var diff : i32 = hs - la; var off : i32 = ho;
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
+    var cap : i32 = 12; if (off - 1 < cap) { cap = off - 1; } if (cap < 0) { cap = 0; }
+    var sh : i32 = 0;
+    if (diff != 0) {
+        var t : i32 = diff;
+        if (t < 65536) { if (sh + 8 <= cap) { t = t << 8; sh = sh + 8; } }
+        if (t < 1048576) { if (sh + 4 <= cap) { t = t << 4; sh = sh + 4; } }
+        if (t < 4194304) { if (sh + 2 <= cap) { t = t << 2; sh = sh + 2; } }
+        if (t < 8388608) { if (sh + 1 <= cap) { t = t << 1; sh = sh + 1; } }
+    }
+    diff = diff << sh; off = off - sh;
     var q : i32 = diff >> 14; var rem : i32 = diff - (q << 14); var half : i32 = 8192; var mant : i32 = q - 512;
     if (rem > half) { mant = mant + 1; }
     else { if (rem == half) { if (sticky == 1) { mant = mant + 1; } else { if ((q & 1) == 1) { mant = mant + 1; } } } }

--- a/specs/ternary/gft_xorpercep3.t27
+++ b/specs/ternary/gft_xorpercep3.t27
@@ -38,18 +38,16 @@ fn magsub(hi: i32, lo: i32) -> i32 {
     if (d >= 26) { la = 0; sticky = 1; }
     else { var ls : i32 = (512 + lm) << 14; la = ls >> d; if ((ls - (la << d)) > 0) { sticky = 1; } }
     var diff : i32 = hs - la; var off : i32 = ho;
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
+    var cap : i32 = 12; if (off - 1 < cap) { cap = off - 1; } if (cap < 0) { cap = 0; }
+    var sh : i32 = 0;
+    if (diff != 0) {
+        var t : i32 = diff;
+        if (t < 65536) { if (sh + 8 <= cap) { t = t << 8; sh = sh + 8; } }
+        if (t < 1048576) { if (sh + 4 <= cap) { t = t << 4; sh = sh + 4; } }
+        if (t < 4194304) { if (sh + 2 <= cap) { t = t << 2; sh = sh + 2; } }
+        if (t < 8388608) { if (sh + 1 <= cap) { t = t << 1; sh = sh + 1; } }
+    }
+    diff = diff << sh; off = off - sh;
     var q : i32 = diff >> 14; var rem : i32 = diff - (q << 14); var half : i32 = 8192; var mant : i32 = q - 512;
     if (rem > half) { mant = mant + 1; }
     else { if (rem == half) { if (sticky == 1) { mant = mant + 1; } else { if ((q & 1) == 1) { mant = mant + 1; } } } }

--- a/specs/ternary/gft_xortrain.t27
+++ b/specs/ternary/gft_xortrain.t27
@@ -38,18 +38,16 @@ fn magsub(hi: i32, lo: i32) -> i32 {
     if (d >= 26) { la = 0; sticky = 1; }
     else { var ls : i32 = (512 + lm) << 14; la = ls >> d; if ((ls - (la << d)) > 0) { sticky = 1; } }
     var diff : i32 = hs - la; var off : i32 = ho;
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
-    if (diff < 8388608) { if (off > 1) { diff = diff << 1; off = off - 1; } }
+    var cap : i32 = 12; if (off - 1 < cap) { cap = off - 1; } if (cap < 0) { cap = 0; }
+    var sh : i32 = 0;
+    if (diff != 0) {
+        var t : i32 = diff;
+        if (t < 65536) { if (sh + 8 <= cap) { t = t << 8; sh = sh + 8; } }
+        if (t < 1048576) { if (sh + 4 <= cap) { t = t << 4; sh = sh + 4; } }
+        if (t < 4194304) { if (sh + 2 <= cap) { t = t << 2; sh = sh + 2; } }
+        if (t < 8388608) { if (sh + 1 <= cap) { t = t << 1; sh = sh + 1; } }
+    }
+    diff = diff << sh; off = off - sh;
     var q : i32 = diff >> 14; var rem : i32 = diff - (q << 14); var half : i32 = 8192; var mant : i32 = q - 512;
     if (rem > half) { mant = mant + 1; }
     else { if (rem == half) { if (sticky == 1) { mant = mant + 1; } else { if ((q & 1) == 1) { mant = mant + 1; } } } }


### PR DESCRIPTION
Applied the proven log-depth magsub normalize (binary-search priority-encoder 8/4/2/1 + single barrel shift, replacing the 12-iteration linear loop) to all 24 GF-T specs. Every spec re-verified: all in-spec tests PASS (bit-identical; magsub proven identical over 17.4M (hi,lo) pairs). magsub is the design-size bulk, so this shrinks every GF-T core ~2x: logistic 16.7M->9.62M, xorpercep 17.86M->9.1M — under the ~17M correctness ceiling. Silicon reconfirmation pending an AX7203 power-cycle. docs/NOW.md updated. Refs #1764