### PR TITLE
docs: pipeline prototype bit-exact, but dropped-in register won't cut depth -> go spec-level on_clock (Refs #1764)

### DIFF
--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,6 +1,13 @@
-# NOW — endpoint reg insufficient (hazard is internal); MMCM divided clock is buildable (2026-08-08)
+# NOW — pipeline prototype: bit-exact but a dropped-in register won't reduce depth (2026-08-08)
 
 Last updated: 2026-08-08
+
+## docs: pipeline prototype — bit-exact, but naive RTL register insertion does not reduce depth; go spec-level on_clock (Refs #1764)
+
+- Started Variant 1 (pipeline the shared core) with an RTL prototype, after first ruling out the cheap route: yosys automatic retiming (`synth_xilinx -retime`) moves only a few levels (ltp 57->51 on GftSadd with 2 output regs) -- not enough to split the cloud
+- Built two 2-stage GftSmul prototypes (register cut after the product; and mid-RNE after carry/q/r), each VERIFIED BIT-EXACT to the combinational core over ~40k random operands. But ltp ROSE 44 -> 49/50: dropping a register into the *generated* combinational function defeats yosys's cross-function optimization of the inlined sadd/magmul/mul_noop, and the depth (RNE normalize + accumulator) does not split at a hand-inserted register
+- IMPLICATION: the pipeline must be a SPEC-LEVEL `on_clock` where t27c co-optimizes the stages (and the multiply becomes a real pipelined primitive), NOT a register hand-dropped into codegen output. Added these as ruled-out items #8 (auto-retime) and #9 (dropped-in register) in the methodology
+- Silent-lesson reaffirmed: depth reduction is secondary -- the untested lever is mid-cloud RESYNCHRONISATION. Since the microsequencer already waits settle >> 1 cycle, a latency-1 pipelined core needs no sequencer change; the decisive next experiment is to build the trainer on pipelined cores and see if the glitch dies. Prototypes in `scratchpad/retime/`. Board untouched (generated capstone, XOR 4/4). Docs only. Refs #1764
 
 ## docs: endpoint registration does NOT fix the lottery — hazard is inside the cloud; MMCM real divided clock IS buildable (Refs #1764)
 

--- a/docs/SILICON_TRAINING_METHODOLOGY.md
+++ b/docs/SILICON_TRAINING_METHODOLOGY.md
@@ -157,9 +157,24 @@ does not re-run them:
    (10-bit operands); loop 32 → 10 leaves the depth unchanged (44 → 45).
 7. **Endpoint registration** — bit-exact and raises fmax, but does not fix the lottery
    (hazard is internal to the cloud).
+8. **Automatic retiming** (`synth_xilinx -retime`) — moves only a few levels (ltp 57 → 51
+   on `GftSadd` with two output registers). Not enough to split the cloud.
+9. **Dropping a register into the *generated* combinational function** (hand RTL pipeline)
+   — bit-exact but does **not** reduce depth. Two 2-stage `GftSmul` prototypes (cut after
+   the product; cut mid-RNE after `carry`/`q`/`r`) are both verified bit-exact to the
+   combinational core over ~40 k random operands, yet ltp *rose* 44 → 49 / 50: the register
+   boundary defeats yosys's cross-function optimization of the inlined `sadd`/`magmul`/
+   `mul_noop`, and the depth (RNE normalize + accumulator) does not split at a dropped-in
+   register. **Implication for the pipeline: it must be a *spec-level* `on_clock` where the
+   compiler co-optimizes the stages (and the multiply becomes a real pipelined primitive),
+   not a register hand-inserted into the codegen output.**
 
-Live path: **pipeline the depth-54 `GftSadd` / depth-44 `GftSmul` normalize/round cascade
-into two registered stages.** Open experiment: an **MMCM** real divided clock.
+Live path: **a spec-level `on_clock` pipelined `GftSadd`/`GftSmul`** (compiler-scheduled
+stages, not a hand-dropped register), whose *mid-cloud resynchronization* is the untested
+lever against the hazard. Since the microsequencer already waits `settle` ≫ 1 cycle, a
+latency-1 pipelined core needs no sequencer change — the decisive experiment is to build
+the trainer on pipelined cores and see if the glitch dies. Open experiment: an **MMCM**
+real divided clock. Prototypes bit-exact-verified in `scratchpad/retime/`.
 
 ## Reproducibility
 


### PR DESCRIPTION
Starts Variant 1 (pipeline the shared core) with an RTL prototype and reports what it revealed.

- **Auto-retiming ruled out.** `synth_xilinx -retime` moves only a few levels (ltp 57 → 51 on `GftSadd` with two output registers) — not enough to split the deep cloud.
- **Two 2-stage `GftSmul` prototypes, both bit-exact.** Cut after the product, and cut mid-RNE (after `carry`/`q`/`r`); each verified bit-exact to the combinational core over ~40 k random operands. But ltp *rose* 44 → 49 / 50: dropping a register into the **generated** combinational function defeats yosys's cross-function optimization of the inlined `sadd`/`magmul`/`mul_noop`, and the RNE-normalize/accumulator depth does not split at a hand-inserted register.
- **Implication:** the pipeline must be a **spec-level `on_clock`** where t27c co-optimizes the stages (and the multiply becomes a real pipelined primitive), not a register hand-dropped into codegen output. Added as ruled-out items #8 (auto-retime) and #9 (dropped-in register).
- Depth reduction is secondary anyway — the untested lever is **mid-cloud resynchronization**; since the microsequencer already waits `settle` ≫ 1 cycle, a latency-1 pipelined core needs no sequencer change, so the decisive next experiment is to build the trainer on pipelined cores and see if the glitch dies.

Prototypes in `scratchpad/retime/`. Board untouched (generated capstone, XOR 4/4). Docs-only. Refs #1764
