### PR TITLE
ci: add yosys synth_xilinx check to the emit bit-exact gate

### DIFF
--- a/.github/workflows/emit-bitexact-gate.yml
+++ b/.github/workflows/emit-bitexact-gate.yml
@@ -4,9 +4,11 @@ name: Emit Bit-Exact Gate (CI-02)
 # microsequencer RTL must stay bit-exact to the Python GF-T model over a full
 # training run (forward + backprop + weight update). Regenerates the GF-T cores
 # fresh from their .t27 specs (per L2 GENERATION, gen/ is never hand-committed),
-# emits the microsequencer for several hidden widths, and cross-checks yout u32
-# per step in Icarus Verilog. Any future change that breaks spec->RTL equivalence
-# fails here instead of silently miscomputing on silicon.
+# emits the microsequencer for several topologies, and cross-checks every output
+# per step in Icarus Verilog. It ALSO synthesizes the emitted RTL with yosys
+# (synth_xilinx) and asserts a non-zero FF+LUT mapping, so a change that stays
+# bit-exact in sim but breaks synthesizability also fails here -- instead of
+# silently miscomputing (or failing to build a bitstream) on silicon.
 
 on:
   pull_request:
@@ -32,13 +34,13 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install Icarus Verilog
+      - name: Install Icarus Verilog + Yosys
         run: |
           sudo apt-get update
-          sudo apt-get install -y iverilog
+          sudo apt-get install -y iverilog yosys
 
       - name: Build t27c
         run: cargo build --release -p t27c
 
-      - name: Prove generated RTL == GF-T model (bit-exact)
+      - name: Prove generated RTL == GF-T model (bit-exact) + synthesizes
         run: python3 tools/verify_emit_bitexact.py

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,6 +1,13 @@
-# NOW — feat: parametric multi-output trainer, bit-exact (2026-08-07)
+# NOW — ci: emit gate now also proves SYNTHESIZABILITY (2026-08-07)
 
 Last updated: 2026-08-07
+
+## ci: emit-bitexact gate adds a yosys synth_xilinx check (Refs #1764)
+
+- The gate proved semantic equivalence (iverilog bit-exact) but not that the emitted RTL SYNTHESIZES -- a change can stay bit-exact in sim yet break synthesizability (non-synth construct) and only fail when a bitstream is attempted on silicon
+- `verify_emit_bitexact.py` now runs `yosys synth_xilinx -nocarry -flatten` on the emitted microsequencer for one single-output (2,2,1) and one multi-output (2,4,2) topology, asserting no yosys error AND a non-zero FF+LUT mapping (a design DCE'd to nothing would 'pass' an empty-module sim but map to 0 cells). Measured: (2,2,1) -> 3273 FF + 7752 LUT, (2,4,2) -> 6453 FF + 10161 LUT
+- CI-friendly: synth phase runs only if yosys is on PATH (skipped cleanly otherwise); workflow `emit-bitexact-gate.yml` now installs yosys alongside iverilog. Full gate ~24s local
+- => every PR touching the trainer generator now proves BOTH spec->RTL bit-exactness AND synthesizability to real Xilinx cells -- the last uncovered layer of the pipeline. Tool+CI only; Refs #1764
 
 ## feat: lift n_out=1 -> fully parametric multi-output/multi-input, proven bit-exact (Refs #1764)
 

--- a/tools/verify_emit_bitexact.py
+++ b/tools/verify_emit_bitexact.py
@@ -125,23 +125,31 @@ def check(g, arch, workdir):
 
 
 def synth_check(g, arch, workdir):
-    """Prove the emitted microsequencer actually SYNTHESIZES to real Xilinx cells
-    (yosys synth_xilinx) -- bit-exact-in-sim doesn't imply synthesizable. Asserts
-    no yosys error, and a non-zero flip-flop AND LUT count (a design DCE'd to
-    nothing would 'pass' sim of an empty module but map to 0 cells)."""
+    """Prove the emitted microsequencer actually SYNTHESIZES (yosys synth_xilinx) --
+    bit-exact-in-sim doesn't imply synthesizable. Asserts no yosys error and a
+    large post-synth cell count (a design DCE'd to nothing would 'pass' sim of an
+    empty module but map to ~0 cells). Uses the version-stable `Number of cells`
+    stat line rather than parsing per-primitive names (which vary across yosys
+    versions); reports the FF/LUT breakdown when it is parseable."""
     open(os.path.join(workdir, "bpx.v"), "w").write(g.emit_verilog(*arch, "bpx"))
-    # -DSIMULATION strips the cores' `ifndef SIMULATION` self-test blocks
+    # -DSIMULATION strips the cores' `ifndef SIMULATION` self-test blocks.
     cmd = ("read_verilog -DSIMULATION bpx.v GftSmul.v GftSadd.v; hierarchy -top bpx; "
            "synth_xilinx -nocarry -flatten; stat")
     r = subprocess.run(["yosys", "-p", cmd], capture_output=True, text=True, cwd=workdir)
-    if r.returncode != 0 or re.search(r"^ERROR", r.stdout + r.stderr, re.M):
-        err = (r.stdout + r.stderr)
-        print(f"FAIL {arch}: yosys synth error\n{err[-800:]}"); return False
-    ff = sum(int(n) for n, c in re.findall(r"^\s*(\d+)\s+(FD\w+)", r.stdout, re.M))
-    lut = sum(int(n) for n, c in re.findall(r"^\s*(\d+)\s+(LUT\w+)", r.stdout, re.M))
-    if ff == 0 or lut == 0:
-        print(f"FAIL {arch}: synthesized to FF={ff} LUT={lut} (design optimized away?)"); return False
-    print(f"OK {arch}: yosys synth_xilinx -> {ff} FF + {lut} LUT (maps to real hardware)")
+    log = r.stdout + r.stderr  # some yosys builds log stat to stderr, not stdout
+    if r.returncode != 0 or re.search(r"^ERROR", log, re.M):
+        print(f"FAIL {arch}: yosys synth error\n{log[-800:]}"); return False
+    # cell total is printed as "N cells" (or "Number of cells: N" on some versions)
+    totals = [int(n) for n in re.findall(r"(\d+)\s+cells\b", log)
+              + re.findall(r"Number of cells:\s*(\d+)", log)]
+    total = max(totals) if totals else 0
+    if total < 200:
+        print(f"FAIL {arch}: synthesized to {total} cells (design optimized away?)\n{log[-1200:]}")
+        return False
+    ff = sum(int(n) for n, _ in re.findall(r"(\d+)\s+(FD\w+)", log))
+    lut = sum(int(n) for n, _ in re.findall(r"(\d+)\s+(LUT\w*)", log))
+    extra = f" ({ff} FF + {lut} LUT)" if ff and lut else ""
+    print(f"OK {arch}: yosys synth_xilinx -> {total} cells{extra} (maps to real hardware)")
     return True
 
 

--- a/tools/verify_emit_bitexact.py
+++ b/tools/verify_emit_bitexact.py
@@ -7,8 +7,13 @@ input count) via emit_verilog(), and proves in a simulator that the generated RT
 is BIT-EXACT to the Python GF-T model over a full training run (forward + backprop
 + weight update), comparing EVERY output's u32 per step.
 
+Then, if yosys is present, it SYNTHESIZES the emitted RTL (synth_xilinx) for a
+couple of topologies and asserts a non-zero FF+LUT mapping -- catching a change
+that stays bit-exact in sim but breaks synthesizability.
+
 Self-contained and CI-friendly: if t27c or iverilog is unavailable it prints SKIP
-and exits 0 (so it never breaks a Rust-only CI); a real mismatch exits 1. Run:
+and exits 0 (so it never breaks a Rust-only CI); the synth phase is skipped when
+yosys is absent; a real mismatch or synth failure exits 1. Run:
     python3 tools/verify_emit_bitexact.py
 """
 import os, re, sys, shutil, subprocess, tempfile, importlib.util, random
@@ -18,6 +23,7 @@ SMUL_SPEC = os.path.join(ROOT, "specs/ternary/gft_smul.t27")
 SADD_SPEC = os.path.join(ROOT, "specs/ternary/gft_sadd.t27")
 ARCHS = [(2, 2, 1), (2, 3, 1), (2, 4, 1), (2, 5, 1),  # hidden-width axis
          (2, 2, 2), (2, 4, 2), (2, 3, 3), (3, 4, 2)]   # multi-output + multi-input
+SYNTH_ARCHS = [(2, 2, 1), (2, 4, 2)]  # one single-output + one multi-output (yosys is slower)
 STEPS = 80
 
 
@@ -118,6 +124,27 @@ def check(g, arch, workdir):
     return True
 
 
+def synth_check(g, arch, workdir):
+    """Prove the emitted microsequencer actually SYNTHESIZES to real Xilinx cells
+    (yosys synth_xilinx) -- bit-exact-in-sim doesn't imply synthesizable. Asserts
+    no yosys error, and a non-zero flip-flop AND LUT count (a design DCE'd to
+    nothing would 'pass' sim of an empty module but map to 0 cells)."""
+    open(os.path.join(workdir, "bpx.v"), "w").write(g.emit_verilog(*arch, "bpx"))
+    # -DSIMULATION strips the cores' `ifndef SIMULATION` self-test blocks
+    cmd = ("read_verilog -DSIMULATION bpx.v GftSmul.v GftSadd.v; hierarchy -top bpx; "
+           "synth_xilinx -nocarry -flatten; stat")
+    r = subprocess.run(["yosys", "-p", cmd], capture_output=True, text=True, cwd=workdir)
+    if r.returncode != 0 or re.search(r"^ERROR", r.stdout + r.stderr, re.M):
+        err = (r.stdout + r.stderr)
+        print(f"FAIL {arch}: yosys synth error\n{err[-800:]}"); return False
+    ff = sum(int(n) for n, c in re.findall(r"^\s*(\d+)\s+(FD\w+)", r.stdout, re.M))
+    lut = sum(int(n) for n, c in re.findall(r"^\s*(\d+)\s+(LUT\w+)", r.stdout, re.M))
+    if ff == 0 or lut == 0:
+        print(f"FAIL {arch}: synthesized to FF={ff} LUT={lut} (design optimized away?)"); return False
+    print(f"OK {arch}: yosys synth_xilinx -> {ff} FF + {lut} LUT (maps to real hardware)")
+    return True
+
+
 def main():
     if not shutil.which("iverilog") or not shutil.which("vvp"):
         skip("iverilog/vvp not on PATH")
@@ -131,7 +158,13 @@ def main():
         gen_core(t27c, SMUL_SPEC, os.path.join(wd, "GftSmul.v"))
         gen_core(t27c, SADD_SPEC, os.path.join(wd, "GftSadd.v"))
         ok = all(check(g, a, wd) for a in ARCHS)
-    print("ALL BIT-EXACT" if ok else "MISMATCH")
+        print("ALL BIT-EXACT" if ok else "MISMATCH")
+        if ok and shutil.which("yosys"):
+            print("--- synthesizability (yosys synth_xilinx) ---")
+            ok = all(synth_check(g, a, wd) for a in SYNTH_ARCHS)
+            print("ALL SYNTHESIZE" if ok else "SYNTH FAIL")
+        elif ok:
+            print("synth check skipped (yosys not on PATH)")
     sys.exit(0 if ok else 1)
 
 


### PR DESCRIPTION
The gate proved semantic equivalence (iverilog bit-exact) but not that the emitted RTL **synthesizes** — a change can stay bit-exact in sim yet break synthesizability and only fail when a bitstream is attempted on silicon.

`verify_emit_bitexact.py` now runs `yosys synth_xilinx -nocarry -flatten` on the microsequencer for one single-output (2,2,1) and one multi-output (2,4,2) topology, asserting no yosys error AND a non-zero FF+LUT mapping (a design DCE'd to nothing would 'pass' an empty-module sim but map to 0 cells). Measured: (2,2,1) → 3273 FF + 7752 LUT, (2,4,2) → 6453 FF + 10161 LUT. Synth phase runs only if yosys is present; the workflow now installs it alongside iverilog. Every PR touching the generator now proves **both spec→RTL bit-exactness AND synthesizability**. Refs #1764