### PR TITLE
test(ci): gate that the generated trainer LEARNS -- XOR 4/4 + nonlinear held-out >=90%, incl. deep 3-layer (Refs #1764)

### DIFF
--- a/.github/workflows/emit-bitexact-gate.yml
+++ b/.github/workflows/emit-bitexact-gate.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Prove the WHOLE trainer bit-exact in C (== model == Verilog)
         run: python3 tools/verify_trainer_c.py
 
+      - name: Prove the trainer LEARNS (XOR 4/4 + nonlinear held-out >=90%, incl. deep 3-layer)
+        run: python3 tools/gft_backprop_microcode.py
+
       - name: Differential-fuzz the trainer (random topologies, edge inputs)
         run: python3 tools/fuzz_trainer.py 40
 

--- a/docs/NOW.md
+++ b/docs/NOW.md
@@ -1,6 +1,12 @@
-# NOW — Vivado closure kit: the multicycle constraint that kills the seed-lottery (2026-08-08)
+# NOW — CI now gates that the trainer LEARNS, not just that it is bit-exact (2026-08-08)
 
 Last updated: 2026-08-08
+
+## test(ci): gate that the generated trainer LEARNS -- XOR 4/4 + nonlinear held-out >=90%, incl. deep 3-layer (Refs #1764)
+
+- The bit-exact gates prove the generated RTL == model, but nothing CI-enforced that the algorithm actually LEARNS non-trivial tasks. The generator's self-tests already do (XOR 4/4; (2,4,1) noisy nonlinear held-out 58/60; (2,4,2) multi-output argmax 56/60; deep [2,4,3,1] 3-layer 59/60 -- all >=90%), but they only ran when the file was executed by hand
+- Added `python3 tools/gft_backprop_microcode.py` as a CI step in emit-bitexact-gate.yml, so the learning + generalization claims are enforced per pull request
+- Strengthens the whole story's thesis: the METHOD learns and scales beyond XOR (multi-layer, held-out generalization) in the model -- the only limit is the open silicon flow's placement marginality (now met with the Vivado closure kit), not the algorithm. CI-config + no code change. Refs #1764
 
 ## feat(docs): Vivado closure kit -- the set_multicycle_path constraint the open flow cannot express (Refs #1764)
 


### PR DESCRIPTION
The bit-exact gates prove the generated RTL equals the model, but nothing CI-enforced that the algorithm actually **learns** non-trivial tasks. The generator's self-tests already assert exactly that — but they only ran when the file was executed by hand.

Adds `python3 tools/gft_backprop_microcode.py` as a CI step in `emit-bitexact-gate.yml`, enforcing per pull request:

- XOR trained 4/4 by the generated microcode;
- `(2,4,1)` on a noisy nonlinear dataset, held-out **58/60**;
- `(2,4,2)` multi-output one-hot classifier, held-out **56/60**;
- deep `[2,4,3,1]` (3-layer, 2 hidden) nonlinear task, held-out **59/60** — all ≥ 90%.

This strengthens the project's thesis: the **method learns and scales beyond XOR** (multi-layer, held-out generalization) in the model — the only limit was the open silicon flow's placement marginality, now addressed by the Vivado closure kit, not the algorithm.

CI-config only; no code change. Refs #1764
