### PR TITLE
Unbreak FPGA CI and correct two unbacked hardware claims

### DIFF
--- a/.github/workflows/fpga-build.yml
+++ b/.github/workflows/fpga-build.yml
@@ -324,8 +324,8 @@ jobs:
         run: |
           if [ ! -f ~/.local/bin/nextpnr-xilinx ]; then
             cd ~
-            git clone https://github.com/YosysHQ/nextpnr.git -b nextpnr-0.8
-            cd nextpnr
+            git clone https://github.com/gatecat/nextpnr-xilinx.git
+            cd nextpnr-xilinx
             mkdir build && cd build
             cmake .. -DARCH=xilinx -DUSE_OPENMP=OFF
             make -j4

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ Discoverability mirror of the numeric corpus. GitHub remains the primary source 
 | Compiler | `t27c parse` | GREEN | 170+ specs parse |
 | Compiler | `t27c gen-verilog` | GREEN | 5/5 FPGA modules synthesize |
 | Compiler | `t27c seal` | GREEN | 170+ seals in `.trinity/seals/` |
-| FPGA | Yosys synthesis | GREEN | 5/5 modules pass synth_xilinx |
-| FPGA | E2E bitstream | GREEN | Yosys→nextpnr→prjxray→.bit (zero Vivado) |
+| FPGA | Yosys synthesis | RED | `fpga-synthesis` CI job failing; last green 2026-04-14. Local `gen-verilog` smoke still passes 5/5 |
+| FPGA | E2E bitstream | RED | Yosys→nextpnr→prjxray→.bit never validated in CI: `fpga-build.yml` is 36 success / 842 failure / 3 cancelled over 881 runs, and `fpga-bitstream` is skipped behind `needs: fpga-synthesis` |
 | FPGA | Board profiles | GREEN | QMTECH XC7A100T (minimal+full), Arty A7 |
 | FPGA | `--profile` flag | GREEN | `--profile minimal|full` in fpga-build |
 | Pins | Pins IR | GREEN | `specs/pins/ir.t27` — conflict detection invariants |
@@ -67,7 +67,7 @@ Discoverability mirror of the numeric corpus. GitHub remains the primary source 
 | CI | Seal coverage | GREEN | All specs sealed |
 | CI | Schema validation | GREEN | Conformance vectors validated |
 | CI | FPGA smoke | GREEN | Verilog gen in CI |
-| CI | FPGA bitstream artifact | GREEN | .bit uploaded per PR (7-day retention) |
+| CI | FPGA bitstream artifact | RED | No .bit uploaded since 2026-04-14 — job skipped behind failing `fpga-synthesis` |
 | TRI | PHI LOOP CLI | GREEN | `cli/tri/` standalone binary |
 | TRI | MCP server | GREEN | `cli/tri-mcp/` — 10 tools over JSON-RPC |
 | Spec | Phase 3 (shell/tools/file) | YELLOW | 6/8 parse; 2 file specs have parser issue (#388) |

--- a/bootstrap/src/main.rs
+++ b/bootstrap/src/main.rs
@@ -4934,7 +4934,7 @@ endmodule
         fs::write(
             &synth_script,
             format!(
-                "read_verilog {files}\nhierarchy -check -top {top}\nproc; opt; fsm; opt; memory; opt\nsynth_xilinx -top {top}\nwrite_json {json}\nstat\n",
+                "read_verilog -sv -DSIMULATION {files}\nhierarchy -check -top {top}\nproc; opt; fsm; opt; memory; opt\nsynth_xilinx -top {top}\nwrite_json {json}\nstat\n",
                 files = verilog_files,
                 top = top,
                 json = synth_json.display(),
@@ -4959,7 +4959,7 @@ endmodule
         fs::write(
             &synth_script,
             format!(
-                "read_verilog {files}\nhierarchy -check -top {top}\nproc; opt; fsm; opt; memory; opt\nsynth_xilinx -top {top}\nwrite_json {json}\nstat\n",
+                "read_verilog -sv -DSIMULATION {files}\nhierarchy -check -top {top}\nproc; opt; fsm; opt; memory; opt\nsynth_xilinx -top {top}\nwrite_json {json}\nstat\n",
                 files = verilog_files,
                 top = top,
                 json = synth_json.display(),

--- a/docs/arxiv-submission/trinity-gf16.tex
+++ b/docs/arxiv-submission/trinity-gf16.tex
@@ -293,7 +293,7 @@ Results}\label{fpga-implementation-results}
 \begin{itemize}
 \tightlist
 \item
-  \textbf{FPGA:} QMTECH XC7A100T-1FGG676C (Artix-7, 126,800 LUTs, 240
+  \textbf{FPGA:} QMTECH XC7A100T-1FGG676C (Artix-7, 63,400 LUTs, 240
   DSP48E1)
 \item
   \textbf{Toolchain:} openXC7 (Yosys 0.62 + nextpnr-xilinx)

--- a/docs/arxiv-trinity-gf16-draft.md
+++ b/docs/arxiv-trinity-gf16-draft.md
@@ -113,7 +113,7 @@ C[i][j] = dot4(A[i][0:3], B[0:3][j])
 
 ### 4.1 Platform
 
-- **FPGA:** QMTECH XC7A100T-1FGG676C (Artix-7, 126,800 LUTs, 240 DSP48E1)
+- **FPGA:** QMTECH XC7A100T-1FGG676C (Artix-7, 63,400 LUTs, 240 DSP48E1)
 - **Toolchain:** openXC7 (Yosys 0.62 + nextpnr-xilinx)
 - **Clock:** 20-stage ring oscillator (onboard M21 crystal non-functional)
 - **Programming:** XVC via ESP32 (192.168.1.30:2542)

--- a/specs/numeric/formats_catalog.t27
+++ b/specs/numeric/formats_catalog.t27
@@ -225,7 +225,7 @@ module FormatsCatalog {
   // CATALOG: id=gf12 name="GF12" bits=12 s=1 e=4 m=7 bias=7 phi_distance=0.047 storage=u16 cluster=GoldenFloat status=Verified standard="this work; L0/F3" use_case="mid-range / audio" gf_relation=self source="BENCH-007 (specs/numeric/gf12.t27)"
   fn gf12() -> str { return "gf12"; }
 
-  // CATALOG: id=gf16 name="GF16" bits=16 s=1 e=6 m=9 bias=31 phi_distance=0.049 storage=u16 cluster=GoldenFloat status=Verified standard="this work; PHI_BIAS=60; FPGA 35/35 at 323 MHz Artix-7" use_case="training and inference (production)" gf_relation=self source="specs/numeric/gf16.t27; zenodo 10.5281/zenodo.19227877 (HW archive)"
+  // CATALOG: id=gf16 name="GF16" bits=16 s=1 e=6 m=9 bias=31 phi_distance=0.049 storage=u16 cluster=GoldenFloat status=Verified standard="this work; PHI_BIAS=60" use_case="training and inference (production)" gf_relation=self source="specs/numeric/gf16.t27"
   fn gf16() -> str { return "gf16"; }
 
   // CATALOG: id=gf20 name="GF20" bits=20 s=1 e=7 m=12 bias=63 phi_distance=0.035 storage=u32 cluster=GoldenFloat status=Experimental standard="this work; 17-squared empirical PHI_BIAS=289" use_case="high-precision edge" gf_relation=self source="specs/numeric/gf20.t27 (spec only)"


### PR DESCRIPTION
Four independent fixes, all small.

**1. `fpga-synthesis` has been red since 2026-04-14.** Both writers of `synth.ys` in `bootstrap/src/main.rs` (:4937 Docker branch, :4962 local-yosys branch) emit `read_verilog {files}` with the Verilog-2005 frontend, while the backend deliberately emits SystemVerilog static casts (`compiler.rs:5068`). Yosys therefore fails with `Static cast is only supported in SystemVerilog mode` on `build/fpga/generated/uart.v`. Both now read `read_verilog -sv -DSIMULATION {files}`, matching the invocation that already works at `suite.rs:859`.

That `fpga-synthesis-arty` passes today is not a counter-example: `--minimal` narrows the yosys input to `{top}.v`, which carries no test blocks.

**2. `fpga-bitstream` has never succeeded once.** `.github/workflows/fpga-build.yml:327` clones upstream `YosysHQ/nextpnr` and configures `-DARCH=xilinx`, but upstream nextpnr has no xilinx architecture — nextpnr-xilinx is a separate fork. CMake rejects the arch and the job exits 1. Now clones `gatecat/nextpnr-xilinx`.

⚠️ **This will not turn the job green on its own.** The Create chipdb symlink step writes a 1 MB `/dev/zero` placeholder, and real nextpnr-xilinx will reject it. Building the chipdb from prjxray-db is a larger change and is deliberately not in this PR.

**3. README claimed GREEN for three red rows.** Measured from the API: `fpga-build.yml` has 881 runs — 36 success, 842 failure, 3 cancelled; last success 2026-04-14; the `fpga-bitstream` job is skipped behind `needs: fpga-synthesis`. Those three rows now read RED with the last-green date. The `gen-verilog` smoke rows are left GREEN — that path uses the correct invocation and does pass.

**4. Two unbacked hardware figures.**

`specs/numeric/formats_catalog.t27:228` cited `zenodo 10.5281/zenodo.19227877` as its hardware archive. That DOI resolves to Trinity B007: VSA Operations for Ternary Computing v5.0 — resource type Software, one 2.0 kB file, no FPGA frequency and no design. The 323 MHz figure and the Zenodo citation are removed; `source` now points at `specs/numeric/gf16.t27`. The 35/35 claim goes with them: the only 35/35 in this repo is Icarus and cocotb, i.e. simulation, not an FPGA run.

`docs/arxiv-submission/trinity-gf16.tex:296` and `docs/arxiv-trinity-gf16-draft.md:116` give the XC7A100T LUT count as 126,800. That is the part's flip-flop count; its LUT count is 63,400. Corrected. Note this makes the design's occupancy look *better*, not worse: 40,350/63,400 = 63.6%.

**Not in this PR, flagged for you:**

- `specs/igla/coder/benchmark.t27:670` and `:677` carry the same 35/35 at 323 MHz. That file faithfully quotes arXiv:2606.05017, so editing it before a v4 correction would desynchronise it from its own source.
- The `spiOverJtag_xc7a100tfgg676.bit` rename (the file is an FTG256 bitstream; the real FGG676 build is parked under `.v2`) involves binaries and a `.gz` regeneration.